### PR TITLE
Renamed most instances of Yomichan -> Yomitan under ext/*.html

### DIFF
--- a/ext/action-popup.html
+++ b/ext/action-popup.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>Yomichan Action Popup</title>
+    <title>Yomitan Action Popup</title>
     <link rel="icon" type="image/png" href="/images/icon16.png" sizes="16x16">
     <link rel="icon" type="image/png" href="/images/icon19.png" sizes="19x19">
     <link rel="icon" type="image/png" href="/images/icon32.png" sizes="32x32">
@@ -55,7 +55,7 @@
 </div>
 
 <div id="full">
-    <h3 id="extension-info">Yomichan</h3>
+    <h3 id="extension-info">Yomitan</h3>
     <label class="link-group">
         <span class="link-group-icon"><input type="checkbox" id="enable-search2"></span><span class="link-group-label">Enable content scanning</span>
     </label>

--- a/ext/info.html
+++ b/ext/info.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>Yomichan Info</title>
+    <title>Yomitan Info</title>
     <link rel="icon" type="image/png" href="/images/icon16.png" sizes="16x16">
     <link rel="icon" type="image/png" href="/images/icon19.png" sizes="19x19">
     <link rel="icon" type="image/png" href="/images/icon32.png" sizes="32x32">
@@ -23,7 +23,7 @@
 
     <span tabindex="-1" id="content-scroll-focus"></span>
 
-    <h1>Yomichan Info</h1>
+    <h1>Yomitan Info</h1>
 
     <h2 id="general">General</h2>
     <div class="settings-group">
@@ -45,9 +45,9 @@
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">
             <ul>
-                <li>Information and downloadable dictionaries: <a href="https://foosoft.net/projects/yomichan/" rel="noreferrer noopener">Homepage</a></li>
-                <li>Support and source code: <a href="https://github.com/FooSoft/yomichan" rel="noreferrer noopener">Github</a></li>
-                <li>Release notes: <a href="https://github.com/FooSoft/yomichan/releases" rel="noreferrer noopener" data-href-format="https://github.com/FooSoft/yomichan/releases/tag/{version}" id="release-notes-this-version-link">This version</a> | <a href="https://github.com/FooSoft/yomichan/releases" rel="noreferrer noopener">All versions</a></li>
+                <li>Information and downloadable dictionaries: <a href="https://github.com/themoeway/yomitan#yomitan" rel="noreferrer noopener">Homepage</a></li>
+                <li>Support and source code: <a href="https://github.com/themoeway/yomitan" rel="noreferrer noopener">Github</a></li>
+                <li>Release notes: <a href="https://github.com/themoeway/yomitan/releases" rel="noreferrer noopener" data-href-format="https://github.com/themoeway/yomitan/releases/tag/{version}" id="release-notes-this-version-link">This version</a> | <a href="https://github.com/themoeway/yomitan/releases" rel="noreferrer noopener">All versions</a></li>
                 <li>More extension information: <a href="/permissions.html">Permissions</a> | <a href="/legal.html">Licenses</a> | <a href="/issues.html">Issues</a></li>
             </ul>
         </div></div></div></div>

--- a/ext/issues.html
+++ b/ext/issues.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>Yomichan Issues</title>
+    <title>Yomitan Issues</title>
     <link rel="icon" type="image/png" href="/images/icon16.png" sizes="16x16">
     <link rel="icon" type="image/png" href="/images/icon19.png" sizes="19x19">
     <link rel="icon" type="image/png" href="/images/icon32.png" sizes="32x32">
@@ -23,15 +23,15 @@
 
     <span tabindex="-1" id="content-scroll-focus"></span>
 
-    <h1>Yomichan Issues</h1>
+    <h1>Yomitan Issues</h1>
 
     <h2 id="audio-download-failed-permissions-error">Audio download failed due to possible extension permissions error <em>(Chrome)</em></h2>
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">
             <p>
-                Depending on the extension's configuration, Yomichan can sometimes run into issues with
+                Depending on the extension's configuration, Yomitan can sometimes run into issues with
                 downloading audio files while creating Anki cards.
-                This may be due to a permissions issue where Yomichan hasn't been granted access to
+                This may be due to a permissions issue where Yomitan hasn't been granted access to
                 the sites hosting the audio files.
             </p>
             <p>
@@ -48,11 +48,11 @@
             <p>
                 If a website failes to keep its HTTPS certificate up to date,
                 downloads can fail because the browser flags the connection as insecure.
-                This has happened occasionally for some websites that Yomichan interacts with,
+                This has happened occasionally for some websites that Yomitan interacts with,
                 and the issue is usually resolved within a day.
             </p>
             <p>
-                This issue is a server-side issue that Yomichan doesn't have control over.
+                This issue is a server-side issue that Yomitan doesn't have control over.
             </p>
         </div></div></div></div>
     </div>

--- a/ext/legal.html
+++ b/ext/legal.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>Yomichan Legal</title>
+    <title>Yomitan Legal</title>
     <link rel="icon" type="image/png" href="/images/icon16.png" sizes="16x16">
     <link rel="icon" type="image/png" href="/images/icon19.png" sizes="19x19">
     <link rel="icon" type="image/png" href="/images/icon32.png" sizes="32x32">
@@ -23,9 +23,9 @@
 
     <span tabindex="-1" id="content-scroll-focus"></span>
 
-    <h1>Yomichan Legal</h1>
+    <h1>Yomitan Legal</h1>
 
-    <h2>Yomichan License</h2>
+    <h2>Yomitan License</h2>
     <div class="settings-group"><div class="settings-item"><div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">
 <pre>
 Copyright (C) 2016-2022  Yomichan Authors

--- a/ext/permissions.html
+++ b/ext/permissions.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>Yomichan Permissions</title>
+    <title>Yomitan Permissions</title>
     <link rel="icon" type="image/png" href="/images/icon16.png" sizes="16x16">
     <link rel="icon" type="image/png" href="/images/icon19.png" sizes="19x19">
     <link rel="icon" type="image/png" href="/images/icon32.png" sizes="32x32">
@@ -24,7 +24,7 @@
 
     <span tabindex="-1" id="content-scroll-focus"></span>
 
-    <h1>Yomichan Permissions</h1>
+    <h1>Yomitan Permissions</h1>
 
     <h2 id="permissions"></h2>
     <div class="settings-group">
@@ -32,7 +32,7 @@
             <div class="settings-item-left">
                 <div class="settings-item-label"><code>&lt;all_urls&gt;</code></div>
                 <div class="settings-item-description">
-                    Yomichan requires access to all URLs in order to run scripts to scan text and show the definitions popup,
+                    Yomitan requires access to all URLs in order to run scripts to scan text and show the definitions popup,
                     request audio for playback and download, and connect with Anki.
                 </div>
             </div>
@@ -41,7 +41,7 @@
             <div class="settings-item-left">
                 <div class="settings-item-label"><code>storage</code> and <code>unlimitedStorage</code></div>
                 <div class="settings-item-description">
-                    Yomichan uses storage permissions in order to save extension settings and dictionary data.
+                    Yomitan uses storage permissions in order to save extension settings and dictionary data.
                     <code>unlimitedStorage</code> is used to help prevent web browsers from unexpectedly
                     deleting dictionary data.
                 </div>
@@ -52,7 +52,7 @@
                 <div class="settings-item-label"><code>webRequest</code> and <code>webRequestBlocking</code></div>
                 <div class="settings-item-description">
                     <p>
-                        Yomichan uses these permissions to ensure certain requests have valid and secure headers.
+                        Yomitan uses these permissions to ensure certain requests have valid and secure headers.
                         This sometimes involves removing or changing the <code>Origin</code> request header,
                         as this can be used to fingerprint browser configuration.
                     </p>
@@ -67,7 +67,7 @@
                 <div class="settings-item-label"><code>declarativeNetRequest</code></div>
                 <div class="settings-item-description">
                     <p>
-                        Yomichan uses this permission to ensure certain requests have valid and secure headers.
+                        Yomitan uses this permission to ensure certain requests have valid and secure headers.
                         This sometimes involves removing or changing the <code>Origin</code> request header,
                         as this can be used to fingerprint browser configuration.
                     </p>
@@ -81,7 +81,7 @@
             <div class="settings-item-left">
                 <div class="settings-item-label"><code>scripting</code></div>
                 <div class="settings-item-description">
-                    Yomichan will sometimes need to inject stylesheets into webpages in order to
+                    Yomitan will sometimes need to inject stylesheets into webpages in order to
                     properly display the search popup.
                 </div>
             </div>
@@ -90,7 +90,7 @@
             <div class="settings-item-left">
                 <div class="settings-item-label"><code>clipboardWrite</code></div>
                 <div class="settings-item-description">
-                    Yomichan supports simulating the <code>Ctrl+C</code> (copy to clipboard) keyboard shortcut
+                    Yomitan supports simulating the <code>Ctrl+C</code> (copy to clipboard) keyboard shortcut
                     when a definitions popup is open and focused.
                 </div>
             </div>
@@ -99,9 +99,9 @@
             <div class="settings-item-left">
                 <div class="settings-item-label"><code>clipboardRead</code> <span class="light">(optional)</span></div>
                 <div class="settings-item-description">
-                    Yomichan supports automatically opening a search window when Japanese text is copied to the clipboard
+                    Yomitan supports automatically opening a search window when Japanese text is copied to the clipboard
                     while the browser is running, depending on how certain settings are configured.
-                    This allows Yomichan to support scanning text from external applications, provided there is a way
+                    This allows Yomitan to support scanning text from external applications, provided there is a way
                     to copy text from those applications to the clipboard.
                 </div>
             </div>
@@ -113,7 +113,7 @@
             <div class="settings-item-left">
                 <div class="settings-item-label"><code>nativeMessaging</code> <span class="light" data-show-for-browser="chrome edge">(optional)</span></div>
                 <div class="settings-item-description">
-                    Yomichan has the ability to communicate with an optional native messaging component in order to support
+                    Yomitan has the ability to communicate with an optional native messaging component in order to support
                     parsing large blocks of Japanese text using
                     <a href="https://en.wikipedia.org/wiki/MeCab" target="_blank" rel="noopener noreferrer">MeCab</a>.
                     The installation of this component is optional and is not included by default.
@@ -127,7 +127,7 @@
             <div class="settings-item-left">
                 <div class="settings-item-label"><code>webNavigation</code> <span class="light">(optional)</span></div>
                 <div class="settings-item-description">
-                    Yomichan may require this permission to inject content scripts for certain browsers
+                    Yomitan may require this permission to inject content scripts for certain browsers
                     if Google Docs accessibility mode is enabled.
                 </div>
             </div>
@@ -140,7 +140,7 @@
                 <div class="settings-item-label">Allow in private windows <span class="light">(optional)</span></div>
                 <div class="settings-item-description">
                     <p>
-                        When enabled, Yomichan is able to scan text and show definitions in private/incognito web browser windows.
+                        When enabled, Yomitan is able to scan text and show definitions in private/incognito web browser windows.
                     </p>
                     <p>
                         This option can be configured from the web browser's <a tabindex="0" class="extension-settings-link" data-special-url="chrome://extensions/?id={id}">extension settings pages</a>.
@@ -156,7 +156,7 @@
                 <div class="settings-item-label">Allow access to file URLs <span class="light">(optional)</span></div>
                 <div class="settings-item-description">
                     <p>
-                        When enabled, Yomichan is able to scan text and show definitions on local HTML files located using the <code>file://*</code> scheme.
+                        When enabled, Yomitan is able to scan text and show definitions on local HTML files located using the <code>file://*</code> scheme.
                     </p>
                     <p data-show-for-browser="chrome edge">
                         This option can be configured from the web browser's <a tabindex="0" class="extension-settings-link" data-special-url="chrome://extensions/?id={id}">extension settings pages</a>.
@@ -180,7 +180,7 @@
                         It may not be possible to enable this permission on Firefox for Android.
                     </p>
                     <p data-show-for-browser="chrome edge">
-                        Chromium-based browsers should not need to enable this setting since the Yomichan extension has
+                        Chromium-based browsers should not need to enable this setting since the Yomitan extension has
                         the <code>unlimitedStorage</code> permission, which should prevent data deletion.<sup><a href="https://bugs.chromium.org/p/chromium/issues/detail?id=680392#c15" target="_blank" rel="noopener">[1]</a></sup>
                     </p>
                 </div>

--- a/ext/popup-preview.html
+++ b/ext/popup-preview.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>Yomichan Popup Preview</title>
+    <title>Yomitan Popup Preview</title>
     <link rel="icon" type="image/png" href="/images/icon16.png" sizes="16x16">
     <link rel="icon" type="image/png" href="/images/icon19.png" sizes="19x19">
     <link rel="icon" type="image/png" href="/images/icon32.png" sizes="32x32">

--- a/ext/popup.html
+++ b/ext/popup.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>Yomichan Search</title>
+    <title>Yomitan Search</title>
     <link rel="icon" type="image/png" href="/images/icon16.png" sizes="16x16">
     <link rel="icon" type="image/png" href="/images/icon19.png" sizes="19x19">
     <link rel="icon" type="image/png" href="/images/icon32.png" sizes="32x32">
@@ -46,9 +46,9 @@
 
                     <div id="error-extension-unloaded" hidden>
                         <div class="entry">
-                            <h1>Yomichan Updated!</h1>
+                            <h1>Yomitan Updated!</h1>
                             <p>
-                                The Yomichan extension has been updated to a new version! In order to continue
+                                The Yomitan extension has been updated to a new version! In order to continue
                                 viewing definitions on this page, you must reload this tab or restart your browser.
                             </p>
                         </div>

--- a/ext/search.html
+++ b/ext/search.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>Yomichan Search</title>
+    <title>Yomitan Search</title>
     <link rel="icon" type="image/png" href="/images/icon16.png" sizes="16x16">
     <link rel="icon" type="image/png" href="/images/icon19.png" sizes="19x19">
     <link rel="icon" type="image/png" href="/images/icon32.png" sizes="32x32">
@@ -30,7 +30,7 @@
 
                     <div class="search-header">
                         <div id="intro">
-                            <h1>Yomichan Search</h1>
+                            <h1>Yomitan Search</h1>
                         </div>
 
                         <div class="scan-disable">

--- a/ext/template-renderer.html
+++ b/ext/template-renderer.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>Yomichan Handlebars Sandbox</title>
+    <title>Yomitan Handlebars Sandbox</title>
     <link rel="icon" type="image/png" href="/images/icon16.png" sizes="16x16">
     <link rel="icon" type="image/png" href="/images/icon19.png" sizes="19x19">
     <link rel="icon" type="image/png" href="/images/icon32.png" sizes="32x32">

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>Welcome to Yomichan!</title>
+    <title>Welcome to Yomitan!</title>
     <link rel="icon" type="image/png" href="/images/icon16.png" sizes="16x16">
     <link rel="icon" type="image/png" href="/images/icon19.png" sizes="19x19">
     <link rel="icon" type="image/png" href="/images/icon32.png" sizes="32x32">
@@ -23,13 +23,13 @@
 
     <span tabindex="-1" id="content-scroll-focus"></span>
 
-    <h1>Welcome to Yomichan!</h1>
+    <h1>Welcome to Yomitan!</h1>
 
     <h2>Here are some basics to get started</h2>
     <div class="settings-group">
         <div class="settings-item">
             <div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">
-                Clicking the <img src="/images/yomichan-icon.svg" class="inline-icon" alt=""> <em>Yomichan</em> button in the browser bar will open the quick-actions popup.
+                Clicking the <img src="/images/yomichan-icon.svg" class="inline-icon" alt=""> <em>Yomitan</em> button in the browser bar will open the quick-actions popup.
             </div></div></div>
             <div class="settings-item-children settings-item-children-group">
                 <div class="settings-item"><div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">
@@ -42,14 +42,14 @@
                 </div></div></div></div>
                 <div class="settings-item"><div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">
                     The <img src="/images/question-mark-circle.svg" class="inline-icon" alt=""> <em>question mark</em> button will open the <a href="/info.html" target="_blank" rel="noopener">Information</a> page,
-                    which has some helpful information and links about Yomichan.
+                    which has some helpful information and links about Yomitan.
                 </div></div></div></div>
             </div>
         </div>
         <div class="settings-item">
             <div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">
-                Yomichan requires one or more dictionaries to be installed in order to look up terms, kanji, and other information.
-                Several downloadable dictionaries can be found on the <a href="https://foosoft.net/projects/yomichan/#dictionaries" target="_blank" rel="noopener noreferrer">Yomichan homepage</a>,
+                Yomitan requires one or more dictionaries to be installed in order to look up terms, kanji, and other information.
+                Several downloadable dictionaries can be found on the <a href="https://github.com/themoeway/yomitan#dictionaries" target="_blank" rel="noopener noreferrer">Yomitan homepage</a>,
                 allowing you to choose the dictionaries most relevant for you.
                 Dictionaries can be configured using the button below,
                 or later from the the <a href="/settings.html" rel="noopener">Settings</a> page.
@@ -243,7 +243,7 @@
 
         <div class="warning-text margin-above no-dictionaries-installed-warning" hidden>
             No dictionaries have been installed yet.
-            Visit the <a href="https://foosoft.net/projects/yomichan/#dictionaries" target="_blank" rel="noopener noreferrer">Yomichan homepage</a>
+            Visit the <a href="https://github.com/themoeway/yomitan#dictionaries" target="_blank" rel="noopener noreferrer">Yomitan homepage</a>
             for a list of free dictionaries or click the <em>Import</em> button below to select a dictionary file to import.
         </div>
         <div id="dictionary-error" class="danger-text margin-above" hidden></div>


### PR DESCRIPTION
This mostly completes the work from #97. The license under legal.html is still not changed, and will be covered in a different PR.