### PR TITLE
API maps

### DIFF
--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -74,7 +74,7 @@ export class OffscreenProxy {
     /**
      * @template {import('offscreen').MessageType} TMessageType
      * @param {import('offscreen').Message<TMessageType>} message
-     * @returns {Promise<import('offscreen').MessageReturn<TMessageType>>}
+     * @returns {Promise<import('offscreen').OffscreenApiReturn<TMessageType>>}
      */
     sendMessagePromise(message) {
         return new Promise((resolve, reject) => {

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -19,6 +19,7 @@
 import * as wanakana from '../../lib/wanakana.js';
 import {ClipboardReader} from '../comm/clipboard-reader.js';
 import {invokeMessageHandler} from '../core.js';
+import {createApiMap} from '../core/api-map.js';
 import {ArrayBufferUtil} from '../data/sandbox/array-buffer-util.js';
 import {DictionaryDatabase} from '../language/dictionary-database.js';
 import {JapaneseUtil} from '../language/sandbox/japanese-util.js';
@@ -50,9 +51,10 @@ export class Offscreen {
             richContentPasteTargetSelector: '#clipboard-rich-content-paste-target'
         });
 
+
         /* eslint-disable no-multi-spaces */
-        /** @type {import('offscreen').MessageHandlerMap} */
-        this._messageHandlers = new Map(/** @type {import('offscreen').MessageHandlerMapInit} */ ([
+        /** @type {import('offscreen').OffscreenApiMapInit} */
+        const messageHandlersInit = [
             ['clipboardGetTextOffscreen',    this._getTextHandler.bind(this)],
             ['clipboardGetImageOffscreen',   this._getImageHandler.bind(this)],
             ['clipboardSetBrowserOffscreen', this._setClipboardBrowser.bind(this)],
@@ -65,8 +67,10 @@ export class Offscreen {
             ['findTermsOffscreen',           this._findTermsHandler.bind(this)],
             ['getTermFrequenciesOffscreen',  this._getTermFrequenciesHandler.bind(this)],
             ['clearDatabaseCachesOffscreen', this._clearDatabaseCachesHandler.bind(this)]
-        ]));
-        /* eslint-enable no-multi-spaces */
+        ];
+
+        /** @type {import('offscreen').OffscreenApiMap} */
+        this._messageHandlers = createApiMap(messageHandlersInit);
 
         /** @type {?Promise<void>} */
         this._prepareDatabasePromise = null;
@@ -77,22 +81,22 @@ export class Offscreen {
         chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
     }
 
-    /** @type {import('offscreen').MessageHandler<'clipboardGetTextOffscreen', true>} */
+    /** @type {import('offscreen').OffscreenApiHandler<'clipboardGetTextOffscreen'>} */
     async _getTextHandler({useRichText}) {
         return await this._clipboardReader.getText(useRichText);
     }
 
-    /** @type {import('offscreen').MessageHandler<'clipboardGetImageOffscreen', true>} */
+    /** @type {import('offscreen').OffscreenApiHandler<'clipboardGetImageOffscreen'>} */
     async _getImageHandler() {
         return await this._clipboardReader.getImage();
     }
 
-    /** @type {import('offscreen').MessageHandler<'clipboardSetBrowserOffscreen', false>} */
+    /** @type {import('offscreen').OffscreenApiHandler<'clipboardSetBrowserOffscreen'>} */
     _setClipboardBrowser({value}) {
         this._clipboardReader.browser = value;
     }
 
-    /** @type {import('offscreen').MessageHandler<'databasePrepareOffscreen', true>} */
+    /** @type {import('offscreen').OffscreenApiHandler<'databasePrepareOffscreen'>} */
     _prepareDatabaseHandler() {
         if (this._prepareDatabasePromise !== null) {
             return this._prepareDatabasePromise;
@@ -101,29 +105,29 @@ export class Offscreen {
         return this._prepareDatabasePromise;
     }
 
-    /** @type {import('offscreen').MessageHandler<'getDictionaryInfoOffscreen', true>} */
+    /** @type {import('offscreen').OffscreenApiHandler<'getDictionaryInfoOffscreen'>} */
     async _getDictionaryInfoHandler() {
         return await this._dictionaryDatabase.getDictionaryInfo();
     }
 
-    /** @type {import('offscreen').MessageHandler<'databasePurgeOffscreen', true>} */
+    /** @type {import('offscreen').OffscreenApiHandler<'databasePurgeOffscreen'>} */
     async _purgeDatabaseHandler() {
         return await this._dictionaryDatabase.purge();
     }
 
-    /** @type {import('offscreen').MessageHandler<'databaseGetMediaOffscreen', true>} */
+    /** @type {import('offscreen').OffscreenApiHandler<'databaseGetMediaOffscreen'>} */
     async _getMediaHandler({targets}) {
         const media = await this._dictionaryDatabase.getMedia(targets);
         const serializedMedia = media.map((m) => ({...m, content: ArrayBufferUtil.arrayBufferToBase64(m.content)}));
         return serializedMedia;
     }
 
-    /** @type {import('offscreen').MessageHandler<'translatorPrepareOffscreen', false>} */
+    /** @type {import('offscreen').OffscreenApiHandler<'translatorPrepareOffscreen'>} */
     _prepareTranslatorHandler({deinflectionReasons}) {
         this._translator.prepare(deinflectionReasons);
     }
 
-    /** @type {import('offscreen').MessageHandler<'findKanjiOffscreen', true>} */
+    /** @type {import('offscreen').OffscreenApiHandler<'findKanjiOffscreen'>} */
     async _findKanjiHandler({text, options}) {
         /** @type {import('translation').FindKanjiOptions} */
         const modifiedOptions = {
@@ -133,7 +137,7 @@ export class Offscreen {
         return await this._translator.findKanji(text, modifiedOptions);
     }
 
-    /** @type {import('offscreen').MessageHandler<'findTermsOffscreen', true>} */
+    /** @type {import('offscreen').OffscreenApiHandler<'findTermsOffscreen'>} */
     _findTermsHandler({mode, text, options}) {
         const enabledDictionaryMap = new Map(options.enabledDictionaryMap);
         const excludeDictionaryDefinitions = (
@@ -160,12 +164,12 @@ export class Offscreen {
         return this._translator.findTerms(mode, text, modifiedOptions);
     }
 
-    /** @type {import('offscreen').MessageHandler<'getTermFrequenciesOffscreen', true>} */
+    /** @type {import('offscreen').OffscreenApiHandler<'getTermFrequenciesOffscreen'>} */
     _getTermFrequenciesHandler({termReadingList, dictionaries}) {
         return this._translator.getTermFrequencies(termReadingList, dictionaries);
     }
 
-    /** @type {import('offscreen').MessageHandler<'clearDatabaseCachesOffscreen', false>} */
+    /** @type {import('offscreen').OffscreenApiHandler<'clearDatabaseCachesOffscreen'>} */
     _clearDatabaseCachesHandler() {
         this._translator.clearDatabaseCaches();
     }

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -19,7 +19,7 @@
 import * as wanakana from '../../lib/wanakana.js';
 import {ClipboardReader} from '../comm/clipboard-reader.js';
 import {invokeMessageHandler} from '../core.js';
-import {createApiMap} from '../core/api-map.js';
+import {createApiMap, getApiMapHandler} from '../core/api-map.js';
 import {ArrayBufferUtil} from '../data/sandbox/array-buffer-util.js';
 import {DictionaryDatabase} from '../language/dictionary-database.js';
 import {JapaneseUtil} from '../language/sandbox/japanese-util.js';
@@ -176,7 +176,7 @@ export class Offscreen {
 
     /** @type {import('extension').ChromeRuntimeOnMessageCallback} */
     _onMessage({action, params}, sender, callback) {
-        const messageHandler = this._messageHandlers.get(/** @type {import('offscreen').MessageType} */ (action));
+        const messageHandler = getApiMapHandler(this._messageHandlers, action);
         if (typeof messageHandler === 'undefined') { return false; }
         return invokeMessageHandler(messageHandler, params, callback, sender);
     }

--- a/ext/js/core/api-map.js
+++ b/ext/js/core/api-map.js
@@ -36,3 +36,13 @@ export function extendApiMap(map, init) {
         map.set(key, value);
     }
 }
+
+/**
+ * @template {import('api-map').ApiSurface} [TApiSurface=never]
+ * @param {import('api-map').ApiMap<TApiSurface>} map
+ * @param {string} name
+ * @returns {import('api-map').ApiHandlerAny<TApiSurface>|undefined}
+ */
+export function getApiMapHandler(map, name) {
+    return map.get(/** @type {import('api-map').ApiNames<TApiSurface>} */ (name));
+}

--- a/ext/js/core/api-map.js
+++ b/ext/js/core/api-map.js
@@ -23,3 +23,16 @@
 export function createApiMap(init) {
     return new Map(init);
 }
+
+/**
+ * @template {import('api-map').ApiSurface} [TApiSurface=never]
+ * @param {import('api-map').ApiMap<TApiSurface>} map
+ * @param {import('api-map').ApiMapInit<TApiSurface>} init
+ * @throws {Error}
+ */
+export function extendApiMap(map, init) {
+    for (const [key, value] of init) {
+        if (map.has(key)) { throw new Error(`The handler for ${String(key)} has already been registered`); }
+        map.set(key, value);
+    }
+}

--- a/ext/js/core/api-map.js
+++ b/ext/js/core/api-map.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2023  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @template {import('api-map').ApiSurface} [TApiSurface=never]
+ * @param {import('api-map').ApiMapInit<TApiSurface>} init
+ * @returns {import('api-map').ApiMap<TApiSurface>}
+ */
+export function createApiMap(init) {
+    return new Map(init);
+}

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -24,7 +24,7 @@ type ApiItem = {
     return: unknown;
 };
 
-export type ApiHandler<TApiItem extends ApiItem> = (params: TApiItem['params']) => TApiItem['return'];
+export type ApiHandler<TApiItem extends ApiItem> = (params: TApiItem['params']) => TApiItem['return'] | Promise<TApiItem['return']>;
 
 type ApiHandlerSurface<TApiSurface extends ApiSurface> = {[name in keyof TApiSurface]: ApiHandler<TApiSurface[name]>};
 

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+type ApiSurface = {
+    [name: string]: ApiItem;
+};
+
+type ApiItem = {
+    params: void | {[name: string]: unknown};
+    return: unknown;
+};
+
+export type ApiHandler<TApiItem extends ApiItem> = (params: TApiItem['params']) => TApiItem['return'];
+
+type ApiHandlerSurface<TApiSurface extends ApiSurface> = {[name in keyof TApiSurface]: ApiHandler<TApiSurface[name]>};
+
+export type ApiHandlerAny<TApiSurface extends ApiSurface> = ApiHandlerSurface<TApiSurface>[keyof TApiSurface];
+
+export type ApiParams<TApiSurface extends ApiSurface, TName extends keyof TApiSurface> = TApiSurface[TName]['params'];
+
+export type ApiReturn<TApiSurface extends ApiSurface, TName extends keyof TApiSurface> = TApiSurface[TName]['return'];
+
+export type ApiMap<TApiSurface extends ApiSurface> = Map<keyof TApiSurface, ApiHandlerAny<TApiSurface>>;
+
+export type ApiMapInit<TApiSurface extends ApiSurface> = ApiMapInitItemAny<TApiSurface>[];
+
+export type ApiMapInitLax<TApiSurface extends ApiSurface> = ApiMapInitLaxItem<TApiSurface>[];
+
+export type ApiMapInitLaxItem<TApiSurface extends ApiSurface> = [
+    name: keyof TApiSurface,
+    handler: ApiHandlerAny<TApiSurface>,
+];
+
+type ApiMapInitItem<TApiSurface extends ApiSurface, TName extends keyof TApiSurface> = [
+    name: TName,
+    handler: ApiHandler<TApiSurface[TName]>,
+];
+
+type ApiMapInitItemAny<TApiSurface extends ApiSurface> = {[key in keyof TApiSurface]: ApiMapInitItem<TApiSurface, key>}[keyof TApiSurface];

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -38,13 +38,6 @@ export type ApiMap<TApiSurface extends ApiSurface> = Map<keyof TApiSurface, ApiH
 
 export type ApiMapInit<TApiSurface extends ApiSurface> = ApiMapInitItemAny<TApiSurface>[];
 
-export type ApiMapInitLax<TApiSurface extends ApiSurface> = ApiMapInitLaxItem<TApiSurface>[];
-
-export type ApiMapInitLaxItem<TApiSurface extends ApiSurface> = [
-    name: keyof TApiSurface,
-    handler: ApiHandlerAny<TApiSurface>,
-];
-
 type ApiMapInitItem<TApiSurface extends ApiSurface, TName extends keyof TApiSurface> = [
     name: TName,
     handler: ApiHandler<TApiSurface[TName]>,

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -26,21 +26,30 @@ type ApiItem = {
 
 export type ApiHandler<TApiItem extends ApiItem> = (params: TApiItem['params']) => TApiItem['return'] | Promise<TApiItem['return']>;
 
-type ApiHandlerSurface<TApiSurface extends ApiSurface> = {[name in keyof TApiSurface]: ApiHandler<TApiSurface[name]>};
+type ApiHandlerSurface<TApiSurface extends ApiSurface> = {[name in ApiNames<TApiSurface>]: ApiHandler<TApiSurface[name]>};
 
-export type ApiHandlerAny<TApiSurface extends ApiSurface> = ApiHandlerSurface<TApiSurface>[keyof TApiSurface];
+export type ApiHandlerAny<TApiSurface extends ApiSurface> = ApiHandlerSurface<TApiSurface>[ApiNames<TApiSurface>];
 
-export type ApiParams<TApiSurface extends ApiSurface, TName extends keyof TApiSurface> = TApiSurface[TName]['params'];
+export type ApiNames<TApiSurface extends ApiSurface> = keyof TApiSurface;
 
-export type ApiReturn<TApiSurface extends ApiSurface, TName extends keyof TApiSurface> = TApiSurface[TName]['return'];
+export type ApiParams<TApiSurface extends ApiSurface, TName extends ApiNames<TApiSurface>> = TApiSurface[TName]['params'];
 
-export type ApiMap<TApiSurface extends ApiSurface> = Map<keyof TApiSurface, ApiHandlerAny<TApiSurface>>;
+export type ApiReturn<TApiSurface extends ApiSurface, TName extends ApiNames<TApiSurface>> = TApiSurface[TName]['return'];
+
+export type ApiMap<TApiSurface extends ApiSurface> = Map<ApiNames<TApiSurface>, ApiHandlerAny<TApiSurface>>;
 
 export type ApiMapInit<TApiSurface extends ApiSurface> = ApiMapInitItemAny<TApiSurface>[];
 
-type ApiMapInitItem<TApiSurface extends ApiSurface, TName extends keyof TApiSurface> = [
+export type ApiMapInitLax<TApiSurface extends ApiSurface> = ApiMapInitLaxItem<TApiSurface>[];
+
+export type ApiMapInitLaxItem<TApiSurface extends ApiSurface> = [
+    name: ApiNames<TApiSurface>,
+    handler: ApiHandlerAny<TApiSurface>,
+];
+
+type ApiMapInitItem<TApiSurface extends ApiSurface, TName extends ApiNames<TApiSurface>> = [
     name: TName,
     handler: ApiHandler<TApiSurface[TName]>,
 ];
 
-type ApiMapInitItemAny<TApiSurface extends ApiSurface> = {[key in keyof TApiSurface]: ApiMapInitItem<TApiSurface, key>}[keyof TApiSurface];
+type ApiMapInitItemAny<TApiSurface extends ApiSurface> = {[key in ApiNames<TApiSurface>]: ApiMapInitItem<TApiSurface, key>}[ApiNames<TApiSurface>];


### PR DESCRIPTION
This is a first step towards making serialized API interfaces more type safe, as mentioned in #391.

This has some TypeScript black magic in it, but it basically amounts to describing all APIs on a TypeScript type and then using some common mapping types. For now, this is only set up to work for `Offscreen`, but should be able to be expanded upon.

It ensures type safety in the `ApiMapInit` type, which is used to initialize API maps. This pattern was already seen throughout the application, but with more lenient type checks, and mistakes could still be made.