### PR TITLE
Auto-approve safe PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,15 @@
+name: Auto-Approve Safe PRs
+
+on: pull_request_target
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    environment: themoeway-bot
+    permissions:
+      pull-requests: write
+    if: github.actor == 'djahandarie'
+    steps:
+      - uses: hmarr/auto-approve-action@44888193675f29a83e04faf4002fa8c0b537b1e4 # v3.2.1
+        with:
+          github-token: ${{ secrets.THEMOEWAY_BOT_PAT }}


### PR DESCRIPTION
GitHub doesn't quite work how I want it to for a safe and consistent approval flow in this repo.

Basically, I want:
* Everything to go through the same process (all PRs, no force pushes to master), including my own code
* Nothing should go into master without my review (for devs who are pulling directly off master, it would be bad if they got infected by some malicious code)
* Extra reviews by other members are optional but encouraged

There is no way to accomplish this by default. Either (1) one can loosen branch protections, which would allow me to do force pushes, which is not as visible as a PR-based flow, and less consistent, (2) one can tighten branch protections and give more people ability to do approvals, but that would allow them to merge arbitrary code into master because of how GitHub's model works, and that is more powerful than I want (until I can find a trusted co-maintainer)

So I would like to introduce this workflow so that we can have tight branch protections and a consistent process for new code being introduced into the codebase (which has benefits such as always having descriptions such as this one), but still allow me to commit. At least until I find a co-maintainer.