### PR TITLE
Prevent ci.yml from running twice on PR commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: CI
 permissions:
   contents: read
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
Previously PRs would cause ci.yml to run twice -- now it should hopefully just run once.