### PR TITLE
Minor optimizations for dictionary import

### DIFF
--- a/ext/js/language/dictionary-importer.js
+++ b/ext/js/language/dictionary-importer.js
@@ -113,11 +113,15 @@ export class DictionaryImporter {
         const dataBankSchemas = this._getDataBankSchemas(version);
 
         // Files
-        const termFiles = this._getArchiveFiles(fileMap, 'term_bank_?.json');
-        const termMetaFiles = this._getArchiveFiles(fileMap, 'term_meta_bank_?.json');
-        const kanjiFiles = this._getArchiveFiles(fileMap, 'kanji_bank_?.json');
-        const kanjiMetaFiles = this._getArchiveFiles(fileMap, 'kanji_meta_bank_?.json');
-        const tagFiles = this._getArchiveFiles(fileMap, 'tag_bank_?.json');
+        /** @type {import('dictionary-importer').QueryDetails} */
+        const queryDetails = new Map([
+            ['termFiles', 'term_bank_?.json'],
+            ['termMetaFiles', 'term_meta_bank_?.json'],
+            ['kanjiFiles', 'kanji_bank_?.json'],
+            ['kanjiMetaFiles', 'kanji_meta_bank_?.json'],
+            ['tagFiles', 'tag_bank_?.json']
+        ]);
+        const {termFiles, termMetaFiles, kanjiFiles, kanjiMetaFiles, tagFiles} = Object.fromEntries(this._getArchiveFiles(fileMap, queryDetails));
 
         // Load data
         this._progressNextStep(termFiles.length + termMetaFiles.length + kanjiFiles.length + kanjiMetaFiles.length + tagFiles.length);
@@ -679,18 +683,28 @@ export class DictionaryImporter {
 
     /**
      * @param {import('dictionary-importer').ArchiveFileMap} fileMap
-     * @param {string} fileNameFormat
-     * @returns {import('@zip.js/zip.js').Entry[]}
+     * @param {import('dictionary-importer').QueryDetails} queryDetails
+     * @returns {import('dictionary-importer').QueryResult}
      */
-    _getArchiveFiles(fileMap, fileNameFormat) {
-        const indexPosition = fileNameFormat.indexOf('?');
-        const prefix = fileNameFormat.substring(0, indexPosition);
-        const suffix = fileNameFormat.substring(indexPosition + 1);
-        /** @type {import('@zip.js/zip.js').Entry[]} */
-        const results = [];
+    _getArchiveFiles(fileMap, queryDetails) {
+        /** @type {import('dictionary-importer').QueryResult} */
+        const results = new Map();
         for (const [name, value] of fileMap.entries()) {
-            if (name.startsWith(prefix) && name.endsWith(suffix)) {
-                results.push(value);
+            for (const [fileType, fileNameFormat] of queryDetails.entries()) {
+                const indexPosition = fileNameFormat.indexOf('?');
+                const prefix = fileNameFormat.substring(0, indexPosition);
+                const suffix = fileNameFormat.substring(indexPosition + 1);
+
+                let entries = results.get(fileType);
+                if (typeof entries === 'undefined') {
+                    entries = [];
+                    results.set(fileType, entries);
+                }
+
+                if (name.startsWith(prefix) && name.endsWith(suffix)) {
+                    entries.push(value);
+                    break;
+                }
             }
         }
         return results;

--- a/ext/js/language/dictionary-importer.js
+++ b/ext/js/language/dictionary-importer.js
@@ -115,11 +115,11 @@ export class DictionaryImporter {
         // Files
         /** @type {import('dictionary-importer').QueryDetails} */
         const queryDetails = new Map([
-            ['termFiles', 'term_bank_?.json'],
-            ['termMetaFiles', 'term_meta_bank_?.json'],
-            ['kanjiFiles', 'kanji_bank_?.json'],
-            ['kanjiMetaFiles', 'kanji_meta_bank_?.json'],
-            ['tagFiles', 'tag_bank_?.json']
+            ['termFiles', /^term_bank_(\d+)\.json$/],
+            ['termMetaFiles', /^term_meta_bank_(\d+)\.json$/],
+            ['kanjiFiles', /^kanji_bank_(\d+)\.json$/],
+            ['kanjiMetaFiles', /^kanji_meta_bank_(\d+)\.json$/],
+            ['tagFiles', /^tag_bank_(\d+)\.json$/]
         ]);
         const {termFiles, termMetaFiles, kanjiFiles, kanjiMetaFiles, tagFiles} = Object.fromEntries(this._getArchiveFiles(fileMap, queryDetails));
 
@@ -691,17 +691,13 @@ export class DictionaryImporter {
         const results = new Map();
         for (const [name, value] of fileMap.entries()) {
             for (const [fileType, fileNameFormat] of queryDetails.entries()) {
-                const indexPosition = fileNameFormat.indexOf('?');
-                const prefix = fileNameFormat.substring(0, indexPosition);
-                const suffix = fileNameFormat.substring(indexPosition + 1);
-
                 let entries = results.get(fileType);
                 if (typeof entries === 'undefined') {
                     entries = [];
                     results.set(fileType, entries);
                 }
 
-                if (name.startsWith(prefix) && name.endsWith(suffix)) {
+                if (fileNameFormat.test(name)) {
                     entries.push(value);
                     break;
                 }

--- a/types/ext/dictionary-importer.d.ts
+++ b/types/ext/dictionary-importer.d.ts
@@ -98,6 +98,18 @@ export type ImportRequirementContext = {
 
 export type ArchiveFileMap = Map<string, ZipJS.Entry>;
 
+/**
+ * A map of file types inside a dictionary and its matching queries.
+ * Queries should be in the form of `${prefix}?${suffix}`.
+ * File names can be matched with `?` as the wildcard.
+ */
+export type QueryDetails = Map<string, string>;
+
+/**
+ * A map of file types inside a dictionary and its matching ZipJS entries.
+ */
+export type QueryResult = Map<string, ZipJS.Entry[]>;
+
 export type CompiledSchemaNameArray = [
     termBank: CompiledSchemaName,
     termMetaBank: CompiledSchemaName,

--- a/types/ext/dictionary-importer.d.ts
+++ b/types/ext/dictionary-importer.d.ts
@@ -99,11 +99,9 @@ export type ImportRequirementContext = {
 export type ArchiveFileMap = Map<string, ZipJS.Entry>;
 
 /**
- * A map of file types inside a dictionary and its matching queries.
- * Queries should be in the form of `${prefix}?${suffix}`.
- * File names can be matched with `?` as the wildcard.
+ * A map of file types inside a dictionary and its corresponding regular expressions.
  */
-export type QueryDetails = Map<string, string>;
+export type QueryDetails = Map<string, RegExp>;
 
 /**
  * A map of file types inside a dictionary and its matching entries.

--- a/types/ext/dictionary-importer.d.ts
+++ b/types/ext/dictionary-importer.d.ts
@@ -106,7 +106,7 @@ export type ArchiveFileMap = Map<string, ZipJS.Entry>;
 export type QueryDetails = Map<string, string>;
 
 /**
- * A map of file types inside a dictionary and its matching ZipJS entries.
+ * A map of file types inside a dictionary and its matching entries.
  */
 export type QueryResult = Map<string, ZipJS.Entry[]>;
 


### PR DESCRIPTION
Reimplements _getArchiveFiles so that its only run once.
This change allows you to break early if you found the match, avoiding having to cycle through the entire fileMap for each file type.
For a dictionary with mostly files of `term_bank_?.json` format (most dictionaries), the time is improved to O(n) instead of O(n*m).