### PR TITLE
Add Offscreen.prepare for constructor side effects

### DIFF
--- a/ext/js/background/offscreen-main.js
+++ b/ext/js/background/offscreen-main.js
@@ -19,8 +19,9 @@
 import {Offscreen} from './offscreen.js';
 
 /** Entry point. */
-async function main() {
-    new Offscreen();
+function main() {
+    const offscreen = new Offscreen();
+    offscreen.prepare();
 }
 
-await main();
+main();

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -70,11 +70,13 @@ export class Offscreen {
         /** @type {import('offscreen').MessageHandlerMap<string>} */
         this._messageHandlers = messageHandlers;
 
-        const onMessage = this._onMessage.bind(this);
-        chrome.runtime.onMessage.addListener(onMessage);
-
         /** @type {?Promise<void>} */
         this._prepareDatabasePromise = null;
+    }
+
+    /** */
+    prepare() {
+        chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
     }
 
     /** @type {import('offscreen').MessageHandler<'clipboardGetTextOffscreen', true>} */


### PR DESCRIPTION
This is more consistent with other classes. This is probably another largely undocumented style of the project, but in most situations, constructor side effects are avoided and placed into a `prepare` function. `prepare` is also a place to put `async` code which doesn't work in a constructor, but that doesn't directly apply here right now.