### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @djahandarie @Aquafina-water-bottle @EwanFox @MarvNC @Rudo2204 @Timm04

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @djahandarie @Aquafina-water-bottle @EwanFox @MarvNC @Rudo2204 @Timm04
+* @themoeway/yomitan-codeowners


### PR DESCRIPTION
Manage the list of people with approving power using CODEOWNERS and a GitHub team.

This allows for more precise control than just anyone who manages to get write access to the repo (e.g., via organiziational changes). The current plan is for the team to only be populated by actual maintainers and the themoeway-bot for when maintainers need their own PRs approved.