### PR TITLE
fix: reinstate webRequest and correct the permissions docs

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -81,6 +81,7 @@
             "clipboardWrite",
             "unlimitedStorage",
             "declarativeNetRequest",
+            "webRequest",
             "scripting",
             "offscreen"
         ],
@@ -246,15 +247,6 @@
                     ],
                     "items": [
                         "nativeMessaging"
-                    ]
-                },
-                {
-                    "action": "add",
-                    "path": [
-                        "permissions"
-                    ],
-                    "items": [
-                        "webRequest"
                     ]
                 },
                 {

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -275,6 +275,9 @@
             ],
             "excludeFiles": [
                 "sw.js",
+                "offscreen.html",
+                "js/background/offscreen.js",
+                "js/background/offscreen-main.js",
                 "js/dom/simple-dom-parser.js",
                 "lib/parse5.js"
             ]
@@ -323,6 +326,9 @@
             ],
             "excludeFiles": [
                 "sw.js",
+                "offscreen.html",
+                "js/background/offscreen.js",
+                "js/background/offscreen-main.js",
                 "js/dom/simple-dom-parser.js",
                 "lib/parse5.js"
             ]

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -9,8 +9,13 @@
   `unlimitedStorage` is used to help prevent web browsers from unexpectedly
   deleting dictionary data.
 
-* `webRequest` and `webRequestBlocking` _(Firefox only)_ <br>
-  Yomichan uses these permissions to ensure certain requests have valid and secure headers.
+* `webRequest` <br>
+  Yomichan uses this permission to collect audio or create Anki notes using
+  [AnkiConnect](https://ankiweb.net/shared/info/2055492159).
+  It is also required to surface error information from failed requests.
+
+* `webRequestBlocking` _(Firefox only)_ <br>
+  Yomichan uses this permission to ensure certain requests have valid and secure headers.
   This sometimes involves removing or changing the `Origin` request header,
   as this can be used to fingerprint browser configuration.
 

--- a/ext/permissions.html
+++ b/ext/permissions.html
@@ -47,12 +47,24 @@
                 </div>
             </div>
         </div></div>
-        <div class="settings-item" data-show-for-browser="firefox firefox-mobile"><div class="settings-item-inner">
+        <div class="settings-item"><div class="settings-item-inner">
             <div class="settings-item-left">
-                <div class="settings-item-label"><code>webRequest</code> and <code>webRequestBlocking</code></div>
+                <div class="settings-item-label"><code>webRequest</code></div>
                 <div class="settings-item-description">
                     <p>
-                        Yomitan uses these permissions to ensure certain requests have valid and secure headers.
+                        Yomitan uses this permission to collect audio or create Anki notes using
+                        <a href="https://ankiweb.net/shared/info/2055492159" target="_blank" rel="noopener noreferrer">AnkiConnect</a>.
+                        It is also required to surface error information from failed requests.
+                    </p>
+                </div>
+            </div>
+        </div></div>
+        <div class="settings-item" data-show-for-browser="firefox firefox-mobile"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label"><code>webRequestBlocking</code></div>
+                <div class="settings-item-description">
+                    <p>
+                        Yomitan uses this permission to ensure certain requests have valid and secure headers.
                         This sometimes involves removing or changing the <code>Origin</code> request header,
                         as this can be used to fingerprint browser configuration.
                     </p>


### PR DESCRIPTION
`webRequest` is used on Chrome/MV3 to surface error information from failed requests. it was added back to the declarative path by toasted-nutbread in FooSoft/yomichan#2161, but the permissions documentation did not reflect `webRequest`'s continued necessity.