### PR TITLE
add sort dictionary data to parse results on the search page

### DIFF
--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -93,6 +93,12 @@ class Translator {
         }
 
         if (mode === 'simple') {
+            if (sortFrequencyDictionary !== null) {
+                const sortDictionaryMap = [sortFrequencyDictionary]
+                    .filter((key) => enabledDictionaryMap.has(key))
+                    .reduce((subMap, key) => subMap.set(key, enabledDictionaryMap.get(key)), new Map());
+                await this._addTermMeta(dictionaryEntries, sortDictionaryMap);
+            }
             this._clearTermTags(dictionaryEntries);
         } else {
             await this._addTermMeta(dictionaryEntries, enabledDictionaryMap);


### PR DESCRIPTION
this is based on forsakeninfinity's commit https://github.com/forsakeninfinity/yomibaba/commit/c9887d51ed5c917bb900d7964614154de1d76872

i can verify the change with JMdict, CC100, and 止める (とめる vs やめる)