### PR TITLE
fix publish-firefox-development's upload_url for xpi

### DIFF
--- a/.github/workflows/create-prerelease-on-tag.yml
+++ b/.github/workflows/create-prerelease-on-tag.yml
@@ -25,6 +25,7 @@ jobs:
         shell: bash
 
       - name: Release
+        id: release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # pin@v0.1.15
         with:
           generate_release_notes: true
@@ -44,3 +45,4 @@ jobs:
           workflow: publish-firefox-development
           token: ${{ secrets.GITHUB_TOKEN }}
           wait-for-completion: false
+          inputs: '{ "upload_url": "${{ steps.release.outputs.upload_url }}" }'

--- a/.github/workflows/publish-firefox-development.yml
+++ b/.github/workflows/publish-firefox-development.yml
@@ -5,6 +5,10 @@
 name: publish-firefox-development
 on:
   workflow_dispatch:
+    inputs:
+      upload_url:
+        description: "The upload_url from the release created by create-prerelease-on-tag.yml"
+        required: true
 permissions:
   contents: read
 jobs:
@@ -44,7 +48,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
+          upload_url: ${{ inputs.upload_url }}
           asset_path: yomitan-firefox.xpi
           asset_name: yomitan-firefox.xpi
           asset_content_type: application/x-xpinstall


### PR DESCRIPTION
It is required to pass the upload_url from the release generation action all the way through the workflow_dispatch to the upload action for the xpi upload to work.