### PR TITLE
Group minor/patch updates together in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
       interval: "weekly"
     labels:
       - "area/dependencies"
+    groups: # group minor/patch updates together
+      minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -13,3 +20,10 @@ updates:
       interval: "weekly"
     labels:
       - "area/dependencies"
+    groups: # group minor/patch updates together
+      minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
What
====
[Grouping Dependabot version updates into one pull request](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#grouping-dependabot-version-updates-into-one-pull-request)](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#grouping-dependabot-version-updates-into-one-pull-request)

Why
====
Reduce unneeded PR spam, especially to the Discord channel.