### PR TITLE
Update tough-cookie dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5066,9 +5066,9 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-            "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+            "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
             "dev": true,
             "dependencies": {
                 "psl": "^1.1.33",
@@ -9480,9 +9480,9 @@
             }
         },
         "tough-cookie": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-            "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+            "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
             "dev": true,
             "requires": {
                 "psl": "^1.1.33",


### PR DESCRIPTION
Now that web-ext is removed (#263), we can update this dependency.

Fixes CVE-2023-26136 (which we are not affected by, but just to be safe).