### PR TITLE
save options after updating them

### DIFF
--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -114,7 +114,7 @@ class OptionsUtil {
 
         if (typeof options !== 'undefined') {
             options = await this.update(options);
-            await save(options);
+            await this.save(options);
         } else {
             options = this.getDefault();
         }

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -114,6 +114,7 @@ class OptionsUtil {
 
         if (typeof options !== 'undefined') {
             options = await this.update(options);
+            await save(options);
         } else {
             options = this.getDefault();
         }


### PR DESCRIPTION
without saving, the options will be updated every time the background restarts, until any settings are modified or text scanning is toggled. for `_updateVersion21`, this means the welcome page will open repeatedly to show the same warning.

`_optionsUtil.save()` is only called in `_saveOptions`, which is only called through

- `_onApiSetAllSettings`
- `_onApiModifySettings`
- `_onCommandToggleTextScanning`

it should be safe to simply save settings after updating them.