### PR TITLE
Switch to forked chrome webstore upload action which removes 10MB limit

### DIFF
--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Upload to Google Web Store
         id: webStoreUpload
         continue-on-error: true
-        uses: cardinalby/webext-buildtools-chrome-webstore-upload-action@8db7a005529498d95d3e2e0166f6f4050d2b96a5 # pin@v1.0.10
+        uses: djahandarie/webext-buildtools-chrome-webstore-upload-action@d3ce3b6f6a07d1267b0f5a24416a153159255372
         with:
           zipFilePath: yomitan-chrome.zip
           extensionId: ${{ secrets.G_STABLE_EXTENSION_ID }}


### PR DESCRIPTION
Currently it's not possible to upload to the Chrome Webstore if the extension is larger than 10MB, and with most recent changes (in particular, not minifying bundled dependencies), we are at 11MB.

I forked a couple repos in order to test a fix. If it works the fix will be upstreamed and we can switch back.