### PR TITLE
playwright: install Japanese font in Ubuntu image

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install CJK fonts
-        run: sudo apt install -y noto-fonts-cjk
+        uses: awalsh128/cache-apt-pkgs-action@1850ee53f6e706525805321a3f2f863dcf73c962
+        with:
+          packages: fonts-noto-cjk
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install CJK fonts
+        run: sudo apt install -y noto-fonts-cjk
+
       - uses: actions/setup-node@v3
         with:
           cache: "npm"


### PR DESCRIPTION
By default CJK fonts are not installed on the Ubuntu image, which led to characters not displaying on the playwright action.

![image](https://user-images.githubusercontent.com/14931040/227797800-5097a20e-955f-4ded-bbf7-6d63db771260.png)
