### PR TITLE
Restrict workflow permissions to satisfy OSSF Scorecard

### DIFF
--- a/.github/workflows/auto-approve-run.yml
+++ b/.github/workflows/auto-approve-run.yml
@@ -4,6 +4,7 @@ on:
     workflows: [Auto-Approve Safe PRs]
     types:
       - completed
+permissions: {}
 jobs:
   auto-approve-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,5 +1,6 @@
 name: Auto-Approve Safe PRs
 on: pull_request
+permissions: {}
 jobs:
   auto-approve:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Restrict workflow permissions introduced in #218 to satisfy OSSF Scorecard