### PR TITLE
Permissions fixups

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -249,31 +249,6 @@
                     ]
                 },
                 {
-                    "action": "add",
-                    "path": [
-                        "permissions"
-                    ],
-                    "items": [
-                        "webRequest"
-                    ]
-                },
-                {
-                    "action": "add",
-                    "path": [
-                        "permissions"
-                    ],
-                    "items": [
-                        "webRequestBlocking"
-                    ]
-                },
-                {
-                    "action": "remove",
-                    "path": [
-                        "permissions"
-                    ],
-                    "item": "declarativeNetRequest"
-                },
-                {
                     "action": "remove",
                     "path": [
                         "permissions"

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -81,7 +81,6 @@
             "clipboardWrite",
             "unlimitedStorage",
             "declarativeNetRequest",
-            "webRequest",
             "scripting",
             "offscreen"
         ],
@@ -247,6 +246,15 @@
                     ],
                     "items": [
                         "nativeMessaging"
+                    ]
+                },
+                {
+                    "action": "add",
+                    "path": [
+                        "permissions"
+                    ],
+                    "items": [
+                        "webRequest"
                     ]
                 },
                 {

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -229,24 +229,11 @@
                         "gecko": {
                             "id": "{cb7c0bec-7085-4f84-8422-7b55a7c4467c}",
                             "strict_min_version": "115.0"
+                        },
+                        "gecko_android": {
+                            "strict_min_version": "115.0"
                         }
                     }
-                },
-                {
-                    "action": "remove",
-                    "path": [
-                        "optional_permissions"
-                    ],
-                    "item": "nativeMessaging"
-                },
-                {
-                    "action": "add",
-                    "path": [
-                        "permissions"
-                    ],
-                    "items": [
-                        "nativeMessaging"
-                    ]
                 },
                 {
                     "action": "remove",
@@ -332,13 +319,6 @@
                     "path": [
                         "permissions"
                     ],
-                    "item": "webRequestBlocking"
-                },
-                {
-                    "action": "remove",
-                    "path": [
-                        "permissions"
-                    ],
                     "item": "offscreen"
                 },
                 {
@@ -365,6 +345,9 @@
             ],
             "excludeFiles": [
                 "sw.js",
+                "offscreen.html",
+                "js/background/offscreen.js",
+                "js/background/offscreen-main.js",
                 "js/dom/simple-dom-parser.js",
                 "lib/parse5.js"
             ]

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -9,12 +9,7 @@
   `unlimitedStorage` is used to help prevent web browsers from unexpectedly
   deleting dictionary data.
 
-* `webRequest` and `webRequestBlocking` _(Firefox only)_ <br>
-  Yomichan uses these permissions to ensure certain requests have valid and secure headers.
-  This sometimes involves removing or changing the `Origin` request header,
-  as this can be used to fingerprint browser configuration.
-
-* `declarativeNetRequest` _(Chrome only)_ <br>
+* `declarativeNetRequest` <br>
   Yomichan uses this permission to ensure certain requests have valid and secure headers.
   This sometimes involves removing or changing the `Origin` request header,
   as this can be used to fingerprint browser configuration.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -9,13 +9,8 @@
   `unlimitedStorage` is used to help prevent web browsers from unexpectedly
   deleting dictionary data.
 
-* `webRequest` <br>
-  Yomichan uses this permission to collect audio or create Anki notes using
-  [AnkiConnect](https://ankiweb.net/shared/info/2055492159).
-  It is also required to surface error information from failed requests.
-
-* `webRequestBlocking` _(Firefox only)_ <br>
-  Yomichan uses this permission to ensure certain requests have valid and secure headers.
+* `webRequest` and `webRequestBlocking` _(Firefox only)_ <br>
+  Yomichan uses these permissions to ensure certain requests have valid and secure headers.
   This sometimes involves removing or changing the `Origin` request header,
   as this can be used to fingerprint browser configuration.
 
@@ -24,11 +19,11 @@
   This sometimes involves removing or changing the `Origin` request header,
   as this can be used to fingerprint browser configuration.
 
-* `scripting` _(Manifest V3 only)_ <br>
-  Yomichan will sometimes need to inject stylesheets into webpages in order to
+* `scripting` <br>
+  Yomichan needs to inject content scripts and stylesheets into webpages in order to
   properly display the search popup.
 
-* `offscreen` __(Chrome only)_ <br>
+* `offscreen` _(Chrome only)_ <br>
   Yomitan uses this permission to create a secondary backend document that has DOM access, given that Manifest v3
   service workers do not. Service workers can then reach out to out to this document in order to complete
   actions that require access to DOM APIs, such as any that require clipboard access.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -27,15 +27,14 @@
   Yomichan supports simulating the `Ctrl+C` (copy to clipboard) keyboard shortcut
   when a definitions popup is open and focused.
 
-* `clipboardRead` (optional) <br>
+* `clipboardRead` _(optional)_ <br>
   Yomichan supports automatically opening a search window when Japanese text is copied to the clipboard
   while the browser is running, depending on how certain settings are configured.
   This allows Yomichan to support scanning text from external applications, provided there is a way
   to copy text from those applications to the clipboard.
 
-* `nativeMessaging` (optional on Chrome) <br>
+* `nativeMessaging` _(optional, unavailable on Firefox for Android)_ <br>
   Yomichan has the ability to communicate with an optional native messaging component in order to support
   parsing large blocks of Japanese text using
   [MeCab](https://en.wikipedia.org/wiki/MeCab).
   The installation of this component is optional and is not included by default.
-  This permission is optional on Chrome, but required on Firefox, because Firefox does not permit it to be optional.

--- a/ext/js/background/request-builder.js
+++ b/ext/js/background/request-builder.js
@@ -313,7 +313,7 @@ class RequestBuilder {
 
             await this._updateDynamicRules({addRules});
             try {
-                return await this._fetchInternal(url, init, null);
+                return await fetch(url, init);
             } finally {
                 await this._tryUpdateDynamicRules({removeRuleIds: [id]});
             }

--- a/ext/js/background/request-builder.js
+++ b/ext/js/background/request-builder.js
@@ -263,7 +263,7 @@ class RequestBuilder {
     async _clearDynamicRules() {
         if (!isObject(chrome.declarativeNetRequest)) { return; }
 
-        const rules = this._getDynamicRules();
+        const rules = await this._getDynamicRules();
 
         if (rules.length === 0) { return; }
 

--- a/ext/js/background/request-builder.js
+++ b/ext/js/background/request-builder.js
@@ -31,7 +31,6 @@ class RequestBuilder {
      * Creates a new instance.
      */
     constructor() {
-        this._onBeforeSendHeadersExtraInfoSpec = ['blocking', 'requestHeaders', 'extraHeaders'];
         this._textEncoder = new TextEncoder();
         this._ruleIds = new Set();
     }
@@ -55,15 +54,50 @@ class RequestBuilder {
      * @returns {Promise<Response>} The response of the `fetch` call.
      */
     async fetchAnonymous(url, init) {
-        if (isObject(chrome.declarativeNetRequest)) {
-            return await this._fetchAnonymousDeclarative(url, init);
+        const id = this._getNewRuleId();
+        const originUrl = this._getOriginURL(url);
+        url = encodeURI(decodeURI(url));
+
+        this._ruleIds.add(id);
+        try {
+            const addRules = [{
+                id,
+                priority: 1,
+                condition: {
+                    urlFilter: `|${this._escapeDnrUrl(url)}|`,
+                    resourceTypes: ['xmlhttprequest']
+                },
+                action: {
+                    type: 'modifyHeaders',
+                    requestHeaders: [
+                        {
+                            operation: 'remove',
+                            header: 'Cookie'
+                        },
+                        {
+                            operation: 'set',
+                            header: 'Origin',
+                            value: originUrl
+                        }
+                    ],
+                    responseHeaders: [
+                        {
+                            operation: 'remove',
+                            header: 'Set-Cookie'
+                        }
+                    ]
+                }
+            }];
+
+            await this._updateSessionRules({addRules});
+            try {
+                return await fetch(url, init);
+            } finally {
+                await this._tryUpdateSessionRules({removeRuleIds: [id]});
+            }
+        } finally {
+            this._ruleIds.delete(id);
         }
-        const originURL = this._getOriginURL(url);
-        const headerModifications = [
-            ['cookie', null],
-            ['origin', {name: 'Origin', value: originURL}]
-        ];
-        return await this._fetchInternal(url, init, headerModifications);
     }
 
     /**
@@ -126,144 +160,7 @@ class RequestBuilder {
 
     // Private
 
-    async _fetchInternal(url, init, headerModifications) {
-        const filter = {
-            urls: [this._getMatchURL(url)],
-            types: ['xmlhttprequest']
-        };
-
-        let requestId = null;
-        const onBeforeSendHeadersCallback = (details) => {
-            if (requestId !== null || details.url !== url) { return {}; }
-            ({requestId} = details);
-
-            if (headerModifications === null) { return {}; }
-
-            const requestHeaders = details.requestHeaders;
-            this._modifyHeaders(requestHeaders, headerModifications);
-            return {requestHeaders};
-        };
-
-        let errorDetailsTimer = null;
-        let {promise: errorDetailsPromise, resolve: errorDetailsResolve} = deferPromise();
-        const onErrorOccurredCallback = (details) => {
-            if (errorDetailsResolve === null || details.requestId !== requestId) { return; }
-            if (errorDetailsTimer !== null) {
-                clearTimeout(errorDetailsTimer);
-                errorDetailsTimer = null;
-            }
-            errorDetailsResolve(details);
-            errorDetailsResolve = null;
-        };
-
-        const eventListeners = [];
-        const onBeforeSendHeadersExtraInfoSpec = (headerModifications !== null ? this._onBeforeSendHeadersExtraInfoSpec : []);
-        this._addWebRequestEventListener(chrome.webRequest.onBeforeSendHeaders, onBeforeSendHeadersCallback, filter, onBeforeSendHeadersExtraInfoSpec, eventListeners);
-        this._addWebRequestEventListener(chrome.webRequest.onErrorOccurred, onErrorOccurredCallback, filter, void 0, eventListeners);
-
-        try {
-            return await fetch(url, init);
-        } catch (e) {
-            // onErrorOccurred is not always invoked by this point, so a delay is needed
-            if (errorDetailsResolve !== null) {
-                errorDetailsTimer = setTimeout(() => {
-                    errorDetailsTimer = null;
-                    if (errorDetailsResolve === null) { return; }
-                    errorDetailsResolve(null);
-                    errorDetailsResolve = null;
-                }, 100);
-            }
-            const details = await errorDetailsPromise;
-            if (details !== null) {
-                const data = {details};
-                this._assignErrorData(e, data);
-            }
-            throw e;
-        } finally {
-            this._removeWebRequestEventListeners(eventListeners);
-        }
-    }
-
-    _addWebRequestEventListener(target, callback, filter, extraInfoSpec, eventListeners) {
-        try {
-            for (let i = 0; i < 2; ++i) {
-                try {
-                    if (typeof extraInfoSpec === 'undefined') {
-                        target.addListener(callback, filter);
-                    } else {
-                        target.addListener(callback, filter, extraInfoSpec);
-                    }
-                    break;
-                } catch (e) {
-                    // Firefox doesn't support the 'extraHeaders' option and will throw the following error:
-                    // Type error for parameter extraInfoSpec (Error processing 2: Invalid enumeration value "extraHeaders") for [target].
-                    if (i === 0 && `${e.message}`.includes('extraHeaders') && Array.isArray(extraInfoSpec)) {
-                        const index = extraInfoSpec.indexOf('extraHeaders');
-                        if (index >= 0) {
-                            extraInfoSpec.splice(index, 1);
-                            continue;
-                        }
-                    }
-                    throw e;
-                }
-            }
-        } catch (e) {
-            console.log(e);
-            return;
-        }
-        eventListeners.push({target, callback});
-    }
-
-    _removeWebRequestEventListeners(eventListeners) {
-        for (const {target, callback} of eventListeners) {
-            try {
-                target.removeListener(callback);
-            } catch (e) {
-                console.log(e);
-            }
-        }
-    }
-
-    _getMatchURL(url) {
-        const url2 = new URL(url);
-        return `${url2.protocol}//${url2.host}${url2.pathname}${url2.search}`.replace(/\*/g, '%2a');
-    }
-
-    _getOriginURL(url) {
-        const url2 = new URL(url);
-        return `${url2.protocol}//${url2.host}`;
-    }
-
-    _modifyHeaders(headers, modifications) {
-        modifications = new Map(modifications);
-
-        for (let i = 0, ii = headers.length; i < ii; ++i) {
-            const header = headers[i];
-            const name = header.name.toLowerCase();
-            const modification = modifications.get(name);
-            if (typeof modification === 'undefined') { continue; }
-
-            modifications.delete(name);
-
-            if (modification === null) {
-                headers.splice(i, 1);
-                --i;
-                --ii;
-            } else {
-                headers[i] = modification;
-            }
-        }
-
-        for (const header of modifications.values()) {
-            if (header !== null) {
-                headers.push(header);
-            }
-        }
-    }
-
     async _clearSessionRules() {
-        if (!isObject(chrome.declarativeNetRequest)) { return; }
-
         const rules = await this._getSessionRules();
 
         if (rules.length === 0) { return; }
@@ -274,68 +171,6 @@ class RequestBuilder {
         }
 
         await this._updateSessionRules({removeRuleIds});
-    }
-
-    async _clearDynamicRules() {
-        if (!isObject(chrome.declarativeNetRequest)) { return; }
-
-        const rules = await this._getDynamicRules();
-
-        if (rules.length === 0) { return; }
-
-        const removeRuleIds = [];
-        for (const {id} of rules) {
-            removeRuleIds.push(id);
-        }
-
-        await this._updateDynamicRules({removeRuleIds});
-    }
-
-    async _fetchAnonymousDeclarative(url, init) {
-        const id = this._getNewRuleId();
-        const originUrl = this._getOriginURL(url);
-        url = encodeURI(decodeURI(url));
-
-        this._ruleIds.add(id);
-        try {
-            const addRules = [{
-                id,
-                priority: 1,
-                condition: {
-                    urlFilter: `|${this._escapeDnrUrl(url)}|`,
-                    resourceTypes: ['xmlhttprequest']
-                },
-                action: {
-                    type: 'modifyHeaders',
-                    requestHeaders: [
-                        {
-                            operation: 'remove',
-                            header: 'Cookie'
-                        },
-                        {
-                            operation: 'set',
-                            header: 'Origin',
-                            value: originUrl
-                        }
-                    ],
-                    responseHeaders: [
-                        {
-                            operation: 'remove',
-                            header: 'Set-Cookie'
-                        }
-                    ]
-                }
-            }];
-
-            await this._updateSessionRules({addRules});
-            try {
-                return await fetch(url, init);
-            } finally {
-                await this._tryUpdateSessionRules({removeRuleIds: [id]});
-            }
-        } finally {
-            this._ruleIds.delete(id);
-        }
     }
 
     _getSessionRules() {
@@ -364,6 +199,28 @@ class RequestBuilder {
         });
     }
 
+    async _tryUpdateSessionRules(options) {
+        try {
+            await this._updateSessionRules(options);
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    async _clearDynamicRules() {
+        const rules = await this._getDynamicRules();
+
+        if (rules.length === 0) { return; }
+
+        const removeRuleIds = [];
+        for (const {id} of rules) {
+            removeRuleIds.push(id);
+        }
+
+        await this._updateDynamicRules({removeRuleIds});
+    }
+
     _getDynamicRules() {
         return new Promise((resolve, reject) => {
             chrome.declarativeNetRequest.getDynamicRules((result) => {
@@ -390,15 +247,6 @@ class RequestBuilder {
         });
     }
 
-    async _tryUpdateSessionRules(options) {
-        try {
-            await this._updateSessionRules(options);
-            return true;
-        } catch (e) {
-            return false;
-        }
-    }
-
     _getNewRuleId() {
         let id = 1;
         while (this._ruleIds.has(id)) {
@@ -407,6 +255,11 @@ class RequestBuilder {
             if (id === pre) { throw new Error('Could not generate an id'); }
         }
         return id;
+    }
+
+    _getOriginURL(url) {
+        const url2 = new URL(url);
+        return `${url2.protocol}//${url2.host}`;
     }
 
     _escapeDnrUrl(url) {
@@ -420,25 +273,6 @@ class RequestBuilder {
             result += `%${byte.toString(16).toUpperCase().padStart(2, '0')}`;
         }
         return result;
-    }
-
-    _assignErrorData(error, data) {
-        try {
-            error.data = data;
-        } catch (e) {
-            // On Firefox, assigning DOMException.data can fail in certain contexts.
-            // https://bugzilla.mozilla.org/show_bug.cgi?id=1776555
-            try {
-                Object.defineProperty(error, 'data', {
-                    configurable: true,
-                    enumerable: true,
-                    writable: true,
-                    value: data
-                });
-            } catch (e2) {
-                // NOP
-            }
-        }
     }
 
     static _joinUint8Arrays(items, totalLength) {

--- a/ext/js/extension/environment.js
+++ b/ext/js/extension/environment.js
@@ -31,8 +31,9 @@ class Environment {
     }
 
     async _loadEnvironmentInfo() {
-        const browser = await this._getBrowser();
         const os = await this._getOperatingSystem();
+        const browser = await this._getBrowser(os);
+
         return {
             browser,
             platform: {os}
@@ -64,7 +65,7 @@ class Environment {
         });
     }
 
-    async _getBrowser() {
+    async _getBrowser(os) {
         try {
             if (chrome.runtime.getURL('/').startsWith('ms-browser-extension://')) {
                 return 'edge-legacy';
@@ -76,16 +77,11 @@ class Environment {
             // NOP
         }
         if (typeof browser !== 'undefined') {
-            try {
-                const info = await browser.runtime.getBrowserInfo();
-                if (info.name === 'Fennec') {
-                    return 'firefox-mobile';
-                }
-            } catch (e) {
-                // NOP
-            }
             if (this._isSafari()) {
                 return 'safari';
+            }
+            if (os === 'android') {
+                return 'firefox-mobile';
             }
             return 'firefox';
         } else {

--- a/ext/permissions.html
+++ b/ext/permissions.html
@@ -94,9 +94,9 @@
                 <label class="toggle"><input type="checkbox" class="permissions-toggle" data-required-permissions="clipboardRead"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
-        <div class="settings-item"><div class="settings-item-inner">
+        <div class="settings-item" data-hide-for-browser="firefox-mobile"><div class="settings-item-inner">
             <div class="settings-item-left">
-                <div class="settings-item-label"><code>nativeMessaging</code> <span class="light" data-show-for-browser="chrome edge">(optional)</span></div>
+                <div class="settings-item-label"><code>nativeMessaging</code> <span class="light">(optional)</span></div>
                 <div class="settings-item-description">
                     Yomitan has the ability to communicate with an optional native messaging component in order to support
                     parsing large blocks of Japanese text using

--- a/ext/permissions.html
+++ b/ext/permissions.html
@@ -47,22 +47,7 @@
                 </div>
             </div>
         </div></div>
-        <div class="settings-item" data-show-for-browser="firefox firefox-mobile"><div class="settings-item-inner">
-            <div class="settings-item-left">
-                <div class="settings-item-label"><code>webRequest</code> and <code>webRequestBlocking</code></div>
-                <div class="settings-item-description">
-                    <p>
-                        Yomitan uses these permissions to ensure certain requests have valid and secure headers.
-                        This sometimes involves removing or changing the <code>Origin</code> request header,
-                        as this can be used to fingerprint browser configuration.
-                    </p>
-                    <p>
-                        Example: <code class="overflow-wrap">Origin: <span class="extension-id-example"></span></code>
-                    </p>
-                </div>
-            </div>
-        </div></div>
-        <div class="settings-item" data-show-for-browser="chrome edge"><div class="settings-item-inner">
+        <div class="settings-item"><div class="settings-item-inner">
             <div class="settings-item-left">
                 <div class="settings-item-label"><code>declarativeNetRequest</code></div>
                 <div class="settings-item-description">
@@ -77,11 +62,11 @@
                 </div>
             </div>
         </div></div>
-        <div class="settings-item" data-show-for-manifest-version="3"><div class="settings-item-inner">
+        <div class="settings-item"><div class="settings-item-inner">
             <div class="settings-item-left">
                 <div class="settings-item-label"><code>scripting</code></div>
                 <div class="settings-item-description">
-                    Yomitan will sometimes need to inject stylesheets into webpages in order to
+                    Yomitan needs to inject content scripts and stylesheets into webpages in order to
                     properly display the search popup.
                 </div>
             </div>
@@ -121,18 +106,6 @@
             </div>
             <div class="settings-item-right">
                 <label class="toggle"><input type="checkbox" class="permissions-toggle" data-required-permissions="nativeMessaging"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
-            </div>
-        </div></div>
-        <div class="settings-item" data-hide-for-manifest-version="3"><div class="settings-item-inner">
-            <div class="settings-item-left">
-                <div class="settings-item-label"><code>webNavigation</code> <span class="light">(optional)</span></div>
-                <div class="settings-item-description">
-                    Yomitan may require this permission to inject content scripts for certain browsers
-                    if Google Docs accessibility mode is enabled.
-                </div>
-            </div>
-            <div class="settings-item-right">
-                <label class="toggle"><input type="checkbox" class="permissions-toggle" data-required-permissions="webNavigation"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
         <div class="settings-item"><div class="settings-item-inner">

--- a/ext/permissions.html
+++ b/ext/permissions.html
@@ -47,24 +47,12 @@
                 </div>
             </div>
         </div></div>
-        <div class="settings-item"><div class="settings-item-inner">
-            <div class="settings-item-left">
-                <div class="settings-item-label"><code>webRequest</code></div>
-                <div class="settings-item-description">
-                    <p>
-                        Yomitan uses this permission to collect audio or create Anki notes using
-                        <a href="https://ankiweb.net/shared/info/2055492159" target="_blank" rel="noopener noreferrer">AnkiConnect</a>.
-                        It is also required to surface error information from failed requests.
-                    </p>
-                </div>
-            </div>
-        </div></div>
         <div class="settings-item" data-show-for-browser="firefox firefox-mobile"><div class="settings-item-inner">
             <div class="settings-item-left">
-                <div class="settings-item-label"><code>webRequestBlocking</code></div>
+                <div class="settings-item-label"><code>webRequest</code> and <code>webRequestBlocking</code></div>
                 <div class="settings-item-description">
                     <p>
-                        Yomitan uses this permission to ensure certain requests have valid and secure headers.
+                        Yomitan uses these permissions to ensure certain requests have valid and secure headers.
                         This sometimes involves removing or changing the <code>Origin</code> request header,
                         as this can be used to fingerprint browser configuration.
                     </p>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1372,7 +1372,7 @@
                 </p>
             </div>
         </div>
-        <div class="settings-item advanced-only">
+        <div class="settings-item advanced-only" data-hide-for-browser="firefox-mobile">
             <div class="settings-item-inner">
                 <div class="settings-item-left">
                     <div class="settings-item-invalid-indicator"></div>


### PR DESCRIPTION
- replace `fetchInternal` with `fetch` in the declarative path, remove `webRequest` from Chrome
- fix the flakey bug from `updateDynamicRules` on Firefox, remove the `webRequest` path entirely
- make `nativeMessaging` always optional (this has been possible for a while), unblock Firefox for Android
- fix the environment recognition for `firefox-mobile` and guard the MeCab and `nativeMessaging` settings

while enabling the `nativeMessaging` permission on Firefox for Android might break the installation, the permissions toggles don't seem to enable them anyway (permissions work a bit differently on Android).

while the extension can be signed for Android, it can't actually be installed, as the only way to install extensions on Firefox for Android requires a release on AMO.