### PR TITLE
Fix create-prerelease-on-tag.yml

### DIFF
--- a/.github/workflows/create-prerelease-on-tag.yml
+++ b/.github/workflows/create-prerelease-on-tag.yml
@@ -22,7 +22,10 @@ jobs:
         with:
           node-version-file: ".node-version"
 
-      - name: Lint
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
         run: npm run-script build -- --all --yomitan-version ${{ github.ref_name }}
         shell: bash
 


### PR DESCRIPTION
Seems to be broken when dependencies are involved in the build now (like ajv), so attempt to download them first. Not sure why this was even working in the first place to be honest.