### PR TITLE
fix: JPod default audio duration check on Firefox

### DIFF
--- a/ext/js/media/audio-system.js
+++ b/ext/js/media/audio-system.js
@@ -80,7 +80,7 @@ class AudioSystem extends EventDispatcher {
                 const duration = audio.duration;
                 return (
                     duration !== 5.694694 && // Invalid audio (Chrome)
-                    duration !== 5.720718 // Invalid audio (Firefox)
+                    duration !== 5.651111 // Invalid audio (Firefox)
                 );
             }
             default:


### PR DESCRIPTION
JPod always returns an audio file even for audio misses. Examples of audio misses from JPod are そういう and そう言う. The way Yomitan/Yomichan deals with it is by checking the duration of the audio.

For some reason, the duration changed on Firefox, so this just patches that. Ideally, we would check the hash somehow (like how the batch add audio add-on works), but I couldn't figure out how to do that with some extremely basic googling.