### PR TITLE
Switch to version pin for SLSA generator action (as it is required)

### DIFF
--- a/.github/workflows/create-prerelease-on-tag.yml
+++ b/.github/workflows/create-prerelease-on-tag.yml
@@ -61,7 +61,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@07e64b653f10a80b6510f4568f685f8b7b9ea830
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true

--- a/.github/workflows/publish-firefox-development.yml
+++ b/.github/workflows/publish-firefox-development.yml
@@ -100,7 +100,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@07e64b653f10a80b6510f4568f685f8b7b9ea830
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true


### PR DESCRIPTION
Why
====
The SLSA generator action requires a version pin to function. Hopefully scorecard doesn't complain too much about this. It's not ideal from the security perspective, but it's the best option currently.

What
====
Switch from hash to version number.