### PR TITLE
Auto-eslint in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-  "markdown.extension.toc.levels": "1..3"
+    "markdown.extension.toc.levels": "1..3",
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    },
+    "eslint.format.enable": true
 }


### PR DESCRIPTION
Now that we are checking in `.vscode/settings.json`, it seems preferable to have vscode auto-eslint format/fix, as eslint CI failures are quite common for people's first contribution if they don't know about it.