### PR TITLE
Make it easy to build project on Nix package manager / NixOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 npm run-script build -- "$@"

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,4 @@
+{ pkgs ? import <nixpkgs> { } }:
+pkgs.mkShell {
+  nativeBuildInputs = [ pkgs.nodejs ];
+}


### PR DESCRIPTION
* Uses `#!/bin/sh` to improve build script portability
* Adds a `shell.nix` file to provide all necessary dependencies to build the project on [nix](https://nixos.org/)