### PR TITLE
Update manifest scripts: only support v3, and yomichan->yomitan

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -1,10 +1,10 @@
 {
     "manifest": {
-        "manifest_version": 2,
-        "name": "Yomichan",
+        "manifest_version": 3,
+        "name": "Yomitan",
         "version": "22.10.23.0",
         "description": "Japanese dictionary with Anki integration",
-        "author": "Alex Yatskov",
+        "author": "TheMoeWay",
         "icons": {
             "16": "images/icon16.png",
             "19": "images/icon19.png",
@@ -14,7 +14,7 @@
             "64": "images/icon64.png",
             "128": "images/icon128.png"
         },
-        "browser_action": {
+        "action": {
             "default_icon": {
                 "16": "images/icon16.png",
                 "19": "images/icon19.png",
@@ -24,12 +24,11 @@
                 "64": "images/icon64.png",
                 "128": "images/icon128.png"
             },
-            "default_title": "Yomichan",
+            "default_title": "Yomitan",
             "default_popup": "action-popup.html"
         },
         "background": {
-            "page": "background.html",
-            "persistent": true
+            "service_worker": "sw.js"
         },
         "content_scripts": [
             {
@@ -67,7 +66,7 @@
                 ]
             }
         ],
-        "minimum_chrome_version": "57.0.0.0",
+        "minimum_chrome_version": "96.0.0.0",
         "options_ui": {
             "page": "settings.html",
             "open_in_tab": true
@@ -75,21 +74,22 @@
         "sandbox": {
             "pages": [
                 "template-renderer.html"
-            ],
-            "content_security_policy": "sandbox allow-scripts; default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline'"
+            ]
         },
         "permissions": [
-            "<all_urls>",
             "storage",
             "clipboardWrite",
             "unlimitedStorage",
             "webRequest",
-            "webRequestBlocking"
+            "declarativeNetRequest",
+            "scripting"
         ],
         "optional_permissions": [
             "clipboardRead",
-            "nativeMessaging",
-            "webNavigation"
+            "nativeMessaging"
+        ],
+        "host_permissions": [
+            "<all_urls>"
         ],
         "commands": {
             "toggleTextScanning": {
@@ -115,10 +115,20 @@
             }
         },
         "web_accessible_resources": [
-            "popup.html",
-            "template-renderer.html"
+            {
+                "resources": [
+                    "popup.html",
+                    "template-renderer.html"
+                ],
+                "matches": [
+                    "<all_urls>"
+                ]
+            }
         ],
-        "content_security_policy": "default-src 'self'; img-src blob: 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *"
+        "content_security_policy": {
+            "extension_pages": "default-src 'self'; img-src blob: 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *",
+            "sandbox": "sandbox allow-scripts; default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline'"
+        }
     },
     "defaultVariant": "base",
     "variants": [
@@ -129,101 +139,105 @@
         {
             "name": "chrome",
             "inherit": "base",
-            "fileName": "yomichan-chrome.zip",
-            "excludeFiles": [
-                "sw.js",
-                "js/dom/simple-dom-parser.js",
-                "lib/parse5.js"
-            ]
-        },
-        {
-            "name": "chrome-dev",
-            "inherit": "chrome",
-            "fileName": "yomichan-chrome-dev.zip",
-            "modifications": [
-                {
-                    "action": "replace",
-                    "path": ["name"],
-                    "pattern": "^.*$",
-                    "patternFlags": "",
-                    "replacement": "$& (development build)"
-                },
-                {
-                    "action": "replace",
-                    "path": ["description"],
-                    "pattern": "^(.*)(?:\\.\\s*)?$",
-                    "patternFlags": "",
-                    "replacement": "$1. This is a development build; get the stable version here: https://tinyurl.com/yaatdjmp"
-                }
-            ]
-        },
-        {
-            "name": "chrome-mv3",
-            "inherit": "base",
-            "fileName": "yomichan-chrome-mv3.zip",
-            "modifications": [
-                {"action": "set",    "path": ["manifest_version"], "value": 3},
-                {"action": "set",    "path": ["minimum_chrome_version"], "value": "96.0.0.0"},
-                {"action": "move",   "path": ["browser_action"], "newPath": ["action"]},
-                {"action": "delete", "path": ["background", "page"]},
-                {"action": "delete", "path": ["background", "persistent"]},
-                {"action": "set",    "path": ["background", "service_worker"], "value": "sw.js"},
-                {"action": "move",   "path": ["content_security_policy"], "newPath": ["content_security_policy_old"]},
-                {"action": "set",    "path": ["content_security_policy"], "value": {}},
-                {"action": "move",   "path": ["content_security_policy_old"], "newPath": ["content_security_policy", "extension_pages"]},
-                {"action": "move",   "path": ["sandbox", "content_security_policy"], "newPath": ["content_security_policy", "sandbox"]},
-                {"action": "remove", "path": ["permissions"], "item": "<all_urls>"},
-                {"action": "remove", "path": ["permissions"], "item": "webRequestBlocking"},
-                {"action": "add",    "path": ["permissions"], "items": ["declarativeNetRequest", "scripting"]},
-                {"action": "set",    "path": ["host_permissions"], "value": ["<all_urls>"], "after": "optional_permissions"},
-                {"action": "remove", "path": ["optional_permissions"], "item": "webNavigation"},
-                {"action": "move",   "path": ["web_accessible_resources"], "newPath": ["web_accessible_resources_old"]},
-                {"action": "set",    "path": ["web_accessible_resources"], "value": [{"resources": [], "matches": ["<all_urls>"]}], "after": "web_accessible_resources_old"},
-                {"action": "move",   "path": ["web_accessible_resources_old"], "newPath": ["web_accessible_resources", 0, "resources"]}
-            ],
+            "fileName": "yomitan-chrome.zip",
             "excludeFiles": [
                 "background.html",
                 "js/dom/native-simple-dom-parser.js"
             ]
         },
         {
-            "name": "firefox",
-            "inherit": "base",
-            "fileName": "yomichan-firefox.xpi",
+            "name": "chrome-dev",
+            "inherit": "chrome",
+            "fileName": "yomitan-chrome-dev.zip",
             "modifications": [
                 {
+                    "action": "replace",
+                    "path": [
+                        "name"
+                    ],
+                    "pattern": "^.*$",
+                    "patternFlags": "",
+                    "replacement": "$& (development build)"
+                },
+                {
+                    "action": "replace",
+                    "path": [
+                        "description"
+                    ],
+                    "pattern": "^(.*)(?:\\.\\s*)?$",
+                    "patternFlags": "",
+                    "replacement": "$1. This is a development build."
+                }
+            ]
+        },
+        {
+            "name": "firefox",
+            "inherit": "base",
+            "fileName": "yomitan-firefox.zip",
+            "modifications": [
+                {
+                    "action": "delete",
+                    "path": [
+                        "service_worker"
+                    ]
+                },
+                {
+                    "action": "set",
+                    "path": [
+                        "page"
+                    ],
+                    "value": "background.html"
+                },
+                {
                     "action": "remove",
-                    "path": ["web_accessible_resources"],
+                    "path": [
+                        "web_accessible_resources",
+                        0,
+                        "resources"
+                    ],
                     "item": "template-renderer.html"
                 },
                 {
                     "action": "delete",
-                    "path": ["sandbox"]
+                    "path": [
+                        "sandbox"
+                    ]
                 },
                 {
                     "action": "set",
-                    "path": ["content_security_policy"],
+                    "path": [
+                        "content_security_policy",
+                        "extension_pages"
+                    ],
                     "value": "default-src 'self'; script-src 'self' 'unsafe-eval'; img-src blob: 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *"
                 },
                 {
                     "action": "set",
-                    "path": ["browser_specific_settings"],
+                    "path": [
+                        "browser_specific_settings"
+                    ],
                     "value": {
                         "gecko": {
-                            "id": "alex@foosoft.net",
-                            "strict_min_version": "57.0"
+                            "id": "themoeway@googlegroups.com",
+                            "strict_min_version": "101.0"
                         }
                     }
                 },
                 {
                     "action": "remove",
-                    "path": ["optional_permissions"],
+                    "path": [
+                        "optional_permissions"
+                    ],
                     "item": "nativeMessaging"
                 },
                 {
                     "action": "add",
-                    "path": ["permissions"],
-                    "items": ["nativeMessaging"]
+                    "path": [
+                        "permissions"
+                    ],
+                    "items": [
+                        "nativeMessaging"
+                    ]
                 }
             ],
             "excludeFiles": [
@@ -235,72 +249,44 @@
         {
             "name": "firefox-dev",
             "inherit": "firefox",
-            "fileName": "yomichan-firefox-dev.xpi",
+            "fileName": "yomitan-firefox-dev.zip",
             "modifications": [
                 {
                     "action": "replace",
-                    "path": ["name"],
+                    "path": [
+                        "name"
+                    ],
                     "pattern": "^.*$",
                     "patternFlags": "",
                     "replacement": "$& (development build)"
                 },
                 {
                     "action": "replace",
-                    "path": ["description"],
+                    "path": [
+                        "description"
+                    ],
                     "pattern": "^(.*)(?:\\.\\s*)?$",
                     "patternFlags": "",
                     "replacement": "$1. This is a development build; get the stable version here: https://tinyurl.com/yaatdjmp"
                 },
                 {
                     "action": "set",
-                    "path": ["browser_specific_settings", "gecko", "id"],
-                    "value": "alex.testing@foosoft.net"
-                },
-                {
-                    "action": "set",
-                    "path": ["browser_specific_settings", "gecko", "update_url"],
-                    "value": "https://raw.githubusercontent.com/FooSoft/yomichan/metadata/updates.json"
-                }
-            ],
-            "excludeFiles": [
-                "sw.js",
-                "js/dom/simple-dom-parser.js",
-                "lib/parse5.js"
-            ]
-        },
-        {
-            "name": "firefox-mv3",
-            "inherit": "firefox",
-            "fileName": "yomichan-firefox-mv3.xpi",
-            "modifications": [
-                {"action": "set",    "path": ["manifest_version"], "value": 3},
-                {"action": "set",    "path": ["browser_specific_settings", "gecko", "strict_min_version"], "value": "101.0"},
-                {"action": "move",   "path": ["browser_action"], "newPath": ["action"]},
-                {"action": "delete", "path": ["background", "persistent"]},
-                {"action": "move",   "path": ["content_security_policy"], "newPath": ["content_security_policy_old"]},
-                {"action": "set",    "path": ["content_security_policy"], "value": {}},
-                {"action": "move",   "path": ["content_security_policy_old"], "newPath": ["content_security_policy", "extension_pages"]},
-                {"action": "remove", "path": ["permissions"], "item": "<all_urls>"},
-                {"action": "add",    "path": ["permissions"], "items": ["scripting"]},
-                {"action": "set",    "path": ["host_permissions"], "value": ["<all_urls>"], "after": "optional_permissions"},
-                {"action": "remove", "path": ["optional_permissions"], "item": "webNavigation"},
-                {"action": "move",   "path": ["web_accessible_resources"], "newPath": ["web_accessible_resources_old"]},
-                {
-                    "action": "set",
-                    "path": ["web_accessible_resources"],
-                    "value": [
-                        {
-                            "resources": [],
-                            "matches": [
-                                "http://*/*",
-                                "https://*/*",
-                                "file://*/*"
-                            ]
-                        }
+                    "path": [
+                        "browser_specific_settings",
+                        "gecko",
+                        "id"
                     ],
-                    "after": "web_accessible_resources_old"
+                    "value": "themoeway+development@googlegroups.com"
                 },
-                {"action": "move",   "path": ["web_accessible_resources_old"], "newPath": ["web_accessible_resources", 0, "resources"]}
+                {
+                    "action": "set",
+                    "path": [
+                        "browser_specific_settings",
+                        "gecko",
+                        "update_url"
+                    ],
+                    "value": "https://raw.githubusercontent.com/themoeway/yomitan/metadata/updates.json"
+                }
             ],
             "excludeFiles": [
                 "sw.js",
@@ -312,13 +298,39 @@
             "name": "safari",
             "fileName": null,
             "modifications": [
-                {"action": "remove", "path": ["optional_permissions"], "item": "clipboardRead"},
-                {"action": "remove", "path": ["permissions"], "item": "webRequestBlocking"},
-                {"action": "delete", "path": ["content_scripts", 0, "match_about_blank"]},
-                {"action": "delete", "path": ["sandbox"]},
+                {
+                    "action": "remove",
+                    "path": [
+                        "optional_permissions"
+                    ],
+                    "item": "clipboardRead"
+                },
+                {
+                    "action": "remove",
+                    "path": [
+                        "permissions"
+                    ],
+                    "item": "webRequestBlocking"
+                },
+                {
+                    "action": "delete",
+                    "path": [
+                        "content_scripts",
+                        0,
+                        "match_about_blank"
+                    ]
+                },
+                {
+                    "action": "delete",
+                    "path": [
+                        "sandbox"
+                    ]
+                },
                 {
                     "action": "set",
-                    "path": ["content_security_policy"],
+                    "path": [
+                        "content_security_policy"
+                    ],
                     "value": "default-src 'self'; script-src 'self' 'unsafe-eval'; img-src blob: 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *"
                 }
             ],

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,9 +1,9 @@
 {
-    "manifest_version": 2,
-    "name": "Yomichan",
+    "manifest_version": 3,
+    "name": "Yomitan",
     "version": "22.10.23.0",
     "description": "Japanese dictionary with Anki integration",
-    "author": "Alex Yatskov",
+    "author": "TheMoeWay",
     "icons": {
         "16": "images/icon16.png",
         "19": "images/icon19.png",
@@ -13,7 +13,7 @@
         "64": "images/icon64.png",
         "128": "images/icon128.png"
     },
-    "browser_action": {
+    "action": {
         "default_icon": {
             "16": "images/icon16.png",
             "19": "images/icon19.png",
@@ -23,12 +23,11 @@
             "64": "images/icon64.png",
             "128": "images/icon128.png"
         },
-        "default_title": "Yomichan",
+        "default_title": "Yomitan",
         "default_popup": "action-popup.html"
     },
     "background": {
-        "page": "background.html",
-        "persistent": true
+        "service_worker": "sw.js"
     },
     "content_scripts": [
         {
@@ -66,7 +65,7 @@
             ]
         }
     ],
-    "minimum_chrome_version": "57.0.0.0",
+    "minimum_chrome_version": "96.0.0.0",
     "options_ui": {
         "page": "settings.html",
         "open_in_tab": true
@@ -74,21 +73,22 @@
     "sandbox": {
         "pages": [
             "template-renderer.html"
-        ],
-        "content_security_policy": "sandbox allow-scripts; default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline'"
+        ]
     },
     "permissions": [
-        "<all_urls>",
         "storage",
         "clipboardWrite",
         "unlimitedStorage",
         "webRequest",
-        "webRequestBlocking"
+        "declarativeNetRequest",
+        "scripting"
     ],
     "optional_permissions": [
         "clipboardRead",
-        "nativeMessaging",
-        "webNavigation"
+        "nativeMessaging"
+    ],
+    "host_permissions": [
+        "<all_urls>"
     ],
     "commands": {
         "toggleTextScanning": {
@@ -114,8 +114,18 @@
         }
     },
     "web_accessible_resources": [
-        "popup.html",
-        "template-renderer.html"
+        {
+            "resources": [
+                "popup.html",
+                "template-renderer.html"
+            ],
+            "matches": [
+                "<all_urls>"
+            ]
+        }
     ],
-    "content_security_policy": "default-src 'self'; img-src blob: 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *"
+    "content_security_policy": {
+        "extension_pages": "default-src 'self'; img-src blob: 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *",
+        "sandbox": "sandbox allow-scripts; default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline'"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "yomichan",
+    "name": "yomitan",
     "version": "0.0.0",
     "description": "Japanese pop-up dictionary extension for Chrome and Firefox.",
     "directories": {
@@ -19,7 +19,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/FooSoft/yomichan.git"
+        "url": "git+https://github.com/themoeway/yomitan.git"
     },
     "license": "GPL-3.0-or-later",
     "licenses": [
@@ -29,9 +29,9 @@
         }
     ],
     "bugs": {
-        "url": "https://github.com/FooSoft/yomichan/issues"
+        "url": "https://github.com/themoeway/yomitan/issues"
     },
-    "homepage": "https://foosoft.net/projects/yomichan/",
+    "homepage": "https://github.com/themoeway/yomitan/",
     "webExt": {
         "sourceDir": "ext"
     },


### PR DESCRIPTION
* Get rid of old v2 manifests as they will soon be unusable and considerably clutter up the project and currently-in-progress CD
* Rename yomichan to yomitan and update links where applicable within the manifest and package.json