### PR TITLE
restore webRequestBlocking on Firefox

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -80,7 +80,6 @@
             "storage",
             "clipboardWrite",
             "unlimitedStorage",
-            "webRequest",
             "declarativeNetRequest",
             "scripting",
             "offscreen"
@@ -247,6 +246,24 @@
                     ],
                     "items": [
                         "nativeMessaging"
+                    ]
+                },
+                {
+                    "action": "add",
+                    "path": [
+                        "permissions"
+                    ],
+                    "items": [
+                        "webRequest"
+                    ]
+                },
+                {
+                    "action": "add",
+                    "path": [
+                        "permissions"
+                    ],
+                    "items": [
+                        "webRequestBlocking"
                     ]
                 },
                 {

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -9,12 +9,12 @@
   `unlimitedStorage` is used to help prevent web browsers from unexpectedly
   deleting dictionary data.
 
-* `webRequest` and `webRequestBlocking` _(Manifest V2 only)_ <br>
+* `webRequest` and `webRequestBlocking` _(Firefox only)_ <br>
   Yomichan uses these permissions to ensure certain requests have valid and secure headers.
   This sometimes involves removing or changing the `Origin` request header,
   as this can be used to fingerprint browser configuration.
 
-* `declarativeNetRequest` _(Manifest V3 only)_ <br>
+* `declarativeNetRequest` _(Chrome only)_ <br>
   Yomichan uses this permission to ensure certain requests have valid and secure headers.
   This sometimes involves removing or changing the `Origin` request header,
   as this can be used to fingerprint browser configuration.
@@ -23,7 +23,7 @@
   Yomichan will sometimes need to inject stylesheets into webpages in order to
   properly display the search popup.
 
-* `offscreen` __(Manifest v3 only)_ <br>
+* `offscreen` __(Chrome only)_ <br>
   Yomitan uses this permission to create a secondary backend document that has DOM access, given that Manifest v3
   service workers do not. Service workers can then reach out to out to this document in order to complete
   actions that require access to DOM APIs, such as any that require clipboard access.


### PR DESCRIPTION
this permission was missing when `declarativeNetRequest` was removed temporarily from Firefox.