### PR TITLE
More various renaming from Yomichan -> Yomitan

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -901,7 +901,7 @@
                                             "type": "string"
                                         },
                                         "default": [
-                                            "yomichan"
+                                            "yomitan"
                                         ]
                                     },
                                     "screenshot": {

--- a/ext/js/core.js
+++ b/ext/js/core.js
@@ -724,7 +724,7 @@ class Logger extends EventDispatcher {
         if (typeof errorData !== 'undefined') {
             message += `\nData: ${JSON.stringify(errorData, null, 4)}`;
         }
-        message += '\n\nIssues can be reported at https://github.com/FooSoft/yomichan/issues';
+        message += '\n\nIssues can be reported at https://github.com/themoeway/yomitan/issues';
 
         switch (level) {
             case 'info': console.info(message); break;

--- a/ext/js/pages/settings/backup-controller.js
+++ b/ext/js/pages/settings/backup-controller.js
@@ -154,7 +154,7 @@ class BackupController {
         }
         this._settingsExportToken = null;
 
-        const fileName = `yomichan-settings-${this._getSettingsExportDateString(date, '-', '-', '-', 6)}.json`;
+        const fileName = `yomitan-settings-${this._getSettingsExportDateString(date, '-', '-', '-', 6)}.json`;
         const blob = new Blob([JSON.stringify(data, null, 4)], {type: 'application/json'});
         this._saveBlob(blob, fileName);
     }


### PR DESCRIPTION
- `ext/data/schemas/options-schema.json`: renames the default tag added to Anki to `yomitan`.
- `ext/js/pages/settings/backup-controller.js`: changes the name of the exported settings file from `yomichan-settings-(date)` to `yomitan-settings-(date)`.
- `ext/js/core.js`: error message now links to the correct repo