### PR TITLE
Update eslint spacing rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -221,6 +221,12 @@
             "error",
             "never"
         ],
+        "space-infix-ops": [
+            "error",
+            {
+                "int32Hint": false
+            }
+        ],
         "space-unary-ops": "error",
         "spaced-comment": [
             "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -192,6 +192,7 @@
             }
         ],
         "no-implicit-globals": "error",
+        "no-multi-spaces": "error",
         "no-trailing-spaces": "error",
         "no-whitespace-before-property": "error",
         "object-curly-spacing": [
@@ -521,7 +522,10 @@
             "files": [
                 "*.json"
             ],
-            "parser": "jsonc-eslint-parser"
+            "parser": "jsonc-eslint-parser",
+            "rules": {
+                "no-multi-spaces": "off"
+            }
         },
         {
             "files": [

--- a/dev/util.js
+++ b/dev/util.js
@@ -74,7 +74,7 @@ export function getArgs(args, argMap) {
  * @param {?(fileName: string) => boolean} predicate
  * @returns {string[]}
  */
-export function getAllFiles(baseDirectory, predicate=null) {
+export function getAllFiles(baseDirectory, predicate = null) {
     const results = [];
     const directories = [baseDirectory];
     while (directories.length > 0) {

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -41,9 +41,9 @@ export class Frontend {
         parentPopupId,
         parentFrameId,
         useProxyPopup,
-        canUseWindowPopup=true,
+        canUseWindowPopup = true,
         allowRootFramePopupProxy,
-        childrenSupported=true,
+        childrenSupported = true,
         hotkeyHandler
     }) {
         /** @type {import('frontend').PageType} */

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -106,6 +106,7 @@ export class Frontend {
         /** @type {?import('settings').OptionsContext} */
         this._optionsContextOverride = null;
 
+        /* eslint-disable no-multi-spaces */
         /** @type {import('core').MessageHandlerMap} */
         this._runtimeMessageHandlers = new Map(/** @type {import('core').MessageHandlerArray} */ ([
             ['Frontend.requestReadyBroadcast',   {async: false, handler: this._onMessageRequestFrontendReadyBroadcast.bind(this)}],
@@ -117,6 +118,7 @@ export class Frontend {
             ['scanSelectedText', this._onActionScanSelectedText.bind(this)],
             ['scanTextAtCaret',  this._onActionScanTextAtCaret.bind(this)]
         ]);
+        /* eslint-enable no-multi-spaces */
     }
 
     /**
@@ -174,6 +176,7 @@ export class Frontend {
         this._textScanner.on('clear', this._onTextScannerClear.bind(this));
         this._textScanner.on('searched', this._onSearched.bind(this));
 
+        /* eslint-disable no-multi-spaces */
         yomitan.crossFrame.registerHandlers([
             ['Frontend.closePopup',       {async: false, handler: this._onApiClosePopup.bind(this)}],
             ['Frontend.copySelection',    {async: false, handler: this._onApiCopySelection.bind(this)}],
@@ -181,6 +184,7 @@ export class Frontend {
             ['Frontend.getPopupInfo',     {async: false, handler: this._onApiGetPopupInfo.bind(this)}],
             ['Frontend.getPageInfo',      {async: false, handler: this._onApiGetPageInfo.bind(this)}]
         ]);
+        /* eslint-enable no-multi-spaces */
 
         this._prepareSiteSpecific();
         this._updateContentScale();

--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -72,12 +72,12 @@ export class PopupFactory {
      * @returns {Promise<import('popup').PopupAny>}
      */
     async getOrCreatePopup({
-        frameId=null,
-        id=null,
-        parentPopupId=null,
-        depth=null,
-        popupWindow=false,
-        childrenSupported=false
+        frameId = null,
+        id = null,
+        parentPopupId = null,
+        depth = null,
+        popupWindow = false,
+        childrenSupported = false
     }) {
         // Find by existing id
         if (id !== null) {

--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -47,6 +47,7 @@ export class PopupFactory {
      */
     prepare() {
         this._frameOffsetForwarder.prepare();
+        /* eslint-disable no-multi-spaces */
         yomitan.crossFrame.registerHandlers([
             ['PopupFactory.getOrCreatePopup',     {async: true,  handler: this._onApiGetOrCreatePopup.bind(this)}],
             ['PopupFactory.setOptionsContext',    {async: true,  handler: this._onApiSetOptionsContext.bind(this)}],
@@ -64,6 +65,7 @@ export class PopupFactory {
             ['PopupFactory.getFrameSize',         {async: true,  handler: this._onApiGetFrameSize.bind(this)}],
             ['PopupFactory.setFrameSize',         {async: true,  handler: this._onApiSetFrameSize.bind(this)}]
         ]);
+        /* eslint-enable no-multi-spaces */
     }
 
     /**

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -718,7 +718,7 @@ export class Popup extends EventDispatcher {
      * @param {string} action
      * @param {import('core').SerializableObject} params
      */
-    _invokeWindow(action, params={}) {
+    _invokeWindow(action, params = {}) {
         const contentWindow = this._frame.contentWindow;
         if (this._frameClient === null || !this._frameClient.isConnected() || contentWindow === null) { return; }
 

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -147,6 +147,7 @@ export class Backend {
         /** @type {PermissionsUtil} */
         this._permissionsUtil = new PermissionsUtil();
 
+        /* eslint-disable no-multi-spaces */
         /** @type {import('backend').MessageHandlerMap} */
         this._messageHandlers = new Map(/** @type {import('backend').MessageHandlerMapInit} */ ([
             ['requestBackendReadySignal',    {async: false, contentScript: true,  handler: this._onApiRequestBackendReadySignal.bind(this)}],
@@ -193,6 +194,7 @@ export class Backend {
             ['loadExtensionScripts',         {async: true,  contentScript: true,  handler: this._onApiLoadExtensionScripts.bind(this)}],
             ['openCrossFramePort',           {async: false, contentScript: true,  handler: this._onApiOpenCrossFramePort.bind(this)}]
         ]));
+        /* eslint-enable no-multi-spaces */
         /** @type {import('backend').MessageHandlerWithProgressMap} */
         this._messageHandlersWithProgress = new Map(/** @type {import('backend').MessageHandlerWithProgressMapInit} */ ([
             // Empty
@@ -201,10 +203,10 @@ export class Backend {
         /** @type {Map<string, (params?: import('core').SerializableObject) => void>} */
         this._commandHandlers = new Map(/** @type {[name: string, handler: (params?: import('core').SerializableObject) => void][]} */ ([
             ['toggleTextScanning', this._onCommandToggleTextScanning.bind(this)],
-            ['openInfoPage',       this._onCommandOpenInfoPage.bind(this)],
-            ['openSettingsPage',   this._onCommandOpenSettingsPage.bind(this)],
-            ['openSearchPage',     this._onCommandOpenSearchPage.bind(this)],
-            ['openPopupWindow',    this._onCommandOpenPopupWindow.bind(this)]
+            ['openInfoPage', this._onCommandOpenInfoPage.bind(this)],
+            ['openSettingsPage', this._onCommandOpenSettingsPage.bind(this)],
+            ['openSearchPage', this._onCommandOpenSearchPage.bind(this)],
+            ['openPopupWindow', this._onCommandOpenPopupWindow.bind(this)]
         ]));
     }
 

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -805,7 +805,7 @@ export class Backend {
     }
 
     /** @type {import('api').Handler<import('api').GetOrCreateSearchPopupDetails, import('api').GetOrCreateSearchPopupResult>} */
-    async _onApiGetOrCreateSearchPopup({focus=false, text}) {
+    async _onApiGetOrCreateSearchPopup({focus = false, text}) {
         const {tab, created} = await this._getOrCreateSearchPopup();
         if (focus === true || (focus === 'ifCreated' && created)) {
             await this._focusTab(tab);
@@ -1979,7 +1979,7 @@ export class Backend {
      * @param {?number} [timeout=null]
      * @returns {Promise<void>}
      */
-    _waitUntilTabFrameIsReady(tabId, frameId, timeout=null) {
+    _waitUntilTabFrameIsReady(tabId, frameId, timeout = null) {
         return new Promise((resolve, reject) => {
             /** @type {?import('core').Timeout} */
             let timer = null;

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -50,6 +50,7 @@ export class Offscreen {
             richContentPasteTargetSelector: '#clipboard-rich-content-paste-target'
         });
 
+        /* eslint-disable no-multi-spaces */
         /** @type {import('offscreen').MessageHandlerMap} */
         const messageHandlers = new Map([
             ['clipboardGetTextOffscreen',    {async: true,  handler: this._getTextHandler.bind(this)}],
@@ -65,6 +66,7 @@ export class Offscreen {
             ['getTermFrequenciesOffscreen',  {async: true,  handler: this._getTermFrequenciesHandler.bind(this)}],
             ['clearDatabaseCachesOffscreen', {async: false, handler: this._clearDatabaseCachesHandler.bind(this)}]
         ]);
+        /* eslint-enable no-multi-spaces */
         /** @type {import('offscreen').MessageHandlerMap<string>} */
         this._messageHandlers = messageHandlers;
 

--- a/ext/js/background/profile-conditions-util.js
+++ b/ext/js/background/profile-conditions-util.js
@@ -34,11 +34,11 @@ export class ProfileConditionsUtil {
                 'popupLevel',
                 {
                     operators: new Map(/** @type {import('profile-conditions-util').OperatorMapArray} */ ([
-                        ['equal',              this._createSchemaPopupLevelEqual.bind(this)],
-                        ['notEqual',           this._createSchemaPopupLevelNotEqual.bind(this)],
-                        ['lessThan',           this._createSchemaPopupLevelLessThan.bind(this)],
-                        ['greaterThan',        this._createSchemaPopupLevelGreaterThan.bind(this)],
-                        ['lessThanOrEqual',    this._createSchemaPopupLevelLessThanOrEqual.bind(this)],
+                        ['equal', this._createSchemaPopupLevelEqual.bind(this)],
+                        ['notEqual', this._createSchemaPopupLevelNotEqual.bind(this)],
+                        ['lessThan', this._createSchemaPopupLevelLessThan.bind(this)],
+                        ['greaterThan', this._createSchemaPopupLevelGreaterThan.bind(this)],
+                        ['lessThanOrEqual', this._createSchemaPopupLevelLessThanOrEqual.bind(this)],
                         ['greaterThanOrEqual', this._createSchemaPopupLevelGreaterThanOrEqual.bind(this)]
                     ]))
                 }

--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -318,7 +318,7 @@ export class AnkiConnect {
      * @param {?string[]} actions A list of actions to check for
      * @returns {Promise<import('anki').ApiReflectResult>} Information about the APIs.
      */
-    async apiReflect(scopes, actions=null) {
+    async apiReflect(scopes, actions = null) {
         const result = await this._invoke('apiReflect', {scopes, actions});
         if (!(typeof result === 'object' && result !== null)) {
             throw this._createUnexpectedResultError('object', result);

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -482,7 +482,7 @@ export class API {
      * @param {number} [timeout]
      * @returns {Promise<TReturn>}
      */
-    _invokeWithProgress(action, params, onProgress0, timeout=5000) {
+    _invokeWithProgress(action, params, onProgress0, timeout = 5000) {
         return new Promise((resolve, reject) => {
             /** @type {?chrome.runtime.Port} */
             let port = null;
@@ -554,7 +554,7 @@ export class API {
      * @param {import('core').SerializableObject} [params]
      * @returns {Promise<TReturn>}
      */
-    _invoke(action, params={}) {
+    _invoke(action, params = {}) {
         const data = {action, params};
         return new Promise((resolve, reject) => {
             try {

--- a/ext/js/comm/clipboard-reader.js
+++ b/ext/js/comm/clipboard-reader.js
@@ -26,7 +26,7 @@ export class ClipboardReader {
      * Creates a new instances of a clipboard reader.
      * @param {{document: ?Document, pasteTargetSelector: ?string, richContentPasteTargetSelector: ?string}} details Details about how to set up the instance.
      */
-    constructor({document=null, pasteTargetSelector=null, richContentPasteTargetSelector=null}) {
+    constructor({document = null, pasteTargetSelector = null, richContentPasteTargetSelector = null}) {
         /** @type {?Document} */
         this._document = document;
         /** @type {?import('environment').Browser} */

--- a/ext/js/comm/frame-ancestry-handler.js
+++ b/ext/js/comm/frame-ancestry-handler.js
@@ -109,7 +109,7 @@ export class FrameAncestryHandler {
      * @param {number} [timeout]
      * @returns {Promise<number[]>}
      */
-    _getFrameAncestryInfo(timeout=5000) {
+    _getFrameAncestryInfo(timeout = 5000) {
         return new Promise((resolve, reject) => {
             const targetWindow = window.parent;
             if (window === targetWindow) {

--- a/ext/js/comm/frame-client.js
+++ b/ext/js/comm/frame-client.js
@@ -41,7 +41,7 @@ export class FrameClient {
      * @param {import('frame-client').SetupFrameFunction} setupFrame
      * @param {number} [timeout]
      */
-    async connect(frame, targetOrigin, hostFrameId, setupFrame, timeout=10000) {
+    async connect(frame, targetOrigin, hostFrameId, setupFrame, timeout = 10000) {
         const {secret, token, frameId} = await this._connectInternal(frame, targetOrigin, hostFrameId, setupFrame, timeout);
         this._secret = secret;
         this._token = token;

--- a/ext/js/core.js
+++ b/ext/js/core.js
@@ -600,7 +600,7 @@ export class DynamicProperty extends EventDispatcher {
      * @returns {import('core').TokenString} A string token which can be passed to the clearOverride function
      *   to remove the override.
      */
-    setOverride(value, priority=0) {
+    setOverride(value, priority = 0) {
         const overridesCount = this._overrides.length;
         let i = 0;
         for (; i < overridesCount; ++i) {
@@ -670,7 +670,7 @@ export class Logger extends EventDispatcher {
      *   Other values will be logged at a non-error level.
      * @param {?import('log').LogContext} [context] An optional context object for the error which should typically include a `url` field.
      */
-    log(error, level, context=null) {
+    log(error, level, context = null) {
         if (typeof context !== 'object' || context === null) {
             context = {url: location.href};
         }
@@ -745,7 +745,7 @@ export class Logger extends EventDispatcher {
      * @param {unknown} error The error to log. This is typically an `Error` or `Error`-like object.
      * @param {?import('log').LogContext} context An optional context object for the error which should typically include a `url` field.
      */
-    warn(error, context=null) {
+    warn(error, context = null) {
         this.log(error, 'warn', context);
     }
 
@@ -754,7 +754,7 @@ export class Logger extends EventDispatcher {
      * @param {unknown} error The error to log. This is typically an `Error` or `Error`-like object.
      * @param {?import('log').LogContext} context An optional context object for the error which should typically include a `url` field.
      */
-    error(error, context=null) {
+    error(error, context = null) {
         this.log(error, 'error', context);
     }
 }

--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -51,15 +51,15 @@ export class AnkiNoteBuilder {
         deckName,
         modelName,
         fields,
-        tags=[],
-        requirements=[],
-        checkForDuplicates=true,
-        duplicateScope='collection',
-        duplicateScopeCheckAllModels=false,
-        resultOutputMode='split',
-        glossaryLayoutMode='default',
-        compactTags=false,
-        mediaOptions=null
+        tags = [],
+        requirements = [],
+        checkForDuplicates = true,
+        duplicateScope = 'collection',
+        duplicateScopeCheckAllModels = false,
+        resultOutputMode = 'split',
+        glossaryLayoutMode = 'default',
+        compactTags = false,
+        mediaOptions = null
     }) {
         let duplicateScopeDeckName = null;
         let duplicateScopeCheckChildren = false;
@@ -130,9 +130,9 @@ export class AnkiNoteBuilder {
         dictionaryEntry,
         mode,
         context,
-        resultOutputMode='split',
-        glossaryLayoutMode='default',
-        compactTags=false,
+        resultOutputMode = 'split',
+        glossaryLayoutMode = 'default',
+        compactTags = false,
         marker
     }) {
         const commonData = this._createData(dictionaryEntry, mode, context, resultOutputMode, glossaryLayoutMode, compactTags, void 0);

--- a/ext/js/data/database.js
+++ b/ext/js/data/database.js
@@ -265,7 +265,7 @@ export class Database {
      * @param {?(completedCount: number, totalCount: number) => void} onProgress
      * @returns {Promise<void>}
      */
-    bulkDelete(objectStoreName, indexName, query, filterKeys=null, onProgress=null) {
+    bulkDelete(objectStoreName, indexName, query, filterKeys = null, onProgress = null) {
         return new Promise((resolve, reject) => {
             const transaction = this._readWriteTransaction([objectStoreName], resolve, reject);
             const objectStore = transaction.objectStore(objectStoreName);

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -39,7 +39,7 @@ export class OptionsUtil {
      * @param {?number} [targetVersion]
      * @returns {Promise<import('settings').Options>}
      */
-    async update(optionsInput, targetVersion=null) {
+    async update(optionsInput, targetVersion = null) {
         // Invalid options
         let options = /** @type {{[key: string]: unknown}} */ (
             typeof optionsInput === 'object' && optionsInput !== null && !Array.isArray(optionsInput) ?

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -530,6 +530,7 @@ export class OptionsUtil {
      * @returns {import('options-util').ModernUpdate[]}
      */
     _getVersionUpdates(targetVersion) {
+        /* eslint-disable no-multi-spaces */
         const result = [
             {async: false, update: this._updateVersion1.bind(this)},
             {async: false, update: this._updateVersion2.bind(this)},
@@ -553,6 +554,7 @@ export class OptionsUtil {
             {async: false, update: this._updateVersion20.bind(this)},
             {async: true,  update: this._updateVersion21.bind(this)}
         ];
+        /* eslint-enable no-multi-spaces */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
             result.splice(targetVersion);
         }
@@ -818,6 +820,7 @@ export class OptionsUtil {
             };
             delete profile.options.anki.sentenceExt;
             profile.options.general.popupActionBarLocation = 'top';
+            /* eslint-disable no-multi-spaces */
             profile.options.inputs = {
                 hotkeys: [
                     {action: 'close',             key: 'Escape',    modifiers: [],       scopes: ['popup'], enabled: true},
@@ -838,6 +841,7 @@ export class OptionsUtil {
                     {action: 'copyHostSelection', key: 'KeyC',      modifiers: ['ctrl'], scopes: ['popup'], enabled: true}
                 ]
             };
+            /* eslint-enable no-multi-spaces */
             profile.options.anki.suspendNewCards = false;
             profile.options.popupWindow = {
                 width: profile.options.general.popupWidth,

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -107,12 +107,14 @@ export class DisplayAnki {
     /** */
     prepare() {
         this._noteContext = this._getNoteContext();
+        /* eslint-disable no-multi-spaces */
         this._display.hotkeyHandler.registerActions([
             ['addNoteKanji',      () => { this._tryAddAnkiNoteForSelectedEntry('kanji'); }],
             ['addNoteTermKanji',  () => { this._tryAddAnkiNoteForSelectedEntry('term-kanji'); }],
             ['addNoteTermKana',   () => { this._tryAddAnkiNoteForSelectedEntry('term-kana'); }],
             ['viewNote',          this._viewNoteForSelectedEntry.bind(this)]
         ]);
+        /* eslint-enable no-multi-spaces */
         this._display.on('optionsUpdated', this._onOptionsUpdated.bind(this));
         this._display.on('contentClear', this._onContentClear.bind(this));
         this._display.on('contentUpdateStart', this._onContentUpdateStart.bind(this));

--- a/ext/js/display/display-audio.js
+++ b/ext/js/display/display-audio.js
@@ -82,6 +82,7 @@ export class DisplayAudio {
     /** */
     prepare() {
         this._audioSystem.prepare();
+        /* eslint-disable no-multi-spaces */
         this._display.hotkeyHandler.registerActions([
             ['playAudio',           this._onHotkeyActionPlayAudio.bind(this)],
             ['playAudioFromSource', this._onHotkeyActionPlayAudioFromSource.bind(this)]
@@ -89,6 +90,7 @@ export class DisplayAudio {
         this._display.registerDirectMessageHandlers([
             ['Display.clearAutoPlayTimer', {async: false, handler: this._onMessageClearAutoPlayTimer.bind(this)}]
         ]);
+        /* eslint-enable no-multi-spaces */
         this._display.on('optionsUpdated', this._onOptionsUpdated.bind(this));
         this._display.on('contentClear', this._onContentClear.bind(this));
         this._display.on('contentUpdateEntry', this._onContentUpdateEntry.bind(this));

--- a/ext/js/display/display-audio.js
+++ b/ext/js/display/display-audio.js
@@ -119,7 +119,7 @@ export class DisplayAudio {
      * @param {number} headwordIndex
      * @param {?string} [sourceType]
      */
-    async playAudio(dictionaryEntryIndex, headwordIndex, sourceType=null) {
+    async playAudio(dictionaryEntryIndex, headwordIndex, sourceType = null) {
         let sources = this._audioSources;
         if (sourceType !== null) {
             sources = [];

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -28,7 +28,7 @@ export class DisplayGenerator {
     /**
      * @param {import('display').DisplayGeneratorConstructorDetails} details
      */
-    constructor({japaneseUtil, contentManager, hotkeyHelpController=null}) {
+    constructor({japaneseUtil, contentManager, hotkeyHelpController = null}) {
         /** @type {import('../language/sandbox/japanese-util.js').JapaneseUtil} */
         this._japaneseUtil = japaneseUtil;
         /** @type {import('./display-content-manager.js').DisplayContentManager} */

--- a/ext/js/display/display-history.js
+++ b/ext/js/display/display-history.js
@@ -25,7 +25,7 @@ export class DisplayHistory extends EventDispatcher {
     /**
      * @param {{clearable?: boolean, useBrowserHistory?: boolean}} details
      */
-    constructor({clearable=true, useBrowserHistory=false}) {
+    constructor({clearable = true, useBrowserHistory = false}) {
         super();
         /** @type {boolean} */
         this._clearable = clearable;

--- a/ext/js/display/display-notification.js
+++ b/ext/js/display/display-notification.js
@@ -66,7 +66,7 @@ export class DisplayNotification {
     /**
      * @param {boolean} [animate]
      */
-    close(animate=false) {
+    close(animate = false) {
         if (this.isClosed()) { return; }
 
         if (animate) {

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -585,7 +585,7 @@ export class Display extends EventDispatcher {
      * @param {import('core').SerializableObject} [params]
      * @returns {Promise<TReturn>}
      */
-    async invokeContentOrigin(action, params={}) {
+    async invokeContentOrigin(action, params = {}) {
         if (this._contentOriginTabId === this._tabId && this._contentOriginFrameId === this._frameId) {
             throw new Error('Content origin is same page');
         }
@@ -601,7 +601,7 @@ export class Display extends EventDispatcher {
      * @param {import('core').SerializableObject} [params]
      * @returns {Promise<TReturn>}
      */
-    async invokeParentFrame(action, params={}) {
+    async invokeParentFrame(action, params = {}) {
         if (this._parentFrameId === null || this._parentFrameId === this._frameId) {
             throw new Error('Invalid parent frame');
         }

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -195,6 +195,7 @@ export class Display extends EventDispatcher {
         /** @type {ThemeController} */
         this._themeController = new ThemeController(document.documentElement);
 
+        /* eslint-disable no-multi-spaces */
         this._hotkeyHandler.registerActions([
             ['close',             () => { this._onHotkeyClose(); }],
             ['nextEntry',         this._onHotkeyActionMoveRelative.bind(this, 1)],
@@ -218,6 +219,7 @@ export class Display extends EventDispatcher {
         this.registerWindowMessageHandlers([
             ['Display.extensionUnloaded', {async: false, handler: this._onMessageExtensionUnloaded.bind(this)}]
         ]);
+        /* eslint-enable no-multi-spaces */
     }
 
     /** @type {DisplayGenerator} */

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -93,11 +93,13 @@ export class SearchDisplayController {
         this._display.hotkeyHandler.registerActions([
             ['focusSearchBox', this._onActionFocusSearchBox.bind(this)]
         ]);
+        /* eslint-disable no-multi-spaces */
         this._registerMessageHandlers([
             ['SearchDisplayController.getMode',           {async: false, handler: this._onMessageGetMode.bind(this)}],
             ['SearchDisplayController.setMode',           {async: false, handler: this._onMessageSetMode.bind(this)}],
             ['SearchDisplayController.updateSearchQuery', {async: false, handler: this._onExternalSearchUpdate.bind(this)}]
         ]);
+        /* eslint-enable no-multi-spaces */
 
         this._updateClipboardMonitorEnabled();
 

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -284,7 +284,7 @@ export class SearchDisplayController {
     /**
      * @param {{text: string, animate?: boolean}} details
      */
-    _onExternalSearchUpdate({text, animate=true}) {
+    _onExternalSearchUpdate({text, animate = true}) {
         const options = this._display.getOptions();
         if (options === null) { return; }
         const {clipboard: {autoSearchContent, maximumSearchLength}} = options;

--- a/ext/js/dom/document-focus-controller.js
+++ b/ext/js/dom/document-focus-controller.js
@@ -28,7 +28,7 @@ export class DocumentFocusController {
      * @param {?string} autofocusElementSelector A selector string which can be used to specify an element which
      *   should be automatically focused on prepare.
      */
-    constructor(autofocusElementSelector=null) {
+    constructor(autofocusElementSelector = null) {
         /** @type {?HTMLElement} */
         this._autofocusElement = (autofocusElementSelector !== null ? document.querySelector(autofocusElementSelector) : null);
         /** @type {?HTMLElement} */

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -349,7 +349,7 @@ export class DocumentUtil {
      * @param {EventListener} onFullscreenChanged The event callback.
      * @param {?import('../core.js').EventListenerCollection} eventListenerCollection An optional `EventListenerCollection` to add the registration to.
      */
-    static addFullscreenChangeEventListener(onFullscreenChanged, eventListenerCollection=null) {
+    static addFullscreenChangeEventListener(onFullscreenChanged, eventListenerCollection = null) {
         const target = document;
         const options = false;
         const fullscreenEventNames = [

--- a/ext/js/dom/dom-data-binder.js
+++ b/ext/js/dom/dom-data-binder.js
@@ -27,7 +27,7 @@ export class DOMDataBinder {
     /**
      * @param {import('dom-data-binder').ConstructorDetails<T>} details
      */
-    constructor({selector, createElementMetadata, compareElementMetadata, getValues, setValues, onError=null}) {
+    constructor({selector, createElementMetadata, compareElementMetadata, getValues, setValues, onError = null}) {
         /** @type {string} */
         this._selector = selector;
         /** @type {import('dom-data-binder').CreateElementMetadataCallback<T>} */

--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -31,7 +31,7 @@ export class DOMTextScanner {
      *   regardless of CSS styling.
      * @param {boolean} generateLayoutContent Whether or not newlines should be added based on CSS styling.
      */
-    constructor(node, offset, forcePreserveWhitespace=false, generateLayoutContent=true) {
+    constructor(node, offset, forcePreserveWhitespace = false, generateLayoutContent = true) {
         const ruby = DOMTextScanner.getParentRubyElement(node);
         const resetOffset = (ruby !== null);
         if (resetOffset) { node = ruby; }

--- a/ext/js/dom/panel-element.js
+++ b/ext/js/dom/panel-element.js
@@ -57,7 +57,7 @@ export class PanelElement extends EventDispatcher {
      * @param {boolean} value
      * @param {boolean} [animate]
      */
-    setVisible(value, animate=true) {
+    setVisible(value, animate = true) {
         value = !!value;
         if (this.isVisible() === value) { return; }
 

--- a/ext/js/dom/popup-menu.js
+++ b/ext/js/dom/popup-menu.js
@@ -95,7 +95,7 @@ export class PopupMenu extends EventDispatcher {
      * @param {boolean} [cancelable]
      * @returns {boolean}
      */
-    close(cancelable=true) {
+    close(cancelable = true) {
         return this._close(null, 'close', cancelable, null);
     }
 

--- a/ext/js/dom/selector-observer.js
+++ b/ext/js/dom/selector-observer.js
@@ -25,7 +25,7 @@ export class SelectorObserver {
      * Creates a new instance.
      * @param {import('selector-observer').ConstructorDetails<T>} details The configuration for the object.
      */
-    constructor({selector, ignoreSelector=null, onAdded=null, onRemoved=null, onChildrenUpdated=null, isStale=null}) {
+    constructor({selector, ignoreSelector = null, onAdded = null, onRemoved = null, onChildrenUpdated = null, isStale = null}) {
         /** @type {string} */
         this._selector = selector;
         /** @type {?string} */
@@ -65,7 +65,7 @@ export class SelectorObserver {
      * @throws {Error} An error if element is null.
      * @throws {Error} An error if an element is already being observed.
      */
-    observe(element, attributes=false) {
+    observe(element, attributes = false) {
         if (element === null) {
             throw new Error('Invalid element');
         }

--- a/ext/js/general/text-source-map.js
+++ b/ext/js/general/text-source-map.js
@@ -21,7 +21,7 @@ export class TextSourceMap {
      * @param {string} source
      * @param {number[]|null} [mapping=null]
      */
-    constructor(source, mapping=null) {
+    constructor(source, mapping = null) {
         /** @type {string} */
         this._source = source;
         /** @type {?number[]} */

--- a/ext/js/input/hotkey-util.js
+++ b/ext/js/input/hotkey-util.js
@@ -24,7 +24,7 @@ export class HotkeyUtil {
      * Creates a new instance.
      * @param {?import('environment').OperatingSystem} os The operating system for this instance.
      */
-    constructor(os=null) {
+    constructor(os = null) {
         /** @type {?import('environment').OperatingSystem} */
         this._os = os;
         /** @type {string} */

--- a/ext/js/language/deinflector.js
+++ b/ext/js/language/deinflector.js
@@ -103,6 +103,8 @@ export class Deinflector {
     }
 }
 
+
+/* eslint-disable no-multi-spaces */
 /** @type {Map<string, import('translation-internal').DeinflectionRuleFlags>} */
 // eslint-disable-next-line no-underscore-dangle
 Deinflector._ruleTypes = new Map([
@@ -114,3 +116,4 @@ Deinflector._ruleTypes = new Map([
     ['adj-i', /** @type {import('translation-internal').DeinflectionRuleFlags} */ (0b00100000)], // Adjective i
     ['iru',   /** @type {import('translation-internal').DeinflectionRuleFlags} */ (0b01000000)] // Intermediate -iru endings for progressive or perfect tense
 ]);
+/* eslint-enable no-multi-spaces */

--- a/ext/js/language/dictionary-importer.js
+++ b/ext/js/language/dictionary-importer.js
@@ -538,7 +538,7 @@ export class DictionaryImporter {
          */
         const createError = (message) => {
             const {expression, reading} = entry;
-            const readingSource = reading.length > 0 ? ` (${reading})`: '';
+            const readingSource = reading.length > 0 ? ` (${reading})` : '';
             return new Error(`${message} at path ${JSON.stringify(path)} for ${expression}${readingSource} in ${dictionary}`);
         };
 

--- a/ext/js/language/dictionary-importer.js
+++ b/ext/js/language/dictionary-importer.js
@@ -112,11 +112,11 @@ export class DictionaryImporter {
         const dataBankSchemas = this._getDataBankSchemas(version);
 
         // Files
-        const termFiles      = this._getArchiveFiles(fileMap, 'term_bank_?.json');
-        const termMetaFiles  = this._getArchiveFiles(fileMap, 'term_meta_bank_?.json');
-        const kanjiFiles     = this._getArchiveFiles(fileMap, 'kanji_bank_?.json');
+        const termFiles = this._getArchiveFiles(fileMap, 'term_bank_?.json');
+        const termMetaFiles = this._getArchiveFiles(fileMap, 'term_meta_bank_?.json');
+        const kanjiFiles = this._getArchiveFiles(fileMap, 'kanji_bank_?.json');
         const kanjiMetaFiles = this._getArchiveFiles(fileMap, 'kanji_meta_bank_?.json');
-        const tagFiles       = this._getArchiveFiles(fileMap, 'tag_bank_?.json');
+        const tagFiles = this._getArchiveFiles(fileMap, 'tag_bank_?.json');
 
         // Load data
         this._progressNextStep(termFiles.length + termMetaFiles.length + kanjiFiles.length + kanjiMetaFiles.length + tagFiles.length);

--- a/ext/js/language/sandbox/japanese-util.js
+++ b/ext/js/language/sandbox/japanese-util.js
@@ -88,7 +88,7 @@ const JAPANESE_RANGES = [
     [0xff1a, 0xff1f], // Fullwidth punctuation 2
     [0xff3b, 0xff3f], // Fullwidth punctuation 3
     [0xff5b, 0xff60], // Fullwidth punctuation 4
-    [0xffe0, 0xffee]  // Currency markers
+    [0xffe0, 0xffee] // Currency markers
 ];
 
 const SMALL_KANA_SET = new Set(Array.from('ぁぃぅぇぉゃゅょゎァィゥェォャュョヮ'));

--- a/ext/js/language/sandbox/japanese-util.js
+++ b/ext/js/language/sandbox/japanese-util.js
@@ -235,7 +235,7 @@ export class JapaneseUtil {
     /**
      * @param {?import('wanakana')|import('../../../lib/wanakana.js')} wanakana
      */
-    constructor(wanakana=null) {
+    constructor(wanakana = null) {
         /** @type {?import('wanakana')} */
         this._wanakana = /** @type {import('wanakana')} */ (wanakana);
     }
@@ -386,7 +386,7 @@ export class JapaneseUtil {
      * @param {boolean} [keepProlongedSoundMarks]
      * @returns {string}
      */
-    convertKatakanaToHiragana(text, keepProlongedSoundMarks=false) {
+    convertKatakanaToHiragana(text, keepProlongedSoundMarks = false) {
         let result = '';
         const offset = (HIRAGANA_CONVERSION_RANGE[0] - KATAKANA_CONVERSION_RANGE[0]);
         for (let char of text) {
@@ -469,7 +469,7 @@ export class JapaneseUtil {
      * @param {?import('../../general/text-source-map.js').TextSourceMap} [sourceMap]
      * @returns {string}
      */
-    convertHalfWidthKanaToFullWidth(text, sourceMap=null) {
+    convertHalfWidthKanaToFullWidth(text, sourceMap = null) {
         let result = '';
 
         // This function is safe to use charCodeAt instead of codePointAt, since all
@@ -516,7 +516,7 @@ export class JapaneseUtil {
      * @param {?import('../../general/text-source-map.js').TextSourceMap} sourceMap
      * @returns {string}
      */
-    convertAlphabeticToKana(text, sourceMap=null) {
+    convertAlphabeticToKana(text, sourceMap = null) {
         let part = '';
         let result = '';
 
@@ -679,7 +679,7 @@ export class JapaneseUtil {
      * @param {?import('../../general/text-source-map.js').TextSourceMap} [sourceMap]
      * @returns {string}
      */
-    collapseEmphaticSequences(text, fullCollapse, sourceMap=null) {
+    collapseEmphaticSequences(text, fullCollapse, sourceMap = null) {
         let result = '';
         let collapseCodePoint = -1;
         const hasSourceMap = (sourceMap !== null);

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -31,12 +31,12 @@ export class TextScanner extends EventDispatcher {
     constructor({
         node,
         getSearchContext,
-        ignoreElements=null,
-        ignorePoint=null,
-        searchTerms=false,
-        searchKanji=false,
-        searchOnClick=false,
-        searchOnClickOnly=false
+        ignoreElements = null,
+        ignorePoint = null,
+        searchTerms = false,
+        searchKanji = false,
+        searchOnClick = false,
+        searchOnClickOnly = false
     }) {
         super();
         /** @type {HTMLElement|Window} */

--- a/ext/js/pages/settings/backup-controller.js
+++ b/ext/js/pages/settings/backup-controller.js
@@ -537,7 +537,7 @@ export class BackupController {
      * @param {string} message
      * @param {boolean} [isWarning]
      */
-    _databaseExportImportErrorMessage(message, isWarning=false) {
+    _databaseExportImportErrorMessage(message, isWarning = false) {
         const errorMessageContainer = /** @type {HTMLElement} */ (document.querySelector('#db-ops-error-report'));
         errorMessageContainer.style.display = 'block';
         errorMessageContainer.textContent = message;

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -300,7 +300,7 @@ class DictionaryExtraInfo {
                 node.parentNode.removeChild(node);
             }
         }
-        this._nodes.length =0;
+        this._nodes.length = 0;
     }
 
     // Private

--- a/ext/js/pages/settings/keyboard-mouse-input-field.js
+++ b/ext/js/pages/settings/keyboard-mouse-input-field.js
@@ -30,7 +30,7 @@ export class KeyboardMouseInputField extends EventDispatcher {
      * @param {?import('environment').OperatingSystem} os
      * @param {?(pointerType: string) => boolean} [isPointerTypeSupported]
      */
-    constructor(inputNode, mouseButton, os, isPointerTypeSupported=null) {
+    constructor(inputNode, mouseButton, os, isPointerTypeSupported = null) {
         super();
         /** @type {HTMLInputElement} */
         this._inputNode = inputNode;
@@ -65,7 +65,7 @@ export class KeyboardMouseInputField extends EventDispatcher {
      * @param {boolean} [mouseModifiersSupported]
      * @param {boolean} [keySupported]
      */
-    prepare(key, modifiers, mouseModifiersSupported=false, keySupported=false) {
+    prepare(key, modifiers, mouseModifiersSupported = false, keySupported = false) {
         this.cleanup();
 
         this._mouseModifiersSupported = mouseModifiersSupported;

--- a/ext/js/pages/settings/keyboard-shortcuts-controller.js
+++ b/ext/js/pages/settings/keyboard-shortcuts-controller.js
@@ -45,6 +45,7 @@ export class KeyboardShortcutController {
         this._stringComparer = new Intl.Collator('en-US'); // Invariant locale
         /** @type {?HTMLElement} */
         this._scrollContainer = null;
+        /* eslint-disable no-multi-spaces */
         /** @type {Map<string, import('keyboard-shortcut-controller').ActionDetails>} */
         this._actionDetails = new Map([
             ['',                                 {scopes: new Set()}],
@@ -69,6 +70,7 @@ export class KeyboardShortcutController {
             ['scanTextAtCaret',                  {scopes: new Set(['web'])}],
             ['toggleOption',                     {scopes: new Set(['popup', 'search']), argument: {template: 'hotkey-argument-setting-path', default: ''}}]
         ]);
+        /* eslint-enable no-multi-spaces */
     }
 
     /** @type {import('./settings-controller.js').SettingsController} */

--- a/ext/js/pages/settings/popup-preview-frame.js
+++ b/ext/js/pages/settings/popup-preview-frame.js
@@ -56,6 +56,7 @@ export class PopupPreviewFrame {
         /** @type {string} */
         this._targetOrigin = chrome.runtime.getURL('/').replace(/\/$/, '');
 
+        /* eslint-disable no-multi-spaces */
         /** @type {Map<string, (params: import('core').SerializableObjectAny) => void>} */
         this._windowMessageHandlers = new Map(/** @type {[key: string, handler: (params: import('core').SerializableObjectAny) => void][]} */ ([
             ['PopupPreviewFrame.setText',              this._onSetText.bind(this)],
@@ -63,6 +64,7 @@ export class PopupPreviewFrame {
             ['PopupPreviewFrame.setCustomOuterCss',    this._setCustomOuterCss.bind(this)],
             ['PopupPreviewFrame.updateOptionsContext', this._updateOptionsContext.bind(this)]
         ]));
+        /* eslint-enable no-multi-spaces */
     }
 
     /** */

--- a/ext/js/pages/settings/profile-conditions-ui.js
+++ b/ext/js/pages/settings/profile-conditions-ui.js
@@ -49,6 +49,7 @@ export class ProfileConditionsUI extends EventDispatcher {
         const normalizeInteger = this._normalizeInteger.bind(this);
         const validateFlags = this._validateFlags.bind(this);
         const normalizeFlags = this._normalizeFlags.bind(this);
+        /* eslint-disable no-multi-spaces */
         /** @type {Map<import('profile-conditions-ui').DescriptorType, import('profile-conditions-ui').Descriptor>} */
         this._descriptors = new Map([
             [
@@ -104,6 +105,7 @@ export class ProfileConditionsUI extends EventDispatcher {
                 }
             ]
         ]);
+        /* eslint-enable no-multi-spaces */
         /** @type {Set<string>} */
         this._validFlags = new Set([
             'clipboard'

--- a/ext/js/pages/settings/profile-conditions-ui.js
+++ b/ext/js/pages/settings/profile-conditions-ui.js
@@ -221,12 +221,12 @@ export class ProfileConditionsUI extends EventDispatcher {
         const info = this._getOperatorDetails(type, operator);
 
         const {
-            displayName=operator,
-            type: type2='string',
-            defaultValue='',
-            resetDefaultOnChange=false,
-            validate=null,
-            normalize=null
+            displayName = operator,
+            type: type2 = 'string',
+            defaultValue = '',
+            resetDefaultOnChange = false,
+            validate = null,
+            normalize = null
         } = (typeof info === 'undefined' ? {} : info);
 
         return {

--- a/ext/js/script/dynamic-loader.js
+++ b/ext/js/script/dynamic-loader.js
@@ -64,7 +64,7 @@ export const dynamicLoader = (() => {
      * @returns {Promise<?HTMLStyleElement|HTMLLinkElement>}
      * @throws {Error}
      */
-    async function loadStyle(id, type, value, useWebExtensionApi=false, parentNode=null) {
+    async function loadStyle(id, type, value, useWebExtensionApi = false, parentNode = null) {
         if (useWebExtensionApi && yomitan.isExtensionUrl(window.location.href)) {
             // Permissions error will occur if trying to use the WebExtension API to inject into an extension page
             useWebExtensionApi = false;

--- a/ext/js/templates/sandbox/anki-template-renderer.js
+++ b/ext/js/templates/sandbox/anki-template-renderer.js
@@ -74,6 +74,7 @@ export class AnkiTemplateRenderer {
      * Prepares the data that is necessary before the template renderer can be safely used.
      */
     async prepare() {
+        /* eslint-disable no-multi-spaces */
         this._templateRenderer.registerHelpers([
             ['dumpObject',       this._dumpObject.bind(this)],
             ['furigana',         this._furigana.bind(this)],
@@ -103,6 +104,7 @@ export class AnkiTemplateRenderer {
             ['hiragana',         this._hiragana.bind(this)],
             ['katakana',         this._katakana.bind(this)]
         ]);
+        /* eslint-enable no-multi-spaces */
         this._templateRenderer.registerDataType('ankiNote', {
             modifier: ({marker, commonData}) => this._ankiNoteDataCreator.create(marker, commonData),
             composeData: ({marker}, commonData) => ({marker, commonData})
@@ -392,9 +394,9 @@ export class AnkiTemplateRenderer {
             case '!=': return operand1 != operand2; // eslint-disable-line eqeqeq
             case '===': return operand1 === operand2;
             case '!==': return operand1 !== operand2;
-            case '<':  return operand1 < operand2;
+            case '<': return operand1 < operand2;
             case '<=': return operand1 <= operand2;
-            case '>':  return operand1 > operand2;
+            case '>': return operand1 > operand2;
             case '>=': return operand1 >= operand2;
             case '<<': return operand1 << operand2;
             case '>>': return operand1 >> operand2;

--- a/ext/js/templates/sandbox/template-renderer-media-provider.js
+++ b/ext/js/templates/sandbox/template-renderer-media-provider.js
@@ -79,7 +79,7 @@ export class TemplateRendererMediaProvider {
      */
     _getFormattedValue(data, namedArgs) {
         let {value} = data;
-        const {escape=true} = namedArgs;
+        const {escape = true} = namedArgs;
         if (escape) {
             value = Handlebars.Utils.escapeExpression(value);
         }

--- a/ext/js/templates/template-renderer-proxy.js
+++ b/ext/js/templates/template-renderer-proxy.js
@@ -99,7 +99,7 @@ export class TemplateRendererProxy {
      * @param {number} [timeout]
      * @returns {Promise<void>}
      */
-    _loadFrame(frame, url, timeout=5000) {
+    _loadFrame(frame, url, timeout = 5000) {
         return new Promise((resolve, reject) => {
             let state = 0x0; // 0x1 = frame added; 0x2 = frame loaded; 0x4 = frame ready
             const cleanup = () => {
@@ -165,7 +165,7 @@ export class TemplateRendererProxy {
      * @param {?number} [timeout]
      * @returns {Promise<unknown>}
      */
-    _invoke(action, params, timeout=null) {
+    _invoke(action, params, timeout = null) {
         return new Promise((resolve, reject) => {
             const frameWindow = (this._frame !== null ? this._frame.contentWindow : null);
             if (frameWindow === null) {

--- a/ext/js/yomitan.js
+++ b/ext/js/yomitan.js
@@ -88,6 +88,7 @@ export class Yomitan extends EventDispatcher {
         /** @type {?(() => void)} */
         this._isBackendReadyPromiseResolve = resolve;
 
+        /* eslint-disable no-multi-spaces */
         /** @type {import('core').MessageHandlerMap} */
         this._messageHandlers = new Map(/** @type {import('core').MessageHandlerArray} */ ([
             ['Yomitan.isReady',         {async: false, handler: this._onMessageIsReady.bind(this)}],
@@ -97,6 +98,7 @@ export class Yomitan extends EventDispatcher {
             ['Yomitan.databaseUpdated', {async: false, handler: this._onMessageDatabaseUpdated.bind(this)}],
             ['Yomitan.zoomChanged',     {async: false, handler: this._onMessageZoomChanged.bind(this)}]
         ]));
+        /* eslint-enable no-multi-spaces */
     }
 
     /**

--- a/ext/js/yomitan.js
+++ b/ext/js/yomitan.js
@@ -140,7 +140,7 @@ export class Yomitan extends EventDispatcher {
      * Prepares the instance for use.
      * @param {boolean} [isBackground=false] Assigns whether this instance is being used from the background page/service worker.
      */
-    async prepare(isBackground=false) {
+    async prepare(isBackground = false) {
         this._isBackground = isBackground;
         chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
 

--- a/test/cache-map.test.js
+++ b/test/cache-map.test.js
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/* eslint-disable no-multi-spaces */
+
 import {expect, test} from 'vitest';
 import {CacheMap} from '../ext/js/general/cache-map.js';
 

--- a/test/data/html/test-document2-script.js
+++ b/test/data/html/test-document2-script.js
@@ -87,7 +87,7 @@ function toggleFullscreen(element) {
  * @param {HTMLElement|DocumentFragment} container
  * @param {?Element} [fullscreenElement]
  */
-function setup(container, fullscreenElement=null) {
+function setup(container, fullscreenElement = null) {
     const fullscreenLink = container.querySelector('.fullscreen-link');
     if (fullscreenLink !== null) {
         if (fullscreenElement === null) {

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -107,7 +107,8 @@ function countKanjiWithCharacter(kanji, character) {
 
 /** */
 async function testDatabase1() {
-    test('Database1', async () => {    // Load dictionary data
+    test('Database1', async () => {
+        // Load dictionary data
         const testDictionary = createTestDictionaryArchive('valid-dictionary1');
         const testDictionarySource = await testDictionary.generateAsync({type: 'arraybuffer'});
         const testDictionaryIndex = JSON.parse(await testDictionary.files['index.json'].async('string'));
@@ -849,7 +850,8 @@ async function testFindTagForTitle1(database, title) {
 
 /** */
 async function testDatabase2() {
-    test('Database2', async () => {    // Load dictionary data
+    test('Database2', async () => {
+        // Load dictionary data
         const testDictionary = createTestDictionaryArchive('valid-dictionary1');
         const testDictionarySource = await testDictionary.generateAsync({type: 'arraybuffer'});
         const testDictionaryIndex = JSON.parse(await testDictionary.files['index.json'].async('string'));

--- a/test/deinflector.test.js
+++ b/test/deinflector.test.js
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/* eslint-disable no-multi-spaces */
+
 import fs from 'fs';
 import {fileURLToPath} from 'node:url';
 import path from 'path';

--- a/test/hotkey-util.test.js
+++ b/test/hotkey-util.test.js
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/* eslint-disable no-multi-spaces */
+
 import {expect, test} from 'vitest';
 import {HotkeyUtil} from '../ext/js/input/hotkey-util.js';
 

--- a/test/japanese-util.test.js
+++ b/test/japanese-util.test.js
@@ -152,7 +152,7 @@ function testConvertKatakanaToHiragana() {
             ['カーナー', 'かーなー', true]
         ];
 
-        for (const [string, expected, keepProlongedSoundMarks=false] of data) {
+        for (const [string, expected, keepProlongedSoundMarks = false] of data) {
             expect(jp.convertKatakanaToHiragana(string, keepProlongedSoundMarks)).toStrictEqual(expected);
         }
     });

--- a/test/json-schema.test.js
+++ b/test/json-schema.test.js
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/* eslint-disable no-multi-spaces */
+
 import {expect, test} from 'vitest';
 import {JsonSchema} from '../ext/js/data/json-schema.js';
 

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/* eslint-disable no-multi-spaces */
+
 import fs from 'fs';
 import url, {fileURLToPath} from 'node:url';
 import path from 'path';

--- a/test/playwright/visual.spec.js
+++ b/test/playwright/visual.spec.js
@@ -72,7 +72,9 @@ test('visual', async ({page, extensionId}) => {
             popup_frame = await frame_attached; // wait for popup to be attached
         }
         try {
-            await (await /** @type {import('@playwright/test').Frame} */ (popup_frame).frameElement()).waitForElementState('visible', {timeout: 500});  // some tests don't have a popup, so don't fail if it's not there; TODO: check if the popup is expected to be there
+            // Some tests don't have a popup, so don't fail if it's not there
+            // TODO: check if the popup is expected to be there
+            await (await /** @type {import('@playwright/test').Frame} */ (popup_frame).frameElement()).waitForElementState('visible', {timeout: 500});
         } catch (error) {
             console.log(test_name + ' has no popup');
         }

--- a/test/profile-conditions-util.test.js
+++ b/test/profile-conditions-util.test.js
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/* eslint-disable no-multi-spaces */
+
 import {expect, test} from 'vitest';
 import {ProfileConditionsUtil} from '../ext/js/background/profile-conditions-util.js';
 


### PR DESCRIPTION
This change enables two eslint settings:
* [`no-multi-spaces`](https://eslint.org/docs/latest/rules/no-multi-spaces) - Disallows multiple spaces other than indentation. This is intended to reduce stylistic inconsistencies which usually result from a user typo. However, there are several situations in the codebase where space alignment is useful. As such, those locations explicitly turn off the rule, and may subsequently turn it back on.
* [`space-infix-ops`](https://eslint.org/docs/latest/rules/space-infix-ops) - Makes spacing more clear around operators. This primarily affects how default parameters were assigned, which used Python-like assignments without spaces, such as `const {x=1} = value;`. Enabling this option also helps fix issues with spacing which usually result from user error. This was originally discussed in https://github.com/FooSoft/yomichan/pull/363 and we opted to not enable it at that time.
 
Since the project is in a considerably different state at this point, I think these rules should be enabled moving forward, as it increases the level of stylistic code strictness. This should have benefits for the codebase, as it looks to have multiple (somewhat) active developers.