### PR TITLE
Remove invoke with progress

### DIFF
--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -16,9 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {deferPromise} from '../core.js';
 import {ExtensionError} from '../core/extension-error.js';
-import {parseJson} from '../core/json.js';
 
 export class API {
     /**
@@ -425,133 +423,6 @@ export class API {
     }
 
     // Utilities
-
-    /**
-     * @param {number} timeout
-     * @returns {Promise<chrome.runtime.Port>}
-     */
-    _createActionPort(timeout) {
-        return new Promise((resolve, reject) => {
-            /** @type {?import('core').Timeout} */
-            let timer = null;
-            /** @type {import('core').DeferredPromiseDetails<import('api').CreateActionPortResult>} */
-            const portDetails = deferPromise();
-
-            /**
-             * @param {chrome.runtime.Port} port
-             */
-            const onConnect = async (port) => {
-                try {
-                    const {name: expectedName, id: expectedId} = await portDetails.promise;
-                    /** @type {import('cross-frame-api').PortDetails} */
-                    const portDetails2 = parseJson(port.name);
-                    if (portDetails2.name !== expectedName || portDetails2.id !== expectedId || timer === null) { return; }
-                } catch (e) {
-                    return;
-                }
-
-                clearTimeout(timer);
-                timer = null;
-
-                chrome.runtime.onConnect.removeListener(onConnect);
-                resolve(port);
-            };
-
-            /**
-             * @param {Error} e
-             */
-            const onError = (e) => {
-                if (timer !== null) {
-                    clearTimeout(timer);
-                    timer = null;
-                }
-                chrome.runtime.onConnect.removeListener(onConnect);
-                portDetails.reject(e);
-                reject(e);
-            };
-
-            timer = setTimeout(() => onError(new Error('Timeout')), timeout);
-
-            chrome.runtime.onConnect.addListener(onConnect);
-            /** @type {Promise<import('api').CreateActionPortResult>} */
-            const createActionPortResult = this._invoke('createActionPort');
-            createActionPortResult.then(portDetails.resolve, onError);
-        });
-    }
-
-    /**
-     * @template [TReturn=unknown]
-     * @param {string} action
-     * @param {import('core').SerializableObject} params
-     * @param {?(...args: unknown[]) => void} onProgress0
-     * @param {number} [timeout]
-     * @returns {Promise<TReturn>}
-     */
-    _invokeWithProgress(action, params, onProgress0, timeout = 5000) {
-        return new Promise((resolve, reject) => {
-            /** @type {?chrome.runtime.Port} */
-            let port = null;
-
-            const onProgress = typeof onProgress0 === 'function' ? onProgress0 : () => {};
-
-            /**
-             * @param {import('backend').InvokeWithProgressResponseMessage<TReturn>} message
-             */
-            const onMessage = (message) => {
-                switch (message.type) {
-                    case 'progress':
-                        try {
-                            onProgress(...message.data);
-                        } catch (e) {
-                            // NOP
-                        }
-                        break;
-                    case 'complete':
-                        cleanup();
-                        resolve(message.data);
-                        break;
-                    case 'error':
-                        cleanup();
-                        reject(ExtensionError.deserialize(message.data));
-                        break;
-                }
-            };
-
-            const onDisconnect = () => {
-                cleanup();
-                reject(new Error('Disconnected'));
-            };
-
-            const cleanup = () => {
-                if (port !== null) {
-                    port.onMessage.removeListener(onMessage);
-                    port.onDisconnect.removeListener(onDisconnect);
-                    port.disconnect();
-                    port = null;
-                }
-            };
-
-            (async () => {
-                try {
-                    port = await this._createActionPort(timeout);
-                    port.onMessage.addListener(onMessage);
-                    port.onDisconnect.addListener(onDisconnect);
-
-                    // Chrome has a maximum message size that can be sent, so longer messages must be fragmented.
-                    const messageString = JSON.stringify({action, params});
-                    const fragmentSize = 1e7; // 10 MB
-                    for (let i = 0, ii = messageString.length; i < ii; i += fragmentSize) {
-                        const data = messageString.substring(i, i + fragmentSize);
-                        port.postMessage(/** @type {import('backend').InvokeWithProgressRequestFragmentMessage} */ ({action: 'fragment', data}));
-                    }
-                    port.postMessage(/** @type {import('backend').InvokeWithProgressRequestInvokeMessage} */ ({action: 'invoke'}));
-                } catch (e) {
-                    cleanup();
-                    reject(e);
-                }
-            })();
-        });
-    }
 
     /**
      * @template [TReturn=unknown]

--- a/types/ext/api.d.ts
+++ b/types/ext/api.d.ts
@@ -461,12 +461,3 @@ export type OpenCrossFramePortResult = {
 export type RequestBackendReadySignalDetails = Record<string, never>;
 
 export type RequestBackendReadySignalResult = boolean;
-
-// createActionPort
-
-export type CreateActionPortDetails = Record<string, never>;
-
-export type CreateActionPortResult = {
-    name: 'action-port';
-    id: string;
-};

--- a/types/ext/backend.d.ts
+++ b/types/ext/backend.d.ts
@@ -16,15 +16,6 @@
  */
 
 import type * as Api from './api';
-import type * as Core from './core';
-
-export type MessageHandlerWithProgressDetails = {
-    async: boolean;
-    contentScript: boolean;
-    handler: (params: Core.SerializableObject | undefined, sender: chrome.runtime.MessageSender, onProgress: (...data: unknown[]) => void) => (Promise<unknown> | unknown);
-};
-export type MessageHandlerWithProgressMap = Map<string, MessageHandlerWithProgressDetails>;
-export type MessageHandlerWithProgressMapInit = [key: string, handlerDetails: MessageHandlerWithProgressDetails][];
 
 export type DatabaseUpdateType = 'dictionary';
 export type DatabaseUpdateCause = 'purge' | 'delete' | 'import';
@@ -40,43 +31,3 @@ export type TabInfo = {
 };
 
 export type FindTabsPredicate = (tabInfo: TabInfo) => boolean | Promise<boolean>;
-
-export type InvokeWithProgressRequestMessage = (
-    InvokeWithProgressRequestFragmentMessage |
-    InvokeWithProgressRequestInvokeMessage
-);
-
-export type InvokeWithProgressRequestFragmentMessage = {
-    action: 'fragment';
-    data: string;
-};
-
-export type InvokeWithProgressRequestInvokeMessage = {
-    action: 'invoke';
-};
-
-export type InvokeWithProgressResponseMessage<TReturn = unknown> = (
-    InvokeWithProgressResponseProgressMessage |
-    InvokeWithProgressResponseCompleteMessage<TReturn> |
-    InvokeWithProgressResponseErrorMessage |
-    InvokeWithProgressResponseAcknowledgeMessage
-);
-
-export type InvokeWithProgressResponseProgressMessage = {
-    type: 'progress';
-    data: unknown[];
-};
-
-export type InvokeWithProgressResponseCompleteMessage<TReturn = unknown> = {
-    type: 'complete';
-    data: TReturn;
-};
-
-export type InvokeWithProgressResponseErrorMessage = {
-    type: 'error';
-    data: Core.SerializedError;
-};
-
-export type InvokeWithProgressResponseAcknowledgeMessage = {
-    type: 'ack';
-};

--- a/types/ext/cross-frame-api.d.ts
+++ b/types/ext/cross-frame-api.d.ts
@@ -53,15 +53,10 @@ export type Invocation = {
     timer: Core.Timeout | null;
 };
 
-export type PortDetails = CrossFrameCommunicationPortDetails | ActionPortDetails;
+export type PortDetails = CrossFrameCommunicationPortDetails;
 
 export type CrossFrameCommunicationPortDetails = {
     name: 'cross-frame-communication-port';
     otherTabId: number;
     otherFrameId: number;
-};
-
-export type ActionPortDetails = {
-    name: 'action-port';
-    id: string;
 };


### PR DESCRIPTION
This change removes the unused `API._invokeWithProgress`. This used to be used to perform long-running actions such as database deletions, but these APIs were eventually moved directly into the source of the page, rather than proxying through the backend. This is possible because these actions are not performed from content scripts, but rather from privileged extension pages.

This can be considered a step towards improving the type safety and simplicity of API; #391.

* [x] Rebase on #396 after merge.