### PR TITLE
fix: renamed chrome.browserAction -> chrome.action

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1379,16 +1379,16 @@ class Backend {
 
     _getBrowserIconTitle() {
         return (
-            isObject(chrome.browserAction) &&
-            typeof chrome.browserAction.getTitle === 'function' ?
-                new Promise((resolve) => chrome.browserAction.getTitle({}, resolve)) :
+            isObject(chrome.action) &&
+            typeof chrome.action.getTitle === 'function' ?
+                new Promise((resolve) => chrome.action.getTitle({}, resolve)) :
                 Promise.resolve('')
         );
     }
 
     _updateBadge() {
         let title = this._defaultBrowserActionTitle;
-        if (title === null || !isObject(chrome.browserAction)) {
+        if (title === null || !isObject(chrome.action)) {
             // Not ready or invalid
             return;
         }
@@ -1437,17 +1437,17 @@ class Backend {
             }
         }
 
-        if (color !== null && typeof chrome.browserAction.setBadgeBackgroundColor === 'function') {
-            chrome.browserAction.setBadgeBackgroundColor({color});
+        if (color !== null && typeof chrome.action.setBadgeBackgroundColor === 'function') {
+            chrome.action.setBadgeBackgroundColor({color});
         }
-        if (text !== null && typeof chrome.browserAction.setBadgeText === 'function') {
-            chrome.browserAction.setBadgeText({text});
+        if (text !== null && typeof chrome.action.setBadgeText === 'function') {
+            chrome.action.setBadgeText({text});
         }
-        if (typeof chrome.browserAction.setTitle === 'function') {
+        if (typeof chrome.action.setTitle === 'function') {
             if (status !== null) {
                 title = `${title} - ${status}`;
             }
-            chrome.browserAction.setTitle({title});
+            chrome.action.setTitle({title});
         }
     }
 


### PR DESCRIPTION
This PR simply renames `chrome.browserAction` -> `chrome.action`, to support manifest v3.

According to this blog, it seems like this is completely safe to do (because `chrome.action` only adds to the existing api, and doesn't change anything): https://developer.chrome.com/blog/mv3-actions/#manifest-v3-changes

This affects the icon that is shown when no dictionaries are downloaded. With this change, the `!` icon actually shows.

Partially fixes #96.

Original:
![image](https://user-images.githubusercontent.com/17107540/227402098-49eb5a9c-d0fd-403d-9644-afe8c8075d86.png)

Before fix:
![image](https://user-images.githubusercontent.com/17107540/227402115-649fd286-3a06-48e3-9038-cf9033e4e2c6.png)

After fix:
![image](https://user-images.githubusercontent.com/17107540/227402156-ca1504ee-cda8-4292-9c62-ec64b9034e19.png)

(Note: the fix works on Firefox as well)
![image](https://user-images.githubusercontent.com/17107540/227403040-4b8b67ff-e7b2-44fa-b486-0020123bbe06.png)