### PR TITLE
Fix playwright action so that it leaves comments even for PRs from forks

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,9 +9,6 @@ jobs:
   playwright:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
     steps:
       - uses: actions/checkout@v3
 
@@ -38,15 +35,17 @@ jobs:
       - name: Grab latest dictionaries from dictionaries branch
         uses: actions/checkout@v3
         with:
+          repository: themoeway/yomitan # so that this works on forks
           ref: dictionaries
           path: dictionaries
 
       - name: Grab latest screenshots from master branch
         uses: dawidd6/action-download-artifact@5e780fc7bbd0cac69fc73271ed86edf5dcb72d67 # pin@v2
         continue-on-error: true
-        id: download-screenshots
+        id: master-screenshots
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          repo: themoeway/yomitan # so that this works on forks
           name: playwright-screenshots
           branch: master
           workflow: playwright.yml
@@ -56,13 +55,9 @@ jobs:
       - name: "[PR] Generate new screenshots & compare against master"
         id: playwright
         run: |
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "PLAYWRIGHT_OUTPUT<<$EOF" >> $GITHUB_OUTPUT
-          npx playwright test 2>&1 | tee $GITHUB_OUTPUT || true
-          echo "$EOF" >> $GITHUB_OUTPUT
-          echo "NUM_FAILED=$(grep -c 'Screenshot comparison failed' $GITHUB_OUTPUT)" >> $GITHUB_OUTPUT
+          npx playwright test 2>&1 | tee ./playwright-output || true
         continue-on-error: true
-        if: github.event_name == 'pull_request' && steps.download-screenshots.outcome != 'failure'
+        if: github.event_name == 'pull_request' && steps.master-screenshots.outcome != 'failure'
 
       - name: "[Push] Generate new authoritative screenshots for master"
         id: playwright-master
@@ -79,31 +74,18 @@ jobs:
           name: playwright-report
           path: playwright-report/
 
-      - name: "[Couldn't download screenshots] Comment results on PR"
-        uses: mshick/add-pr-comment@a65df5f64fc741e91c59b8359a4bc56e57aaf5b1 # pin@v2
-        if: github.event_name == 'pull_request' && steps.download-screenshots.outcome == 'failure'
-        with:
-          message: |
-            :heavy_exclamation_mark: Could not fetch screenshots from master branch, so had nothing to make a visual comparison against; please check the "download-screenshots" step in the workflow run and rerun it before merging.
+      - name: "[PR] Store steps.master-screenshots.outcome in a file"
+        run: echo ${{ steps.master-screenshots.outcome }} > ./master-screenshots-outcome
+        if: github.event_name == 'pull_request'
 
-      - name: "[Success] Comment results on PR"
-        uses: mshick/add-pr-comment@a65df5f64fc741e91c59b8359a4bc56e57aaf5b1 # pin@v2
-        if: github.event_name == 'pull_request' && steps.download-screenshots.outcome != 'failure' && steps.playwright.outputs.NUM_FAILED == 0
+      - uses: actions/upload-artifact@v3
         with:
-          message: |
-            :heavy_check_mark: No visual differences introduced by this PR.
-            [View Playwright Report](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) (note: open the "playwright-report" artifact)
+          name: master-screenshots-outcome
+          path: master-screenshots-outcome
+        if: github.event_name == 'pull_request'
 
-      - name: "[Failure] Comment results on PR"
-        uses: mshick/add-pr-comment@a65df5f64fc741e91c59b8359a4bc56e57aaf5b1 # pin@v2
-        if: github.event_name == 'pull_request' && steps.download-screenshots.outcome != 'failure' && steps.playwright.outputs.NUM_FAILED != 0
+      - uses: actions/upload-artifact@v3
         with:
-          message: |
-            :warning: {{ steps.playwright.outputs.NUM_FAILED }} visual differences introduced by this PR; please validate if they are desirable.
-            <details>
-            <summary>Playwright Test Results</summary>
-            <pre>
-            ${{ steps.playwright.outputs.PLAYWRIGHT_OUTPUT }}
-            </pre>
-            </details>
-            [View Playwright Report](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) (note: open the "playwright-report" artifact)
+          name: playwright-output
+          path: playwright-output
+        if: github.event_name == 'pull_request'

--- a/.github/workflows/playwright_comment.yml
+++ b/.github/workflows/playwright_comment.yml
@@ -1,0 +1,72 @@
+name: Comment on the PR with Playwright results
+
+on:
+  workflow_run:
+    workflows: ["Playwright Tests"]
+    types:
+      - completed
+permissions: {}
+jobs:
+  playwright_comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Grab playwright-output from PR run
+        uses: dawidd6/action-download-artifact@5e780fc7bbd0cac69fc73271ed86edf5dcb72d67 # pin@v2
+        continue-on-error: true
+        id: playwright-output
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: playwright-output
+
+      - name: Grab master-screenshots-outcome from PR run
+        uses: dawidd6/action-download-artifact@5e780fc7bbd0cac69fc73271ed86edf5dcb72d67 # pin@v2
+        continue-on-error: true
+        id: master-screenshots-outcome
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: master-screenshots-outcome
+
+      - name: Load artifacts into environment variables
+        id: playwright
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "PLAYWRIGHT_OUTPUT<<$EOF" >> $GITHUB_OUTPUT
+          cat ./playwright-output >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+          echo "NUM_FAILED=$(grep -c 'Screenshot comparison failed' $GITHUB_OUTPUT)" >> $GITHUB_OUTPUT
+
+      - name: "[Comment] Couldn't download screenshots from master branch"
+        uses: mshick/add-pr-comment@a65df5f64fc741e91c59b8359a4bc56e57aaf5b1 # pin@v2
+        if: github.event_name == 'pull_request' && steps.master-screenshots-outcome == 'failure'
+        with:
+          message: |
+            :heavy_exclamation_mark: Could not fetch screenshots from master branch, so had nothing to make a visual comparison against; please check the "master-screenshots" step in the workflow run and rerun it before merging.
+
+      - name: "[Comment] Success: No visual differences introduced by this PR"
+        uses: mshick/add-pr-comment@a65df5f64fc741e91c59b8359a4bc56e57aaf5b1 # pin@v2
+        if: github.event_name == 'pull_request' && steps.master-screenshots-outcome != 'failure' && steps.playwright.outputs.NUM_FAILED == 0
+        with:
+          message: |
+            :heavy_check_mark: No visual differences introduced by this PR.
+            [View Playwright Report](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}#artifacts) (note: open the "playwright-report" artifact)
+
+      - name: "[Comment] Warning: Visual differences introduced by this PR"
+        uses: mshick/add-pr-comment@a65df5f64fc741e91c59b8359a4bc56e57aaf5b1 # pin@v2
+        if: github.event_name == 'pull_request' && steps.master-screenshots-outcome != 'failure' && steps.playwright.outputs.NUM_FAILED != 0
+        with:
+          message: |
+            :warning: ${{ steps.playwright.outputs.NUM_FAILED }} visual differences introduced by this PR; please validate if they are desirable.
+            <details>
+            <summary>Playwright Test Results</summary>
+            <pre>
+            ${{ steps.playwright.outputs.PLAYWRIGHT_OUTPUT }}
+            </pre>
+            </details>
+            [View Playwright Report](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}#artifacts) (note: open the "playwright-report" artifact)


### PR DESCRIPTION
Background
===
Previously the playwright action would only work from `themoeway/yomitan`-originated branches, not from fork-originated branches. Namely, for PRs from forks, the comment step would fail due to the `GITHUB_TOKEN` not having write permissions. The reason for this security control on GitHub's side is because the code being executed is from the fork and therefore untrusted, so we wouldn't want it to have any write privileges on our repo as it could do something arbitrary.

Reference: [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Fix
===
This fix splits up the action into two actions:
- `playwright.yml` (which only has read privileges) executes the forked repo's test code.
- `playwright_comment.yml` (which has PR write privileges) takes the output of the above workflow run and posts the appropriate comments.

This is safe, as even if the output of the forked repo's test code has some malicious content, the worse it can do is post a slightly malformed comment, which an attacker can easily already directly do themselves using the GitHub UI.