### PR TITLE
Fix bug in publish-firefox-development, use correct filepath

### DIFF
--- a/.github/workflows/publish-firefox-development.yml
+++ b/.github/workflows/publish-firefox-development.yml
@@ -53,15 +53,15 @@ jobs:
           asset_name: yomitan-firefox-dev.xpi
           asset_content_type: application/x-xpinstall
 
-      # update update.json so that all people who have the dev version installed get the new update
+      # update updates.json so that all people who have the dev version installed get the new update
 
       - uses: actions/checkout@v4
         with:
           ref: metadata
 
-      - name: Recreate update.json
+      - name: Recreate updates.json
         run: |
-          cat > update.json << EOF
+          cat > updates.json << EOF
           {
               "addons": {
                   "{2d13e145-294e-4ead-9bce-b4644b203a00}": {


### PR DESCRIPTION
What
====
`update.json` → `updates.json`

Why
====
Typo. The correct path in the metadata branch is `updates.json`