### PR TITLE
Add SLSA provenance to releases

### DIFF
--- a/.github/workflows/create-prerelease-on-tag.yml
+++ b/.github/workflows/create-prerelease-on-tag.yml
@@ -7,11 +7,13 @@ on:
 permissions:
   contents: read
 jobs:
-  build-release-publish:
+  build:
     runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: write
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - uses: actions/checkout@v4
 
@@ -23,6 +25,12 @@ jobs:
       - name: Lint
         run: npm run-script build -- --all --yomitan-version ${{ github.ref_name }}
         shell: bash
+
+      - name: Generate hashes
+        id: hash
+        run: |
+          cd builds
+          echo "hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
 
       - name: Release
         id: release
@@ -46,3 +54,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           wait-for-completion: false
           inputs: '{ "upload_url": "${{ steps.release.outputs.upload_url }}" }'
+
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@07e64b653f10a80b6510f4568f685f8b7b9ea830
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      upload-assets: true

--- a/.github/workflows/publish-firefox-development.yml
+++ b/.github/workflows/publish-firefox-development.yml
@@ -12,11 +12,13 @@ on:
 permissions:
   contents: read
 jobs:
-  build-signed-xpi-asset:
+  build:
     runs-on: ubuntu-latest
     environment: cd
     permissions:
       contents: write
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - uses: robinraju/release-downloader@efa4cd07bd0195e6cc65e9e30c251b49ce4d3e51 # pin@v1.8
         with:
@@ -40,6 +42,11 @@ jobs:
           steps.ffSignXpi.outcome == 'failure' &&
           steps.ffSignXpi.outputs.sameVersionAlreadyUploadedError != 'true'
         run: exit 1
+
+      - name: Generate hashes
+        id: hash
+        run: |
+          echo "hashes=$(sha256sum yomitan-firefox-dev.xpi | base64 -w0)" >> "$GITHUB_OUTPUT"
 
       - name: Upload offline xpi release asset
         id: uploadReleaseAsset
@@ -86,3 +93,14 @@ jobs:
         uses: ad-m/github-push-action@29f05e01bb17e6f28228b47437e03a7b69e1f9ef # pin@master
         with:
           branch: metadata
+
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@07e64b653f10a80b6510f4568f685f8b7b9ea830
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      upload-assets: true


### PR DESCRIPTION
Why
====
Currently our releases are not signed in any way, and as a result we fail the "Signed-Releases" check of the openssf scorecard.

What
====
Sign releases using the SLSA generic GitHub provenance generator.

This not only signs the release, but also generates evidence that the release was generated from the repository's GitHub workflow (as opposed to e.g., a malicious repo admin's computer who then uploaded it after).

This is even more powerful than a normal signature, because it means that it's possible for a user to entirely cryptographically verify & audit how the release artifacts were built.