### PR TITLE
Update README, Settings to include new MeCab installer repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ You should be able to replicate your exact Yomitan setup across devices by expor
 
 Click the `Show advanced options` toggle switch in the bottom left corner of the Settings page to enable advanced options.
 
-### Parse sentence using MeCab
+### Parse sentences using MeCab
 
 MeCab is a third-party program which uses its own dictionaries and parsing algorithm to decompose sentences into individual words. MeCab may provide more accurate parsing results than Yomitan's internal parser.
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ The following shortcuts are available on search results:
 
 ## Advanced Options
 
-Click the `Show advanced options` toggle switch in the bottom left corner of the Settings page to enable advanced options.
+Click the `Advanced` toggle switch in the bottom left corner of the Settings page to enable advanced options.
 
 ### Parse sentences using MeCab
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ Yomitan provides advanced features not available in other browser-based dictiona
 - [Basic Usage](#basic-usage)
   - [Importing Dictionaries](#importing-dictionaries)
   - [Importing and Exporting Personal Configuration](#importing-and-exporting-personal-configuration)
-- [Advanced Usage](#advanced-usage)
-  - [Parse sentences using MeCab](#parse-sentences-using-mecab)
 - [Custom Dictionaries](#custom-dictionaries)
 - [Anki Integration](#anki-integration)
   - [Flashcard Configuration](#flashcard-configuration)
   - [Flashcard Creation](#flashcard-creation)
 - [Keyboard Shortcuts](#keyboard-shortcuts)
+- [Advanced Options](#advanced-options)
+  - [Parse sentences using MeCab](#parse-sentences-using-mecab)
 - [Frequently Asked Questions](#frequently-asked-questions)
 - [Licenses](#licenses)
 - [Third-Party Libraries](#third-party-libraries)
@@ -181,17 +181,6 @@ Yomitan also supports exporting and importing your entire collection of dictiona
 Note that you can also similarly export and import your Yomitan settings from the `Backup` section of the Settings page.
 
 You should be able to replicate your exact Yomitan setup across devices by exporting your settings and dictionary collection from the source device then importing those from the destination.
-
-## Advanced Usage
-
-Click the `Show advanced options` toggle switch in the bottom left corner of the Settings page to enable advanced options.
-
-### Parse sentences using MeCab
-
-[MeCab](https://taku910.github.io/mecab/) is a third-party program which uses its own dictionaries and parsing algorithm to decompose sentences into individual words. MeCab may provide more accurate parsing results than Yomitan's internal parser.
-
-In order for Yomitan to use it, both MeCab and a native messaging component must be installed.
-A setup guide can be found <a href="https://github.com/starxeras/yomitan-mecab-installer/blob/master/README.md" target="_blank" rel="noopener noreferrer">here</a>.
 
 ## Custom Dictionaries
 
@@ -331,6 +320,17 @@ The following shortcuts are available on search results:
 | <kbd>Alt</kbd> + <kbd>r</kbd>    | Add current term as reading to Anki.    |
 | <kbd>Alt</kbd> + <kbd>p</kbd>    | Play audio for current term.            |
 | <kbd>Alt</kbd> + <kbd>k</kbd>    | Add current kanji to Anki.              |
+
+## Advanced Options
+
+Click the `Show advanced options` toggle switch in the bottom left corner of the Settings page to enable advanced options.
+
+### Parse sentences using MeCab
+
+[MeCab](https://taku910.github.io/mecab/) is a third-party program which uses its own dictionaries and parsing algorithm to decompose sentences into individual words. MeCab may provide more accurate parsing results than Yomitan's internal parser.
+
+In order for Yomitan to use it, both MeCab and a native messaging component must be installed.
+A setup guide can be found [here](https://github.com/starxeras/yomitan-mecab-installer/blob/master/README.md).
 
 ## Frequently Asked Questions
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Yomitan provides advanced features not available in other browser-based dictiona
 - [Basic Usage](#basic-usage)
   - [Importing Dictionaries](#importing-dictionaries)
   - [Importing and Exporting Personal Configuration](#importing-and-exporting-personal-configuration)
+- [Advanced Usage](#advanced-usage)
+  - [Parse sentences using MeCab](#parse-sentences-using-mecab)
 - [Custom Dictionaries](#custom-dictionaries)
 - [Anki Integration](#anki-integration)
   - [Flashcard Configuration](#flashcard-configuration)
@@ -179,6 +181,17 @@ Yomitan also supports exporting and importing your entire collection of dictiona
 Note that you can also similarly export and import your Yomitan settings from the `Backup` section of the Settings page.
 
 You should be able to replicate your exact Yomitan setup across devices by exporting your settings and dictionary collection from the source device then importing those from the destination.
+
+## Advanced Usage
+
+Click the `Show advanced options` toggle switch in the bottom left corner of the Settings page to enable advanced options.
+
+### Parse sentence using MeCab
+
+MeCab is a third-party program which uses its own dictionaries and parsing algorithm to decompose sentences into individual words. MeCab may provide more accurate parsing results than Yomitan's internal parser.
+
+In order for Yomitan to use it, both MeCab and a native messaging component must be installed.
+A setup guide can be found <a href="https://github.com/starxeras/yomitan-mecab-installer/blob/master/README.md" target="_blank" rel="noopener noreferrer">here</a>.
 
 ## Custom Dictionaries
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Click the `Show advanced options` toggle switch in the bottom left corner of the
 [MeCab](https://taku910.github.io/mecab/) is a third-party program which uses its own dictionaries and parsing algorithm to decompose sentences into individual words. MeCab may provide more accurate parsing results than Yomitan's internal parser.
 
 In order for Yomitan to use it, both MeCab and a native messaging component must be installed.
-A setup guide can be found [here](https://github.com/starxeras/yomitan-mecab-installer/blob/master/README.md).
+A setup guide can be found [here](https://github.com/themoeway/yomitan-mecab-installer/blob/master/README.md).
 
 ## Frequently Asked Questions
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Click the `Show advanced options` toggle switch in the bottom left corner of the
 
 ### Parse sentences using MeCab
 
-MeCab is a third-party program which uses its own dictionaries and parsing algorithm to decompose sentences into individual words. MeCab may provide more accurate parsing results than Yomitan's internal parser.
+[MeCab](https://taku910.github.io/mecab/) is a third-party program which uses its own dictionaries and parsing algorithm to decompose sentences into individual words. MeCab may provide more accurate parsing results than Yomitan's internal parser.
 
 In order for Yomitan to use it, both MeCab and a native messaging component must be installed.
 A setup guide can be found <a href="https://github.com/starxeras/yomitan-mecab-installer/blob/master/README.md" target="_blank" rel="noopener noreferrer">here</a>.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 >
 > Since the owner requested forks be uniquely named, we have chosen a new name: _yomitan_. (_-tan_ is an honorific used for anthropomorphic moe characters.) While we've renamed the codebase and made judicious use of find-and-replace, it is entirely the hard work of foosoft and numerous other open source contributors from 2016-2023 and we do not claim any credit.
 >
-> Since this is a distributed effort, we highly welcome new contributors! Feel free to browse the issue tracker, and you can find us on [TheMoeWay Discord](https://discord.gg/UGNPMDE7zC) at [#yomitan-development](https://discord.com/channels/617136488840429598/1081538711742844980)
+> Since this is a distributed effort, we highly welcome new contributors! Feel free to browse the issue tracker, and you can find us on [TheMoeWay Discord](https://discord.gg/UGNPMDE7zC) at [#yomitan-development](https://discord.com/channels/617136488840429598/1081538711742844980).
 
 Yomitan turns your web browser into a tool for building Japanese language literacy by helping you to decipher texts
 which would be otherwise too difficult tackle. This extension is similar to

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1395,7 +1395,7 @@
                 </p>
                 <p>
                     In order for Yomitan to use it, both MeCab and a native messaging component must be installed.
-                    A setup guide can be found <a href="https://github.com/siikamiika/yomichan-mecab-installer/blob/master/README.md" target="_blank" rel="noopener noreferrer">here</a>.
+                    A setup guide can be found <a href="https://github.com/starxeras/yomitan-mecab-installer/blob/master/README.md" target="_blank" rel="noopener noreferrer">here</a>.
                 </p>
                 <div class="margin-above flex-row-nowrap">
                     <button type="button" id="test-mecab-button">Test</button>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1395,7 +1395,7 @@
                 </p>
                 <p>
                     In order for Yomitan to use it, both MeCab and a native messaging component must be installed.
-                    A setup guide can be found <a href="https://github.com/starxeras/yomitan-mecab-installer/blob/master/README.md" target="_blank" rel="noopener noreferrer">here</a>.
+                    A setup guide can be found <a href="https://github.com/themoeway/yomitan-mecab-installer/blob/master/README.md" target="_blank" rel="noopener noreferrer">here</a>.
                 </p>
                 <div class="margin-above flex-row-nowrap">
                     <button type="button" id="test-mecab-button">Test</button>


### PR DESCRIPTION
In this PR, I added the `Advanced Options` header in the README, with a subheading of `Parse sentences using MeCab`. I'm not sure if this is wanted, but it is all I could come up with to reference the updated repo. In addition, I updated the link in `ext/settings.html` to the new repo.

[The repo](https://github.com/starxeras/yomitan-mecab-installer)

(I also added a period at the end of #yomitan-development, since it bugged me...)