### PR TITLE
Add Intuitive Permission Toggle to Welcome Page

### DIFF
--- a/ext/js/pages/settings/recommended-permissions-controller.js
+++ b/ext/js/pages/settings/recommended-permissions-controller.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2023  Yomitan Authors
+ * Copyright (C) 2021-2022  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+class RecommendedPermissionsController {
+    constructor(settingsController) {
+        this._settingsController = settingsController;
+        this._originToggleNodes = null;
+        this._eventListeners = new EventListenerCollection();
+        this._errorContainer = null;
+    }
+
+    async prepare() {
+        this._originToggleNodes = document.querySelectorAll('.recommended-permissions-toggle');
+        this._errorContainer = document.querySelector('#recommended-permissions-error');
+        for (const node of this._originToggleNodes) {
+            node.addEventListener('change', this._onOriginToggleChange.bind(this), false);
+        }
+
+        this._settingsController.on('permissionsChanged', this._onPermissionsChanged.bind(this));
+        await this._updatePermissions();
+    }
+
+    // Private
+
+    _onPermissionsChanged({permissions}) {
+        this._eventListeners.removeAllEventListeners();
+        const originsSet = new Set(permissions.origins);
+        for (const node of this._originToggleNodes) {
+            node.checked = originsSet.has(node.dataset.origin);
+        }
+    }
+
+    _onOriginToggleChange(e) {
+        const node = e.currentTarget;
+        const value = node.checked;
+        node.checked = !value;
+
+        const {origin} = node.dataset;
+        this._setOriginPermissionEnabled(origin, value);
+    }
+
+    async _updatePermissions() {
+        const permissions = await this._settingsController.permissionsUtil.getAllPermissions();
+        this._onPermissionsChanged({permissions});
+    }
+
+    async _setOriginPermissionEnabled(origin, enabled) {
+        let added = false;
+        try {
+            added = await this._settingsController.permissionsUtil.setPermissionsGranted({origins: [origin]}, enabled);
+        } catch (e) {
+            this._errorContainer.hidden = false;
+            this._errorContainer.textContent = e.message;
+        }
+        if (!added) { return false; }
+        await this._updatePermissions();
+        return true;
+    }
+}

--- a/ext/js/pages/welcome-main.js
+++ b/ext/js/pages/welcome-main.js
@@ -17,13 +17,13 @@
  */
 
 /* global
- * RecommendedPermissionsController
  * DictionaryController
  * DictionaryImportController
  * DocumentFocusController
  * ExtensionContentController
  * GenericSettingController
  * ModalController
+ * RecommendedPermissionsController
  * ScanInputsSimpleController
  * SettingsController
  * SettingsDisplayController

--- a/ext/js/pages/welcome-main.js
+++ b/ext/js/pages/welcome-main.js
@@ -17,6 +17,7 @@
  */
 
 /* global
+ * RecommendedPermissionsController
  * DictionaryController
  * DictionaryImportController
  * DocumentFocusController
@@ -27,7 +28,6 @@
  * SettingsController
  * SettingsDisplayController
  * StatusFooter
- * RecommendedPermissionsController
  */
 
 async function setupEnvironmentInfo() {

--- a/ext/js/pages/welcome-main.js
+++ b/ext/js/pages/welcome-main.js
@@ -27,6 +27,7 @@
  * SettingsController
  * SettingsDisplayController
  * StatusFooter
+ * RecommendedPermissionsController
  */
 
 async function setupEnvironmentInfo() {
@@ -76,6 +77,9 @@ async function setupGenericSettingsController(genericSettingController) {
 
         const simpleScanningInputController = new ScanInputsSimpleController(settingsController);
         simpleScanningInputController.prepare();
+
+        const recommendedPermissionsController = new RecommendedPermissionsController(settingsController);
+        recommendedPermissionsController.prepare();
 
         await Promise.all(preparePromises);
 

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -98,6 +98,20 @@
         </div>
     </div>
 
+    <h2>Recommended Permissions &#40;Important&#41;</h2>
+    <div class="settings-group">
+        <div class="settings-item"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label">Enable recommended permissions</div>
+                <div class="settings-item-description">This will allow Yomitan to scan text from most sites. Further configuration is available on the <a href="/permissions.html" rel="noopener">Permissions page</a>.</div>
+            </div>
+            <div class="settings-item-right">
+                <label class="toggle"><input type="checkbox" class="recommended-permissions-toggle" data-origin="&lt;all_urls&gt;"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+            </div>
+            <div id="recommended-permissions-error" class="margin-above danger-text" hidden></div>
+        </div></div>
+    </div>
+
     <h2>Basic customization</h2>
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner">
@@ -422,6 +436,7 @@
 <script src="/js/pages/settings/dictionary-controller.js"></script>
 <script src="/js/pages/settings/dictionary-import-controller.js"></script>
 <script src="/js/pages/settings/generic-setting-controller.js"></script>
+<script src="/js/pages/settings/recommended-permissions-controller.js"></script>
 <script src="/js/pages/settings/modal.js"></script>
 <script src="/js/pages/settings/modal-controller.js"></script>
 <script src="/js/pages/settings/scan-inputs-simple-controller.js"></script>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -436,9 +436,9 @@
 <script src="/js/pages/settings/dictionary-controller.js"></script>
 <script src="/js/pages/settings/dictionary-import-controller.js"></script>
 <script src="/js/pages/settings/generic-setting-controller.js"></script>
-<script src="/js/pages/settings/recommended-permissions-controller.js"></script>
 <script src="/js/pages/settings/modal.js"></script>
 <script src="/js/pages/settings/modal-controller.js"></script>
+<script src="/js/pages/settings/recommended-permissions-controller.js"></script>
 <script src="/js/pages/settings/scan-inputs-simple-controller.js"></script>
 <script src="/js/pages/settings/settings-controller.js"></script>
 <script src="/js/pages/settings/settings-display-controller.js"></script>


### PR DESCRIPTION
This PR addresses #127 by adding a toggle on the welcome page, which enables the <all_urls> origin permission, and links to the permission page. 
![image](https://github.com/themoeway/yomitan/assets/60858870/9946ec53-f7f9-49d4-b089-76133649f301)

(ESLint seems to be complaining about this, I can't for the life of me figure out why. It passes fine locally).
