### PR TITLE
Add dependabot config, to improve scorecard score

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependencies"


### PR DESCRIPTION
In order to pass https://github.com/ossf/scorecard/blob/main/docs/checks.md#dependency-update-tool, a configuration for dependabot is required in the repo.

Note, dependabot currently only reports in the security tab and is not configured to open PRs, but I will make it do so once we have slightly more robust integration tests in a browser that let's us see in the PR that truly nothing has broken.