### PR TITLE
fix: page and popup state is destroyed on background wakeup

### DIFF
--- a/ext/js/yomichan.js
+++ b/ext/js/yomichan.js
@@ -214,7 +214,9 @@ class Yomichan extends EventDispatcher {
     }
 
     _onMessageOptionsUpdated({source}) {
-        this.trigger('optionsUpdated', {source});
+        if (source !== 'background') {
+            this.trigger('optionsUpdated', {source});
+        }
     }
 
     _onMessageDatabaseUpdated({type, cause}) {


### PR DESCRIPTION
when the background script starts, it sends a `Yomichan.optionsUpdated` message which is retransmitted indiscriminately.

- popups are all torn down/refreshed
- the search bar on the search page can lose state
- if a popup has been loaded on the search page, the search page can redirect/refresh
- options being edited can lose state and the options page can refresh