### PR TITLE
Replace JsonSchema with ajv for dictionary validation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
         "plugin:jsonc/recommended-with-json"
     ],
     "parserOptions": {
-        "ecmaVersion": 9,
+        "ecmaVersion": 11,
         "sourceType": "script",
         "ecmaFeatures": {
             "globalReturn": false,
@@ -401,7 +401,8 @@
                 "DynamicProperty": "readonly",
                 "EventDispatcher": "readonly",
                 "EventListenerCollection": "readonly",
-                "Logger": "readonly"
+                "Logger": "readonly",
+                "import": "readonly"
             }
         },
         {

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dictionaries/
 /playwright/.cache/
 /test/playwright/__screenshots__/
 ext/manifest.json
+ext/lib/validate-schemas.js

--- a/ext/data/schemas/custom-audio-list-schema.json
+++ b/ext/data/schemas/custom-audio-list-schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "customAudioList",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [

--- a/ext/data/schemas/dictionary-index-schema.json
+++ b/ext/data/schemas/dictionary-index-schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "dictionaryIndex",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "description": "Index file containing information about the data contained in the dictionary.",

--- a/ext/data/schemas/dictionary-kanji-bank-v1-schema.json
+++ b/ext/data/schemas/dictionary-kanji-bank-v1-schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "dictionaryKanjiBankV1",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "array",
     "description": "Data file containing kanji information.",

--- a/ext/data/schemas/dictionary-kanji-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-kanji-bank-v3-schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "dictionaryKanjiBankV3",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "array",
     "description": "Data file containing kanji information.",

--- a/ext/data/schemas/dictionary-kanji-meta-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-kanji-meta-bank-v3-schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "dictionaryKanjiMetaBankV3",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "frequency": {

--- a/ext/data/schemas/dictionary-tag-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-tag-bank-v3-schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "dictionaryTagBankV3",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "array",
     "description": "Data file containing tag information for terms and kanji.",

--- a/ext/data/schemas/dictionary-term-bank-v1-schema.json
+++ b/ext/data/schemas/dictionary-term-bank-v1-schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "dictionaryTermBankV1",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "array",
     "description": "Data file containing term information.",

--- a/ext/data/schemas/dictionary-term-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-bank-v3-schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "dictionaryTermBankV3",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "structuredContent": {

--- a/ext/data/schemas/dictionary-term-meta-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-meta-bank-v3-schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "dictionaryTermMetaBankV3",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "frequency": {

--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "options",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [

--- a/ext/lib/ucs2length.js
+++ b/ext/lib/ucs2length.js
@@ -1,0 +1,16 @@
+export default function ucs2length(str) {
+    const len = str.length;
+    let length = 0;
+    let pos = 0;
+    let value;
+    while (pos < len) {
+        length++;
+        value = str.charCodeAt(pos++);
+        if (value >= 0xd800 && value <= 0xdbff && pos < len) {
+            // high surrogate, and there is a next character
+            value = str.charCodeAt(pos);
+            if ((value & 0xfc00) === 0xdc00) pos++; // low surrogate
+        }
+    }
+    return length;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
             "license": "GPL-3.0-or-later",
             "devDependencies": {
                 "@playwright/test": "^1.39.0",
-                "ajv": "^8.11.0",
+                "@types/node": "^20.8.10",
+                "ajv": "^8.12.0",
                 "browserify": "^17.0.0",
                 "css": "^3.0.0",
                 "eslint": "^8.52.0",
@@ -522,6 +523,15 @@
             "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
             "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
             "dev": true
+        },
+        "node_modules/@types/node": {
+            "version": "20.8.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+            "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
@@ -5246,6 +5256,12 @@
                 "undeclared-identifiers": "bin.js"
             }
         },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
+        },
         "node_modules/universalify": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -5984,6 +6000,15 @@
             "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
             "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
             "dev": true
+        },
+        "@types/node": {
+            "version": "20.8.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+            "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+            "dev": true,
+            "requires": {
+                "undici-types": "~5.26.4"
+            }
         },
         "@types/normalize-package-data": {
             "version": "2.4.1",
@@ -9580,6 +9605,12 @@
                 "simple-concat": "^1.0.0",
                 "xtend": "^4.0.1"
             }
+        },
+        "undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
         },
         "universalify": {
             "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     },
     "devDependencies": {
         "@playwright/test": "^1.39.0",
-        "ajv": "^8.11.0",
+        "@types/node": "^20.8.10",
+        "ajv": "^8.12.0",
         "browserify": "^17.0.0",
         "css": "^3.0.0",
         "eslint": "^8.52.0",


### PR DESCRIPTION
Replace [JsonSchema](https://github.com/themoeway/yomitan/blob/master/ext/js/data/json-schema.js) with [ajv](https://ajv.js.org/) for dictionary validation, as it is way faster.

In particular, this drops validation time of [Jitendex](https://github.com/stephenmk/Jitendex/releases/tag/v1.5-1) **from "10 to 40 minutes" to a few seconds**.

It doesn't run into the potential eval issues with ajv, as this implementation compiles the schema in the build process and distributes them with the extension, as suggested by ajv's [own documentation](https://ajv.js.org/security.html#content-security-policy).

Some awkward edges:
* Had to work around a [bug](https://github.com/ajv-validator/ajv/issues/2209) in ajv which required vendoring in [`ucs2length` from ajv](https://github.com/ajv-validator/ajv/blob/490eb8c0eba8392d071fef005e16d330f259d0ba/lib/runtime/ucs2length.ts#L3). 
* Had to use some ugly dynamic `import()`s due to our codebase not currently using ECMAScript modules
* Could not fully strip JsonSchema out from the codebase because other areas like the profile condition validation do actually dynamically generate templates, so there is no way to do that at build-time, and we cannot use ajv for those cases. There is no performance issue in those cases thankfully, but it is ugly to have two JSON schema validators.

@praschke @stephenmk PTAL :pray: 