### PR TITLE
Fix stable deploy on release triggers

### DIFF
--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -1,7 +1,5 @@
 name: publish-chrome
 on:
-  release:
-    types: [released]
   workflow_dispatch:
     inputs:
       attemptNumber:

--- a/.github/workflows/publish-firefox.yml
+++ b/.github/workflows/publish-firefox.yml
@@ -1,7 +1,6 @@
 name: publish-firefox
 on:
-  release:
-    types: [released]
+  workflow_dispatch:
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: release
+on:
+  release:
+    types: [released]
+permissions: {}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+    steps:
+      - name: Dispatch publish-chrome
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 # pin@v2
+        with:
+          workflow: publish-chrome
+          token: ${{ secrets.GITHUB_TOKEN }}
+          wait-for-completion: false
+
+      - name: Dispatch publish-firefox
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 # pin@v2
+        with:
+          workflow: publish-firefox
+          token: ${{ secrets.GITHUB_TOKEN }}
+          wait-for-completion: false


### PR DESCRIPTION
The workflow currently fails when triggered by a release, due to unset workflow_dispatch variables.

This introduces a shim `release.yml` to ensure those variables are always set.