### PR TITLE
Increase yomitan popup size to fit content

### DIFF
--- a/ext/css/action-popup.css
+++ b/ext/css/action-popup.css
@@ -34,6 +34,7 @@ body {
     margin: 0;
     font-family: 'Segoe UI', Tahoma, sans-serif;
     font-size: var(--font-size);
+    width: max-content;
 }
 
 h3 {


### PR DESCRIPTION
Before this change, Yomitan's popup width is too small. 25px which is the [min width of an extension](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/extensions/extension_popup.h;l=57).
<img width="45" alt="Screenshot 2023-08-25 at 6 56 23 PM" src="https://github.com/themoeway/yomitan/assets/3213296/7afed2b4-f775-4292-87f7-ed29a49dc66a">



After this change, Yomitan fits the content.
<img width="103" alt="Screenshot 2023-08-25 at 6 55 33 PM" src="https://github.com/themoeway/yomitan/assets/3213296/a892163a-3d78-4827-8b0d-c18a1dde919f">
![ken-jeong-community](https://github.com/themoeway/yomitan/assets/3213296/a3e216a3-2ff5-4934-94c0-9186de2a2916)


