### PR TITLE
Fix caching and fonts in playwright.yml

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -39,7 +39,7 @@ jobs:
 
       - if: ${{ steps.cache-playwright.outputs.cache-hit != 'true' }}
         name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
         
       - name: Grab latest dictionaries from dictionaries branch
         uses: actions/checkout@v3


### PR DESCRIPTION
When playwright is installed (i.e., not pulled from cache), the `--with-deps` flag causes it to pull in system dependencies as well. That makes the current caching strategy incoherent, as those dependencies will not be part of the cache as defined. Causing different behavior when pulling from cache vs installing fresh.

In particular, some of the dependencies it pulls in are fonts, which causes the output of the test to change due to the available fonts changing.

In fact, fonts are the _only_ dependencies it pulls in, everything else is already present in the stock ubuntu image. So it seems fine to just remove `--with-deps` and just pull in the image. If we discover we need system deps at any point, we can use `npx playwright install-deps chromium` in a separate command to pull in those deps, and figure out an alternate caching strategy for them.