### PR TITLE
search.html clipboard monitor, Anki add note Playwright tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -461,6 +461,8 @@
         },
         {
             "files": [
+                "integration.spec.js",
+                "playwright-util.js",
                 "visual.spec.js"
             ],
             "env": {

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: "[PR] Generate new screenshots & compare against master"
         id: playwright
+        env:
+          PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS: 1
         run: |
           npx playwright test 2>&1 | tee ./playwright-output || true
         continue-on-error: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true
     },
-    "eslint.format.enable": true
+    "eslint.format.enable": true,
+    "playwright.env": {
+        "PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS": 1
+    }
 }

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -172,6 +172,27 @@
             ]
         },
         {
+            "name": "chrome-playwright",
+            "inherit": "chrome-dev",
+            "fileName": "yomitan-chrome-playwright.zip",
+            "modifications": [
+                {
+                    "action": "remove",
+                    "path": [
+                        "optional_permissions"
+                    ],
+                    "item": "clipboardRead"
+                },
+                {
+                    "action": "add",
+                    "path": [
+                        "permissions"
+                    ],
+                    "items": ["clipboardRead"]
+                }
+            ]
+        },
+        {
             "name": "firefox",
             "inherit": "base",
             "fileName": "yomitan-firefox.zip",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -62,8 +62,18 @@ module.exports = defineConfig({
     /* Configure projects for major browsers */
     projects: [
         {
+            name: 'playwright setup',
+            testMatch: /global\.setup\.js/,
+            teardown: 'playwright teardown'
+        },
+        {
+            name: 'playwright teardown',
+            testMatch: /global\.teardown\.js/
+        },
+        {
             name: 'chromium',
-            use: {...devices['Desktop Chrome']}
+            use: {...devices['Desktop Chrome']},
+            dependencies: ['playwright setup']
         }
 
         // {

--- a/test/playwright/global.setup.js
+++ b/test/playwright/global.setup.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const {test: setup} = require('@playwright/test');
+const {ManifestUtil} = require('../../dev/manifest-util');
+const {root} = require('./playwright-util');
+const path = require('path');
+const fs = require('fs');
+
+const manifestPath = path.join(root, 'ext/manifest.json');
+const copyManifestPath = path.join(root, 'ext/manifest-old.json');
+
+setup('use test manifest', () => {
+    const manifestUtil = new ManifestUtil();
+    const variant = manifestUtil.getManifest('chrome-playwright');
+    fs.renameSync(manifestPath, copyManifestPath);
+    fs.writeFileSync(manifestPath, ManifestUtil.createManifestString(variant).replace('$YOMITAN_VERSION', '0.0.0.0'));
+});

--- a/test/playwright/global.teardown.js
+++ b/test/playwright/global.teardown.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const {test: teardown} = require('@playwright/test');
+const {root} = require('./playwright-util');
+const path = require('path');
+const fs = require('fs');
+
+const manifestPath = path.join(root, 'ext/manifest.json');
+const copyManifestPath = path.join(root, 'ext/manifest-old.json');
+
+teardown('bring back original manifest', () => {
+    fs.renameSync(copyManifestPath, manifestPath);
+});

--- a/test/playwright/integration.spec.js
+++ b/test/playwright/integration.spec.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const path = require('path');
+const {
+    test,
+    expect,
+    root,
+    mockModelFieldNames,
+    mockModelFieldsToAnkiValues,
+    expectedAddNoteBody,
+    mockAnkiRouteHandler,
+    writeToClipboardFromPage
+} = require('./playwright-util');
+const {createDictionaryArchive} = require('../../dev/util');
+
+test.beforeEach(async ({context}) => {
+    // wait for the on-install welcome.html tab to load, which becomes the foreground tab
+    const welcome = await context.waitForEvent('page');
+    welcome.close(); // close the welcome tab so our main tab becomes the foreground tab -- otherwise, the screenshot can hang
+});
+
+test('search clipboard', async ({page, extensionId}) => {
+    await page.goto(`chrome-extension://${extensionId}/search.html`);
+    await page.locator('#search-option-clipboard-monitor-container > label').click();
+    await page.waitForTimeout(200); // race
+
+    await writeToClipboardFromPage(page, 'あ');
+    await expect(page.locator('#search-textbox')).toHaveValue('あ');
+});
+
+test('anki add', async ({context, page, extensionId}) => {
+    // mock anki routes
+    let resolve;
+    const addNotePromise = new Promise((res) => {
+        resolve = res;
+    });
+    await context.route(/127.0.0.1:8765\/*/, (route) => {
+        mockAnkiRouteHandler(route);
+        const req = route.request();
+        if (req.url().includes('127.0.0.1:8765') && req.postDataJSON().action === 'addNote') {
+            resolve(req.postDataJSON());
+        }
+    });
+
+    // open settings
+    await page.goto(`chrome-extension://${extensionId}/settings.html`);
+
+    // load in test dictionary
+    const dictionary = createDictionaryArchive(path.join(root, 'test/data/dictionaries/valid-dictionary1'), 'valid-dictionary1');
+    const testDictionarySource = await dictionary.generateAsync({type: 'arraybuffer'});
+    await page.locator('input[id="dictionary-import-file-input"]').setInputFiles({name: 'valid-dictionary1.zip', buffer: Buffer.from(testDictionarySource)});
+    await expect(page.locator('id=dictionaries')).toHaveText('Dictionaries (1 installed, 1 enabled)', {timeout: 5 * 60 * 1000});
+
+    // connect to anki
+    await page.locator('.toggle', {has: page.locator('[data-setting="anki.enable"]')}).click();
+    await expect(page.locator('#anki-error-message')).toHaveText('Connected');
+
+    // prep anki deck
+    await page.locator('[data-modal-action="show,anki-cards"]').click();
+    await page.locator('select.anki-card-deck').selectOption('Mock Deck');
+    await page.locator('select.anki-card-model').selectOption('Mock Model');
+    for (const modelField of mockModelFieldNames) {
+        await page.locator(`[data-setting="anki.terms.fields.${modelField}"]`).fill(mockModelFieldsToAnkiValues[modelField]);
+    }
+    await page.locator('#anki-cards-modal > div > div.modal-footer > button:nth-child(2)').click();
+    await writeToClipboardFromPage(page, '読むの例文');
+
+    // add to anki deck
+    await page.goto(`chrome-extension://${extensionId}/search.html`);
+    await page.waitForTimeout(500); // race
+    await page.locator('#search-textbox').fill('読む');
+    await page.locator('#search-textbox').press('Enter');
+    await page.locator('[data-mode="term-kanji"]').click();
+    const addNoteReqBody = await addNotePromise;
+    expect(addNoteReqBody).toMatchObject(expectedAddNoteBody);
+});

--- a/test/playwright/playwright-util.js
+++ b/test/playwright/playwright-util.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2023  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const path = require('path');
+const {test: base, chromium} = require('@playwright/test');
+
+export const root = path.join(__dirname, '..', '..');
+
+export const test = base.extend({
+    context: async ({ }, use) => {
+        const pathToExtension = path.join(root, 'ext');
+        const context = await chromium.launchPersistentContext('', {
+            // headless: false,
+            args: [
+                '--headless=new',
+                `--disable-extensions-except=${pathToExtension}`,
+                `--load-extension=${pathToExtension}`
+            ]
+        });
+        await use(context);
+        await context.close();
+    },
+    extensionId: async ({context}, use) => {
+        let [background] = context.serviceWorkers();
+        if (!background) {
+            background = await context.waitForEvent('serviceworker');
+        }
+
+        const extensionId = background.url().split('/')[2];
+        await use(extensionId);
+    }
+});
+export const expect = test.expect;
+
+export const mockModelFieldNames = [
+    'Word',
+    'Reading',
+    'Audio',
+    'Sentence'
+];
+
+export const mockModelFieldsToAnkiValues = {
+    'Word': '{expression}',
+    'Reading': '{furigana-plain}',
+    'Sentence': '{clipboard-text}',
+    'Audio': '{audio}'
+};
+
+export const mockAnkiRouteHandler = (route) => {
+    const reqBody = route.request().postDataJSON();
+    const respBody = ankiRouteResponses[reqBody.action];
+    if (!respBody) {
+        return route.abort();
+    }
+    route.fulfill(respBody);
+};
+
+export const writeToClipboardFromPage = async (page, text) => {
+    await page.evaluate(`navigator.clipboard.writeText('${text}')`);
+};
+
+export const expectedAddNoteBody = {
+    'action': 'addNote',
+    'params':
+    {
+        'note': {
+            'fields': {
+                'Word': '読む', 'Reading': '読[よ]む', 'Audio': '[sound:mock_audio.mp3]', 'Sentence': '読むの例文'
+            },
+            'tags': ['yomitan'],
+            'deckName': 'Mock Deck',
+            'modelName': 'Mock Model',
+            'options': {
+                'allowDuplicate': false, 'duplicateScope': 'collection', 'duplicateScopeOptions': {
+                    'deckName': null, 'checkChildren': false, 'checkAllModels': false
+                }
+            }
+        }
+    }, 'version': 2
+};
+
+const baseAnkiResp = {
+    status: 200,
+    contentType: 'text/json'
+};
+
+const ankiRouteResponses = {
+    'version': Object.assign({body: JSON.stringify(6)}, baseAnkiResp),
+    'deckNames': Object.assign({body: JSON.stringify(['Mock Deck'])}, baseAnkiResp),
+    'modelNames': Object.assign({body: JSON.stringify(['Mock Model'])}, baseAnkiResp),
+    'modelFieldNames': Object.assign({body: JSON.stringify(mockModelFieldNames)}, baseAnkiResp),
+    'canAddNotes': Object.assign({body: JSON.stringify([true, true])}, baseAnkiResp),
+    'storeMediaFile': Object.assign({body: JSON.stringify('mock_audio.mp3')}, baseAnkiResp),
+    'addNote': Object.assign({body: JSON.stringify(102312488912)}, baseAnkiResp)
+};

--- a/test/playwright/visual.spec.js
+++ b/test/playwright/visual.spec.js
@@ -16,40 +16,20 @@
  */
 
 const path = require('path');
-const {test: base, chromium} = require('@playwright/test');
-const root = path.join(__dirname, '..', '..');
 
-export const test = base.extend({
-    context: async ({ }, use) => {
-        const pathToExtension = path.join(root, 'ext');
-        const context = await chromium.launchPersistentContext('', {
-            // headless: false,
-            args: [
-                '--headless=new',
-                `--disable-extensions-except=${pathToExtension}`,
-                `--load-extension=${pathToExtension}`
-            ]
-        });
-        await use(context);
-        await context.close();
-    },
-    extensionId: async ({context}, use) => {
-        let [background] = context.serviceWorkers();
-        if (!background) {
-            background = await context.waitForEvent('serviceworker');
-        }
+const {
+    test,
+    expect,
+    root
+} = require('./playwright-util');
 
-        const extensionId = background.url().split('/')[2];
-        await use(extensionId);
-    }
-});
-const expect = test.expect;
-
-test('visual', async ({context, page, extensionId}) => {
+test.beforeEach(async ({context}) => {
     // wait for the on-install welcome.html tab to load, which becomes the foreground tab
     const welcome = await context.waitForEvent('page');
     welcome.close(); // close the welcome tab so our main tab becomes the foreground tab -- otherwise, the screenshot can hang
+});
 
+test('visual', async ({page, extensionId}) => {
     // open settings
     await page.goto(`chrome-extension://${extensionId}/settings.html`);
 


### PR DESCRIPTION
Tests for search.html's clipboard monitor and adding a note to Anki. Anki responses are mocked.

* Playwright tests for search.html and Anki add note (can add more note fields to test  if wanted)
* Enable playwright experimental SW flag needed in order to intercept requests from service workers - for both the vscode playwright extension and for the GH action workflow
* Playwright manifest variant (extended off of chrome-dev) for playwright tests
* Playwright global setup/teardown to use playwright manifest variant - moves clipboardRead to required permissions
* Refactored a bit - extracted code from visual.spec.js to a new util file

notes/questions:
* The playwright manifest setup/teardown was added because I couldn't think of a way to use optional permissions - the permission popup would appear, and simply sit there until I either manually clicked it myself, or the test times out. Googling around, the best I could find were suspect hacks - e.g. simulating arrow key/enter clicks to hit OK on the popup. The solution I used might not be preferred, so explicitly pointing it out here.

* There's a couple places where I felt the need to add a waitForTimeout;  I couldn't find a behavior to wait on instead. Can try harder to find UI behavior to wait on if desired, but so far I wasn't able to find anything.

* The current playwright config's `actionTimeout` is really long - would it be OK to just remove it (which would then default it to 10 seconds)? I haven't tested without it, but I can add in longer explicit timeouts wherever needed in place of it.

* Should audio download requests be mocked? - currently isn't for visual.spec.js.

* Can use less CSS locators if preferred.

* The calls for toHaveScreenshot() in visual.spec.js seem to be causing the yomitan instance used by playwright to crash pretty often locally - don't personally have a fix for it or know for certain why.