### PR TITLE
Edit `vertical-align` style for structured content hyperlinks

### DIFF
--- a/ext/css/structured-content.css
+++ b/ext/css/structured-content.css
@@ -201,7 +201,7 @@
 
 /* Links */
 .gloss-link-text {
-    vertical-align: middle;
+    vertical-align: baseline;
 }
 .gloss-link-external-icon {
     display: inline-block;


### PR DESCRIPTION
Related issue: [vertical-align style on structured content hyperlinks causes visual glitches](https://github.com/themoeway/yomitan/issues/271)

I'll preface this by saying I haven't actually used Yomitan. I've only tested this in the final version of Yomichan (published Oct 23 2022) and the latest version of Yomibaba. Presumably they behave identically.

I produced a [sample dictionary.zip](https://github.com/themoeway/yomitan/files/13059877/sample.dictionary.zip) with a few entries to test this style change. The relevant entry is under the word `リンク`. Images are below.

<details>
  <summary>Links in Chromium with 'vertical-align' set to 'middle'</summary>

![chromium_middle](https://github.com/themoeway/yomitan/assets/8003332/f20d9a28-14f7-4265-8aa3-a13a554f132c)
</details>

<details>
  <summary>Links in Chromium with 'vertical-align' set to 'baseline'</summary>

![chromium_baseline](https://github.com/themoeway/yomitan/assets/8003332/f06e1256-3f03-4e3d-9b74-40fcaeb438d1)
</details>

For whatever reason, Firefox doesn't display much of a difference. It seems that its rendering engine must handle `vertical-align` styles differently. I assume this is why toasted-nutbread didn't catch the problem.


<details>
  <summary>Links in Firefox with 'vertical-align' set to 'middle'</summary>

![firefox_middle](https://github.com/themoeway/yomitan/assets/8003332/a46a4a53-a894-4209-b858-8af3ce2fdfc9)
</details>

<details>
  <summary>Links in Firefox with 'vertical-align' set to 'baseline'</summary>

![firefox_baseline](https://github.com/themoeway/yomitan/assets/8003332/c927f4ce-7ff4-488f-8c2a-e1dbed763294)
</details>