### PR TITLE
Offscreen db

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -2282,7 +2282,7 @@ export class Backend {
             ...findTermsOptions,
             enabledDictionaryMap: enabledDictionaryMapList,
             excludeDictionaryDefinitions: excludeDictionaryDefinitionsList,
-            textReplacementsOptions: textReplacementsSerialized
+            textReplacements: textReplacementsSerialized
         };
         return this._sendMessagePromise({action: 'findTermsOffscreen', params: {mode, text, findTermsOptions: modifiedFindTermsOptions}});
     }

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -16,8 +16,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import * as wanakana from '../../lib/wanakana.js';
 import {ClipboardReader} from '../comm/clipboard-reader.js';
 import {invokeMessageHandler} from '../core.js';
+import {ArrayBufferUtil} from '../data/sandbox/array-buffer-util.js';
+import {DictionaryDatabase} from '../language/dictionary-database.js';
+import {JapaneseUtil} from '../language/sandbox/japanese-util.js';
+import {Translator} from '../language/translator.js';
 import {yomichan} from '../yomichan.js';
 
 /**
@@ -29,6 +34,12 @@ export class Offscreen {
      * Creates a new instance.
      */
     constructor() {
+        this._japaneseUtil = new JapaneseUtil(wanakana);
+        this._dictionaryDatabase = new DictionaryDatabase();
+        this._translator = new Translator({
+            japaneseUtil: this._japaneseUtil,
+            database: this._dictionaryDatabase
+        });
         this._clipboardReader = new ClipboardReader({
             // eslint-disable-next-line no-undef
             document: (typeof document === 'object' && document !== null ? document : null),
@@ -38,11 +49,23 @@ export class Offscreen {
 
         this._messageHandlers = new Map([
             ['clipboardGetTextOffscreen',                 {async: true,  contentScript: true,  handler: this._getTextHandler.bind(this)}],
-            ['clipboardGetImageOffscreen',                 {async: true,  contentScript: true,  handler: this._getImageHandler.bind(this)}]
+            ['clipboardGetImageOffscreen',                 {async: true,  contentScript: true,  handler: this._getImageHandler.bind(this)}],
+            ['databasePrepareOffscreen',                 {async: true,  contentScript: true,  handler: this._prepareDatabaseHandler.bind(this)}],
+            ['getDictionaryInfoOffscreen',                 {async: true,  contentScript: true,  handler: this._getDictionaryInfoHandler.bind(this)}],
+            ['databasePurgeOffscreen',                 {async: true,  contentScript: true,  handler: this._purgeDatabaseHandler.bind(this)}],
+            ['databaseGetMediaOffscreen',                 {async: true,  contentScript: true,  handler: this._getMediaHandler.bind(this)}],
+            ['translatorPrepareOffscreen',                 {async: false,  contentScript: true,  handler: this._prepareTranslatorHandler.bind(this)}],
+            ['findKanjiOffscreen',                 {async: true,  contentScript: true,  handler: this._findKanjiHandler.bind(this)}],
+            ['findTermsOffscreen',                 {async: true,  contentScript: true,  handler: this._findTermsHandler.bind(this)}],
+            ['getTermFrequenciesOffscreen',                 {async: true,  contentScript: true,  handler: this._getTermFrequenciesHandler.bind(this)}],
+            ['clearDatabaseCachesOffscreen',                 {async: false,  contentScript: true,  handler: this._clearDatabaseCachesHandler.bind(this)}]
+
         ]);
 
         const onMessage = this._onMessage.bind(this);
         chrome.runtime.onMessage.addListener(onMessage);
+
+        this._prepareDatabasePromise = null;
     }
 
     _getTextHandler({useRichText}) {
@@ -51,6 +74,59 @@ export class Offscreen {
 
     _getImageHandler() {
         return this._clipboardReader.getImage();
+    }
+
+    _prepareDatabaseHandler() {
+        if (this._prepareDatabasePromise !== null) {
+            return this._prepareDatabasePromise;
+        }
+        this._prepareDatabasePromise = this._dictionaryDatabase.prepare();
+        return this._prepareDatabasePromise;
+    }
+
+    _getDictionaryInfoHandler() {
+        return this._dictionaryDatabase.getDictionaryInfo();
+    }
+
+    _purgeDatabaseHandler() {
+        return this._dictionaryDatabase.purge();
+    }
+
+    async _getMediaHandler({targets}) {
+        const media = await this._dictionaryDatabase.getMedia(targets);
+        const serializedMedia = media.map((m) => ({...m, content: ArrayBufferUtil.arrayBufferToBase64(m.content)}));
+        return serializedMedia;
+    }
+
+    _prepareTranslatorHandler({deinflectionReasons}) {
+        return this._translator.prepare(deinflectionReasons);
+    }
+
+    _findKanjiHandler({text, findKanjiOptions}) {
+        findKanjiOptions.enabledDictionaryMap = new Map(findKanjiOptions.enabledDictionaryMap);
+        return this._translator.findKanji(text, findKanjiOptions);
+    }
+
+    _findTermsHandler({mode, text, findTermsOptions}) {
+        findTermsOptions.enabledDictionaryMap = new Map(findTermsOptions.enabledDictionaryMap);
+        if (findTermsOptions.excludeDictionaryDefinitions) {
+            findTermsOptions.excludeDictionaryDefinitions = new Set(findTermsOptions.excludeDictionaryDefinitions);
+        }
+        findTermsOptions.textReplacements = findTermsOptions.textReplacements.map((group) => {
+            if (!group) {
+                return group;
+            }
+            return group.map((opt) => ({...opt, pattern: new RegExp(opt.pattern)}));
+        });
+        return this._translator.findTerms(mode, text, findTermsOptions);
+    }
+
+    _getTermFrequenciesHandler({termReadingList, dictionaries}) {
+        return this._translator.getTermFrequencies(termReadingList, dictionaries);
+    }
+
+    _clearDatabaseCachesHandler() {
+        return this._translator.clearDatabaseCaches();
     }
 
     _onMessage({action, params}, sender, callback) {

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -116,7 +116,10 @@ export class Offscreen {
             if (!group) {
                 return group;
             }
-            return group.map((opt) => ({...opt, pattern: new RegExp(opt.pattern)}));
+            return group.map((opt) => {
+                const [, pattern, flags] = opt.pattern.match(/\/(.*?)\/([a-z]*)?$/i); // https://stackoverflow.com/a/33642463
+                return {...opt, pattern: new RegExp(pattern, flags ?? '')};
+            });
         });
         return this._translator.findTerms(mode, text, findTermsOptions);
     }


### PR DESCRIPTION
moving db from sw to offscreen

originally I was planning on just reflecting all of the methods/handlers for dictionaryDatabase and keeping translator in SW, but I ended up just moving translator as well and manually writing all of the methods/handlers once I realized several methods would actually need explicit serialization. I don't really like how it currently looks - it feels like service-worker.js is really unwieldy with how many methods are in it. The bunch of message handlers is also irritating.

I also don't like the need to serialize - it might be possible to avoid some of it though through a refactor, but I'm mixed on what to do because it would probably mean more duplicated code because of firefox support. generic serializing could be better rather than in each handler.

haven't tested thoroughly - stuff could be broken.