### PR TITLE
Change no-console to error, only for ext files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,7 +61,6 @@
         "no-case-declarations": "error",
         "no-const-assign": "error",
         "no-constant-condition": "off",
-        "no-console": "warn",
         "no-global-assign": "error",
         "no-param-reassign": "off",
         "no-prototype-builtins": "error",
@@ -556,6 +555,14 @@
                         "pattern": " \\* Copyright \\(C\\) (\\d+-)?2023  Yomitan Authors(\n \\* Copyright \\(C\\) (\\d+-)?2022  Yomichan Authors)?\n \\*\n \\* This program is free software: you can redistribute it and/or modify\n \\* it under the terms of the GNU General Public License as published by\n \\* the Free Software Foundation, either version 3 of the License, or\n \\* \\(at your option\\) any later version\\.\n \\*\n \\* This program is distributed in the hope that it will be useful,\n \\* but WITHOUT ANY WARRANTY; without even the implied warranty of\n \\* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE\\.  See the\n \\* GNU General Public License for more details\\.\n \\*\n \\* You should have received a copy of the GNU General Public License\n \\* along with this program\\.  If not, see <https://www\\.gnu\\.org/licenses/>\\.\n "
                     }
                 ]
+            }
+        },
+        {
+            "files": [
+                "ext/**/*.js"
+            ],
+            "rules": {
+                "no-console": "error"
             }
         },
         {

--- a/ext/js/core.js
+++ b/ext/js/core.js
@@ -727,6 +727,7 @@ export class Logger extends EventDispatcher {
         }
         message += '\n\nIssues can be reported at https://github.com/themoeway/yomitan/issues';
 
+        /* eslint-disable no-console */
         switch (level) {
             case 'info': console.info(message); break;
             case 'debug': console.debug(message); break;
@@ -734,6 +735,7 @@ export class Logger extends EventDispatcher {
             case 'error': console.error(message); break;
             default: console.log(message); break;
         }
+        /* eslint-enable no-console */
 
         this.trigger('log', {error, level, context});
     }

--- a/ext/js/debug/timer.js
+++ b/ext/js/debug/timer.js
@@ -56,6 +56,7 @@ export class Timer {
         Timer.current = this.parent;
         if (this.parent === null) {
             if (!skip) {
+                // eslint-disable-next-line no-console
                 console.log(this.toString());
             }
         } else {

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -564,6 +564,7 @@ export class DisplayAnki {
         const content = this._display.displayGenerator.createAnkiNoteErrorsNotificationContent(displayErrors);
         for (const node of content.querySelectorAll('.anki-note-error-log-link')) {
             /** @type {EventListenerCollection} */ (this._errorNotificationEventListeners).addEventListener(node, 'click', () => {
+                // eslint-disable-next-line no-console
                 console.log({ankiNoteErrors: errors});
             }, false);
         }

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -2027,6 +2027,7 @@ export class Display extends EventDispatcher {
             }
         }
 
+        // eslint-disable-next-line no-console
         console.log(result);
     }
 

--- a/ext/js/dom/sandbox/css-style-applier.js
+++ b/ext/js/dom/sandbox/css-style-applier.js
@@ -49,6 +49,7 @@ export class CssStyleApplier {
         try {
             rawData = await this._fetchJsonAsset(this._styleDataUrl);
         } catch (e) {
+            // eslint-disable-next-line no-console
             console.error(e);
         }
         const styleData = this._styleData;

--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -272,6 +272,7 @@ export class AnkiController {
     /** */
     _onAnkiErrorLogLinkClick() {
         if (this._ankiError === null) { return; }
+        // eslint-disable-next-line no-console
         console.log({error: this._ankiError});
     }
 

--- a/ext/js/pages/settings/backup-controller.js
+++ b/ext/js/pages/settings/backup-controller.js
@@ -555,12 +555,14 @@ export class BackupController {
      * @param {{totalRows: number, completedRows: number, done: boolean}} details
      */
     _databaseExportProgressCallback({totalRows, completedRows, done}) {
+        // eslint-disable-next-line no-console
         console.log(`Progress: ${completedRows} of ${totalRows} rows completed`);
         const messageContainer = /** @type {HTMLElement} */ (document.querySelector('#db-ops-progress-report'));
         messageContainer.style.display = 'block';
         messageContainer.textContent = `Export Progress: ${completedRows} of ${totalRows} rows completed`;
 
         if (done) {
+            // eslint-disable-next-line no-console
             console.log('Done exporting.');
             messageContainer.style.display = 'none';
         }
@@ -600,6 +602,7 @@ export class BackupController {
             const blob = new Blob([data], {type: 'application/json'});
             this._saveBlob(blob, fileName);
         } catch (error) {
+            // eslint-disable-next-line no-console
             console.log(error);
             this._databaseExportImportErrorMessage('Errors encountered while exporting. Please try again. Restart the browser if it continues to fail.');
         } finally {
@@ -614,6 +617,7 @@ export class BackupController {
      * @param {{totalRows: number, completedRows: number, done: boolean}} details
      */
     _databaseImportProgressCallback({totalRows, completedRows, done}) {
+        // eslint-disable-next-line no-console
         console.log(`Progress: ${completedRows} of ${totalRows} rows completed`);
         const messageContainer = /** @type {HTMLElement} */ (document.querySelector('#db-ops-progress-report'));
         messageContainer.style.display = 'block';
@@ -621,6 +625,7 @@ export class BackupController {
         messageContainer.textContent = `Import Progress: ${completedRows} of ${totalRows} rows completed`;
 
         if (done) {
+            // eslint-disable-next-line no-console
             console.log('Done importing.');
             messageContainer.style.color = '#006633';
             messageContainer.textContent = 'Done importing. You will need to re-enable the dictionaries and refresh afterward. If you run into issues, please restart the browser. If it continues to fail, reinstall Yomitan and import dictionaries one-by-one.';
@@ -668,6 +673,7 @@ export class BackupController {
             this._settingsExportDatabaseToken = token;
             await this._importDatabase(this._dictionariesDatabaseName, file);
         } catch (error) {
+            // eslint-disable-next-line no-console
             console.log(error);
             const messageContainer = /** @type {HTMLElement} */ (document.querySelector('#db-ops-progress-report'));
             messageContainer.style.color = 'red';


### PR DESCRIPTION
Originally mentioned here: https://github.com/themoeway/yomitan/pull/339#discussion_r1414634810

I believe warnings are not useful information as they can (and by some people, will) deliberately be ignored, and they add a bunch of messages that are unrelated to the current working feature branch when running the test.

IMO this should be enforced as an error, and any existing locations with this problem should be explicitly annotated in the code to allow them so that they don't show up in future reports. They should really also only apply to the `ext` folder, as the dev/test stuff is command line stuff that should be expected to write to console.