### PR TITLE
Fix Google Docs URL regex to not be excessively wide

### DIFF
--- a/ext/js/accessibility/accessibility-controller.js
+++ b/ext/js/accessibility/accessibility-controller.js
@@ -82,7 +82,7 @@ class AccessibilityController {
                     allFrames: true,
                     matchAboutBlank: true,
                     matches: ['*://docs.google.com/*'],
-                    urlMatches: '^[^:]*://docs.google.com/[\\w\\W]*$',
+                    urlMatches: '^[^:]*://docs\\.google\\.com/[\\w\\W]*$',
                     runAt: 'document_start',
                     js: ['js/accessibility/google-docs.js']
                 };


### PR DESCRIPTION
As reported by CodeQL:

> This string, which is used as a regular expression , has an unescaped '.' before 'google.com/', so it might match more hosts than expected.