### PR TITLE
Attempt to fix auto-approval CI workflow

### DIFF
--- a/.github/workflows/auto-approve-run.yml
+++ b/.github/workflows/auto-approve-run.yml
@@ -1,0 +1,29 @@
+name: Auto-Approve Safe PRs (workflow-run)
+on:
+  workflow_run:
+    workflows: [Auto-Approve Safe PRs]
+    types:
+      - completed
+jobs:
+  auto-approve-run:
+    runs-on: ubuntu-latest
+    environment: themoeway-bot
+    permissions:
+      pull-requests: write
+    if: github.actor == 'djahandarie'
+    steps:
+      - name: Download workflow artifact
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
+        with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            workflow: auto-approve.yml
+            run_id: ${{ github.event.workflow_run.id }}
+      - name: Read the pr_num file
+        id: pr_num_reader
+        uses: juliangruber/read-file-action@02bbba9876a8f870efd4ad64e3b9088d3fb94d4b # v1.1.6
+        with:
+            path: ./pr_num/pr_num.txt
+      - uses: hmarr/auto-approve-action@44888193675f29a83e04faf4002fa8c0b537b1e4 # v3.2.1
+        with:
+          pull-request-number: ${{ steps.pr_num_reader.outputs.content }}
+          github-token: ${{ secrets.THEMOEWAY_BOT_PAT }}

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,15 +1,16 @@
 name: Auto-Approve Safe PRs
-
-on: pull_request_target
-
+on: pull_request
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    environment: themoeway-bot
-    permissions:
-      pull-requests: write
-    if: github.actor == 'djahandarie'
     steps:
-      - uses: hmarr/auto-approve-action@44888193675f29a83e04faf4002fa8c0b537b1e4 # v3.2.1
+      - name: Save the PR number in an artifact
+        shell: bash
+        env:
+          PR_NUM: ${{ github.event.number }}
+        run: echo $PR_NUM > pr_num.txt
+      - name: Upload the PR number
+        uses: actions/upload-artifact@v2
         with:
-          github-token: ${{ secrets.THEMOEWAY_BOT_PAT }}
+          name: pr_num
+          path: ./pr_num.txt


### PR DESCRIPTION
Apparently, even though `pull_request_target` is supposed to run in the context of the base branch, it can't seem to access environments that are restricted to that base branch. Which seems like a bug with GitHub to me.

This is an attempt to work around that behavior, by using `workflow_run` instead of `pull_request_target`, to see if it can access branch-restricted environments.