### PR TITLE
Use `lychee` to check for broken links in CI & fix broken links

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -1,0 +1,22 @@
+name: Broken Link Checker
+
+permissions:
+  contents: read
+
+# runs on prs containing markdown or html changes, as well as every monday at 9 am
+on:
+  pull_request:
+    paths:
+      - "**.md"
+      - "**.html"
+  schedule:
+    - cron: "0 9 * * 1"
+
+jobs:
+  link-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: lycheeverse/lychee-action@9ace499fe66cee282a29eaa628fdac2c72fa087f
+        with:
+          fail: true

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,4 @@
+://localhost
+://127.0.0.1
+%7Bversion%7D
+https://www.edrdg.org/jmdict/edict.html_blanknoopenerhttps://www.edrdg.org/wiki/index.php/KANJIDIC_Project_blanknoopenerhttps://www.edrdg.org/_blanknoopenerhttps://www.edrdg.org/edrdg/licence.html_blanknoopener

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Yomitan turns your web browser into a tool for building Japanese language literacy by helping you to decipher texts
 which would be otherwise too difficult tackle. This extension is similar to
-[Rikaichamp](https://addons.mozilla.org/en-US/firefox/addon/rikaichamp/) for Firefox and
+[10ten Japanese Reader (formerly Rikaichamp)](https://addons.mozilla.org/en-US/firefox/addon/10ten-ja-reader/) for Firefox and
 [Rikaikun](https://chrome.google.com/webstore/detail/rikaikun/jipdnfibhldikgcjhfnomkfpcebammhp?hl=en) for Chrome, but it
 stands apart in its goal of being an all-encompassing learning tool as opposed to a mere browser-based dictionary.
 
@@ -87,7 +87,7 @@ language is not English, you may consider also importing the English version for
     *   [jmdict\_swedish.zip](https://github.com/themoeway/yomitan/raw/dictionaries/jmdict_swedish.zip)
 *   **[JMnedict](https://www.edrdg.org/enamdict/enamdict_doc.html)** (Japanese names)
     *   [jmnedict.zip](https://github.com/themoeway/yomitan/raw/dictionaries/jmnedict.zip)
-*   **[KireiCake](https://kireicake.com/rikaicakes/)** (Japanese slang)
+*   **KireiCake (upstream project dead)** (Japanese slang)
     *   [kireicake.zip](https://github.com/themoeway/yomitan/raw/dictionaries/kireicake.zip)
 *   **[KANJIDIC](http://nihongo.monash.edu/kanjidic2/index.html)** (Japanese kanji)
     *   [kanjidic\_english.zip](https://github.com/themoeway/yomitan/raw/dictionaries/kanjidic_english.zip)


### PR DESCRIPTION
This PR:
* Adds link checking in CI for markdown and HTML files using `lychee`
* Fixes all broken links possible
* Does not yet fix the following broken links because they require a dependency update (parse5 v7.1.1 → v7.1.2), which will be done in a separate PR
   ```
   | ✗ [404] https://github.com/inikulin/parse5/blob/v7.1.1/LICENSE | Failed: Network error: Not Found
   | ✗ [404] https://github.com/inikulin/parse5/tree/v7.1.1/packages/parse5 | Failed: Network error: Not Found
   | ✗ [404] https://github.com/inikulin/parse5/blob/v7.1.1/LICENSE | Failed: Network error: Not Found
   ```

Note the 4th line in `.lycheeignore` is due to this lychee bug:

* https://github.com/lycheeverse/lychee/issues/986