### PR TITLE
Reduce dependabot frequency from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "area/dependencies"
     groups: # group minor/patch updates together
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "area/dependencies"
     groups: # group minor/patch updates together


### PR DESCRIPTION
What
====
Reduce dependabot frequency from weekly to monthly

What
====
To reduce PR spam, increase the chance of minor PRs getting grouped together, and reduce discord spam.