### PR TITLE
API map updates

### DIFF
--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -138,7 +138,7 @@ export class Offscreen {
     }
 
     /** @type {import('offscreen').OffscreenApiHandler<'findTermsOffscreen'>} */
-    _findTermsHandler({mode, text, options}) {
+    async _findTermsHandler({mode, text, options}) {
         const enabledDictionaryMap = new Map(options.enabledDictionaryMap);
         const excludeDictionaryDefinitions = (
             options.excludeDictionaryDefinitions !== null ?

--- a/ext/js/core/api-map.js
+++ b/ext/js/core/api-map.js
@@ -70,7 +70,7 @@ export function invokeApiMapHandler(map, name, params, extraParams, callback, ha
             try {
                 handlerNotFoundCallback();
             } catch (error) {
-                // Ignore
+                // NOP
             }
         }
         return false;

--- a/ext/js/core/api-map.js
+++ b/ext/js/core/api-map.js
@@ -17,8 +17,9 @@
 
 /**
  * @template {import('api-map').ApiSurface} [TApiSurface=never]
- * @param {import('api-map').ApiMapInit<TApiSurface>} init
- * @returns {import('api-map').ApiMap<TApiSurface>}
+ * @template {unknown[]} [TExtraParams=[]]
+ * @param {import('api-map').ApiMapInit<TApiSurface, TExtraParams>} init
+ * @returns {import('api-map').ApiMap<TApiSurface, TExtraParams>}
  */
 export function createApiMap(init) {
     return new Map(init);
@@ -26,8 +27,9 @@ export function createApiMap(init) {
 
 /**
  * @template {import('api-map').ApiSurface} [TApiSurface=never]
- * @param {import('api-map').ApiMap<TApiSurface>} map
- * @param {import('api-map').ApiMapInit<TApiSurface>} init
+ * @template {unknown[]} [TExtraParams=[]]
+ * @param {import('api-map').ApiMap<TApiSurface, TExtraParams>} map
+ * @param {import('api-map').ApiMapInit<TApiSurface, TExtraParams>} init
  * @throws {Error}
  */
 export function extendApiMap(map, init) {
@@ -39,9 +41,10 @@ export function extendApiMap(map, init) {
 
 /**
  * @template {import('api-map').ApiSurface} [TApiSurface=never]
- * @param {import('api-map').ApiMap<TApiSurface>} map
+ * @template {unknown[]} [TExtraParams=[]]
+ * @param {import('api-map').ApiMap<TApiSurface, TExtraParams>} map
  * @param {string} name
- * @returns {import('api-map').ApiHandlerAny<TApiSurface>|undefined}
+ * @returns {import('api-map').ApiHandlerAny<TApiSurface, TExtraParams>|undefined}
  */
 export function getApiMapHandler(map, name) {
     return map.get(/** @type {import('api-map').ApiNames<TApiSurface>} */ (name));

--- a/ext/js/core/api-map.js
+++ b/ext/js/core/api-map.js
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import {ExtensionError} from './extension-error.js';
+
 /**
  * @template {import('api-map').ApiSurface} [TApiSurface=never]
  * @template {unknown[]} [TExtraParams=[]]
@@ -48,4 +50,45 @@ export function extendApiMap(map, init) {
  */
 export function getApiMapHandler(map, name) {
     return map.get(/** @type {import('api-map').ApiNames<TApiSurface>} */ (name));
+}
+
+/**
+ * @template {import('api-map').ApiSurface} [TApiSurface=never]
+ * @template {unknown[]} [TExtraParams=[]]
+ * @param {import('api-map').ApiMap<TApiSurface, TExtraParams>} map
+ * @param {string} name
+ * @param {import('api-map').ApiParamsAny<TApiSurface>} params
+ * @param {TExtraParams} extraParams
+ * @param {(response: import('core').Response<import('api-map').ApiReturnAny<TApiSurface>>) => void} callback
+ * @param {() => void} [handlerNotFoundCallback]
+ * @returns {boolean} `true` if async, `false` otherwise.
+ */
+export function invokeApiMapHandler(map, name, params, extraParams, callback, handlerNotFoundCallback) {
+    const handler = getApiMapHandler(map, name);
+    if (typeof handler === 'undefined') {
+        if (typeof handlerNotFoundCallback === 'function') {
+            try {
+                handlerNotFoundCallback();
+            } catch (error) {
+                // Ignore
+            }
+        }
+        return false;
+    }
+    try {
+        const promiseOrResult = handler(/** @type {import('core').SafeAny} */ (params), ...extraParams);
+        if (promiseOrResult instanceof Promise) {
+            /** @type {Promise<unknown>} */ (promiseOrResult).then(
+                (result) => { callback({result}); },
+                (error) => { callback({error: ExtensionError.serialize(error)}); }
+            );
+            return true;
+        } else {
+            callback({result: promiseOrResult});
+            return false;
+        }
+    } catch (error) {
+        callback({error: ExtensionError.serialize(error)});
+        return false;
+    }
 }

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -50,7 +50,7 @@ type ApiMapInitItem<TSurface extends ApiSurface, TExtraParams extends ApiTExtraP
 ];
 
 /**
- * This type represents a a union of all API map initializers for a given surface.
+ * This type represents a union of all API map initializers for a given surface.
  */
 type ApiMapInitItemAny<TSurface extends ApiSurface, TExtraParams extends ApiTExtraParams> = {[key in ApiNames<TSurface>]: ApiMapInitItem<TSurface, TExtraParams, key>}[ApiNames<TSurface>];
 

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -36,23 +36,23 @@ type ApiDescriptor = {
 /**
  * This type represents a mapping of an entire API surface to its handlers.
  */
-type ApiHandlerSurface<TSurface extends ApiSurface> = {
-    [name in ApiNames<TSurface>]: ApiHandler<TSurface[name]>;
+type ApiHandlerSurface<TSurface extends ApiSurface, TExtraParams extends []> = {
+    [name in ApiNames<TSurface>]: ApiHandler<TSurface[name], TExtraParams>;
 };
 
 /**
  * This type represents a single API map initializer.
  * Type safety is enforced by ensuring that the name and handler signature are valid.
  */
-type ApiMapInitItem<TSurface extends ApiSurface, TName extends ApiNames<TSurface>> = [
+type ApiMapInitItem<TSurface extends ApiSurface, TExtraParams extends [], TName extends ApiNames<TSurface>> = [
     name: TName,
-    handler: ApiHandler<TSurface[TName]>,
+    handler: ApiHandler<TSurface[TName], TExtraParams>,
 ];
 
 /**
  * This type represents a a union of all API map initializers for a given surface.
  */
-type ApiMapInitItemAny<TSurface extends ApiSurface> = {[key in ApiNames<TSurface>]: ApiMapInitItem<TSurface, key>}[ApiNames<TSurface>];
+type ApiMapInitItemAny<TSurface extends ApiSurface, TExtraParams extends []> = {[key in ApiNames<TSurface>]: ApiMapInitItem<TSurface, TExtraParams, key>}[ApiNames<TSurface>];
 
 /** Type alias for the params member of an descriptor. */
 export type ApiParams<TDescriptor extends ApiDescriptor> = TDescriptor['params'];
@@ -61,22 +61,22 @@ export type ApiParams<TDescriptor extends ApiDescriptor> = TDescriptor['params']
 export type ApiReturn<TDescriptor extends ApiDescriptor> = TDescriptor['return'];
 
 /** A type representing a synchronous handler. */
-export type ApiHandlerSync<TDescriptor extends ApiDescriptor> = (params: ApiParams<TDescriptor>) => ApiReturn<TDescriptor>;
+export type ApiHandlerSync<TDescriptor extends ApiDescriptor, TExtraParams extends [] = []> = (params: ApiParams<TDescriptor>, ...extraParams: TExtraParams) => ApiReturn<TDescriptor>;
 
 /** A type representing an asynchronous handler. */
-export type ApiHandlerAsync<TDescriptor extends ApiDescriptor> = (params: ApiParams<TDescriptor>) => Promise<ApiReturn<TDescriptor>>;
+export type ApiHandlerAsync<TDescriptor extends ApiDescriptor, TExtraParams extends [] = []> = (params: ApiParams<TDescriptor>, ...extraParams: TExtraParams) => Promise<ApiReturn<TDescriptor>>;
 
 /** A type representing a generic handler. */
-export type ApiHandler<TDescriptor extends ApiDescriptor> = (params: ApiParams<TDescriptor>) => ApiReturn<TDescriptor> | Promise<ApiReturn<TDescriptor>>;
+export type ApiHandler<TDescriptor extends ApiDescriptor, TExtraParams extends [] = []> = (params: ApiParams<TDescriptor>, ...extraParams: TExtraParams) => ApiReturn<TDescriptor> | Promise<ApiReturn<TDescriptor>>;
 
 /** A union of all of the handlers for a given surface. */
-export type ApiHandlerAny<TSurface extends ApiSurface> = ApiHandlerSurface<TSurface>[ApiNames<TSurface>];
+export type ApiHandlerAny<TSurface extends ApiSurface, TExtraParams extends [] = []> = ApiHandlerSurface<TSurface, TExtraParams>[ApiNames<TSurface>];
 
 /** A union of all of the names for a given surface. */
 export type ApiNames<TSurface extends ApiSurface> = keyof TSurface;
 
 /** A mapping of names to the corresponding handler function. */
-export type ApiMap<TSurface extends ApiSurface> = Map<ApiNames<TSurface>, ApiHandlerAny<TSurface>>;
+export type ApiMap<TSurface extends ApiSurface, TExtraParams extends [] = []> = Map<ApiNames<TSurface>, ApiHandlerAny<TSurface, TExtraParams>>;
 
 /** The initialization array structure for populating an API map. */
-export type ApiMapInit<TSurface extends ApiSurface> = ApiMapInitItemAny<TSurface>[];
+export type ApiMapInit<TSurface extends ApiSurface, TExtraParams extends [] = []> = ApiMapInitItemAny<TSurface, TExtraParams>[];

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -36,7 +36,7 @@ type ApiDescriptor = {
 /**
  * This type represents a mapping of an entire API surface to its handlers.
  */
-type ApiHandlerSurface<TSurface extends ApiSurface, TExtraParams extends []> = {
+type ApiHandlerSurface<TSurface extends ApiSurface, TExtraParams extends ApiTExtraParams> = {
     [name in ApiNames<TSurface>]: ApiHandler<TSurface[name], TExtraParams>;
 };
 
@@ -44,7 +44,7 @@ type ApiHandlerSurface<TSurface extends ApiSurface, TExtraParams extends []> = {
  * This type represents a single API map initializer.
  * Type safety is enforced by ensuring that the name and handler signature are valid.
  */
-type ApiMapInitItem<TSurface extends ApiSurface, TExtraParams extends [], TName extends ApiNames<TSurface>> = [
+type ApiMapInitItem<TSurface extends ApiSurface, TExtraParams extends ApiTExtraParams, TName extends ApiNames<TSurface>> = [
     name: TName,
     handler: ApiHandler<TSurface[TName], TExtraParams>,
 ];
@@ -52,7 +52,11 @@ type ApiMapInitItem<TSurface extends ApiSurface, TExtraParams extends [], TName 
 /**
  * This type represents a a union of all API map initializers for a given surface.
  */
-type ApiMapInitItemAny<TSurface extends ApiSurface, TExtraParams extends []> = {[key in ApiNames<TSurface>]: ApiMapInitItem<TSurface, TExtraParams, key>}[ApiNames<TSurface>];
+type ApiMapInitItemAny<TSurface extends ApiSurface, TExtraParams extends ApiTExtraParams> = {[key in ApiNames<TSurface>]: ApiMapInitItem<TSurface, TExtraParams, key>}[ApiNames<TSurface>];
+
+type ApiTExtraParams = unknown[];
+
+type ApiExtraParamsDefault = [];
 
 /** Type alias for the params member of an descriptor. */
 export type ApiParams<TDescriptor extends ApiDescriptor> = TDescriptor['params'];
@@ -61,22 +65,22 @@ export type ApiParams<TDescriptor extends ApiDescriptor> = TDescriptor['params']
 export type ApiReturn<TDescriptor extends ApiDescriptor> = TDescriptor['return'];
 
 /** A type representing a synchronous handler. */
-export type ApiHandlerSync<TDescriptor extends ApiDescriptor, TExtraParams extends [] = []> = (params: ApiParams<TDescriptor>, ...extraParams: TExtraParams) => ApiReturn<TDescriptor>;
+export type ApiHandlerSync<TDescriptor extends ApiDescriptor, TExtraParams extends ApiTExtraParams = ApiExtraParamsDefault> = (params: ApiParams<TDescriptor>, ...extraParams: TExtraParams) => ApiReturn<TDescriptor>;
 
 /** A type representing an asynchronous handler. */
-export type ApiHandlerAsync<TDescriptor extends ApiDescriptor, TExtraParams extends [] = []> = (params: ApiParams<TDescriptor>, ...extraParams: TExtraParams) => Promise<ApiReturn<TDescriptor>>;
+export type ApiHandlerAsync<TDescriptor extends ApiDescriptor, TExtraParams extends ApiTExtraParams = ApiExtraParamsDefault> = (params: ApiParams<TDescriptor>, ...extraParams: TExtraParams) => Promise<ApiReturn<TDescriptor>>;
 
 /** A type representing a generic handler. */
-export type ApiHandler<TDescriptor extends ApiDescriptor, TExtraParams extends [] = []> = (params: ApiParams<TDescriptor>, ...extraParams: TExtraParams) => ApiReturn<TDescriptor> | Promise<ApiReturn<TDescriptor>>;
+export type ApiHandler<TDescriptor extends ApiDescriptor, TExtraParams extends ApiTExtraParams = ApiExtraParamsDefault> = (params: ApiParams<TDescriptor>, ...extraParams: TExtraParams) => ApiReturn<TDescriptor> | Promise<ApiReturn<TDescriptor>>;
 
 /** A union of all of the handlers for a given surface. */
-export type ApiHandlerAny<TSurface extends ApiSurface, TExtraParams extends [] = []> = ApiHandlerSurface<TSurface, TExtraParams>[ApiNames<TSurface>];
+export type ApiHandlerAny<TSurface extends ApiSurface, TExtraParams extends ApiTExtraParams = ApiExtraParamsDefault> = ApiHandlerSurface<TSurface, TExtraParams>[ApiNames<TSurface>];
 
 /** A union of all of the names for a given surface. */
 export type ApiNames<TSurface extends ApiSurface> = keyof TSurface;
 
 /** A mapping of names to the corresponding handler function. */
-export type ApiMap<TSurface extends ApiSurface, TExtraParams extends [] = []> = Map<ApiNames<TSurface>, ApiHandlerAny<TSurface, TExtraParams>>;
+export type ApiMap<TSurface extends ApiSurface, TExtraParams extends ApiTExtraParams = ApiExtraParamsDefault> = Map<ApiNames<TSurface>, ApiHandlerAny<TSurface, TExtraParams>>;
 
 /** The initialization array structure for populating an API map. */
-export type ApiMapInit<TSurface extends ApiSurface, TExtraParams extends [] = []> = ApiMapInitItemAny<TSurface, TExtraParams>[];
+export type ApiMapInit<TSurface extends ApiSurface, TExtraParams extends ApiTExtraParams = ApiExtraParamsDefault> = ApiMapInitItemAny<TSurface, TExtraParams>[];

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -32,9 +32,9 @@ export type ApiHandlerAny<TApiSurface extends ApiSurface> = ApiHandlerSurface<TA
 
 export type ApiNames<TApiSurface extends ApiSurface> = keyof TApiSurface;
 
-export type ApiParams<TApiSurface extends ApiSurface, TName extends ApiNames<TApiSurface>> = TApiSurface[TName]['params'];
+export type ApiParams<TApiItem extends ApiItem> = TApiItem['params'];
 
-export type ApiReturn<TApiSurface extends ApiSurface, TName extends ApiNames<TApiSurface>> = TApiSurface[TName]['return'];
+export type ApiReturn<TApiItem extends ApiItem> = TApiItem['return'];
 
 export type ApiMap<TApiSurface extends ApiSurface> = Map<ApiNames<TApiSurface>, ApiHandlerAny<TApiSurface>>;
 

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -28,6 +28,10 @@ export type ApiParams<TApiItem extends ApiItem> = TApiItem['params'];
 
 export type ApiReturn<TApiItem extends ApiItem> = TApiItem['return'];
 
+export type ApiHandlerSync<TApiItem extends ApiItem> = (params: ApiParams<TApiItem>) => ApiReturn<TApiItem>;
+
+export type ApiHandlerAsync<TApiItem extends ApiItem> = (params: ApiParams<TApiItem>) => Promise<ApiReturn<TApiItem>>;
+
 export type ApiHandler<TApiItem extends ApiItem> = (params: ApiParams<TApiItem>) => ApiReturn<TApiItem> | Promise<ApiReturn<TApiItem>>;
 
 type ApiHandlerSurface<TApiSurface extends ApiSurface> = {[name in ApiNames<TApiSurface>]: ApiHandler<TApiSurface[name]>};

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -24,17 +24,17 @@ type ApiItem = {
     return: unknown;
 };
 
-export type ApiHandler<TApiItem extends ApiItem> = (params: TApiItem['params']) => TApiItem['return'] | Promise<TApiItem['return']>;
+export type ApiParams<TApiItem extends ApiItem> = TApiItem['params'];
+
+export type ApiReturn<TApiItem extends ApiItem> = TApiItem['return'];
+
+export type ApiHandler<TApiItem extends ApiItem> = (params: ApiParams<TApiItem>) => ApiReturn<TApiItem> | Promise<ApiReturn<TApiItem>>;
 
 type ApiHandlerSurface<TApiSurface extends ApiSurface> = {[name in ApiNames<TApiSurface>]: ApiHandler<TApiSurface[name]>};
 
 export type ApiHandlerAny<TApiSurface extends ApiSurface> = ApiHandlerSurface<TApiSurface>[ApiNames<TApiSurface>];
 
 export type ApiNames<TApiSurface extends ApiSurface> = keyof TApiSurface;
-
-export type ApiParams<TApiItem extends ApiItem> = TApiItem['params'];
-
-export type ApiReturn<TApiItem extends ApiItem> = TApiItem['return'];
 
 export type ApiMap<TApiSurface extends ApiSurface> = Map<ApiNames<TApiSurface>, ApiHandlerAny<TApiSurface>>;
 

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -24,36 +24,36 @@ type ApiDescriptor = {
     return: unknown;
 };
 
-export type ApiParams<TApiDescriptor extends ApiDescriptor> = TApiDescriptor['params'];
+export type ApiParams<TDescriptor extends ApiDescriptor> = TDescriptor['params'];
 
-export type ApiReturn<TApiDescriptor extends ApiDescriptor> = TApiDescriptor['return'];
+export type ApiReturn<TDescriptor extends ApiDescriptor> = TDescriptor['return'];
 
-export type ApiHandlerSync<TApiDescriptor extends ApiDescriptor> = (params: ApiParams<TApiDescriptor>) => ApiReturn<TApiDescriptor>;
+export type ApiHandlerSync<TDescriptor extends ApiDescriptor> = (params: ApiParams<TDescriptor>) => ApiReturn<TDescriptor>;
 
-export type ApiHandlerAsync<TApiDescriptor extends ApiDescriptor> = (params: ApiParams<TApiDescriptor>) => Promise<ApiReturn<TApiDescriptor>>;
+export type ApiHandlerAsync<TDescriptor extends ApiDescriptor> = (params: ApiParams<TDescriptor>) => Promise<ApiReturn<TDescriptor>>;
 
-export type ApiHandler<TApiDescriptor extends ApiDescriptor> = (params: ApiParams<TApiDescriptor>) => ApiReturn<TApiDescriptor> | Promise<ApiReturn<TApiDescriptor>>;
+export type ApiHandler<TDescriptor extends ApiDescriptor> = (params: ApiParams<TDescriptor>) => ApiReturn<TDescriptor> | Promise<ApiReturn<TDescriptor>>;
 
-type ApiHandlerSurface<TApiSurface extends ApiSurface> = {[name in ApiNames<TApiSurface>]: ApiHandler<TApiSurface[name]>};
+type ApiHandlerSurface<TSurface extends ApiSurface> = {[name in ApiNames<TSurface>]: ApiHandler<TSurface[name]>};
 
-export type ApiHandlerAny<TApiSurface extends ApiSurface> = ApiHandlerSurface<TApiSurface>[ApiNames<TApiSurface>];
+export type ApiHandlerAny<TSurface extends ApiSurface> = ApiHandlerSurface<TSurface>[ApiNames<TSurface>];
 
-export type ApiNames<TApiSurface extends ApiSurface> = keyof TApiSurface;
+export type ApiNames<TSurface extends ApiSurface> = keyof TSurface;
 
-export type ApiMap<TApiSurface extends ApiSurface> = Map<ApiNames<TApiSurface>, ApiHandlerAny<TApiSurface>>;
+export type ApiMap<TSurface extends ApiSurface> = Map<ApiNames<TSurface>, ApiHandlerAny<TSurface>>;
 
-export type ApiMapInit<TApiSurface extends ApiSurface> = ApiMapInitItemAny<TApiSurface>[];
+export type ApiMapInit<TSurface extends ApiSurface> = ApiMapInitItemAny<TSurface>[];
 
-export type ApiMapInitLax<TApiSurface extends ApiSurface> = ApiMapInitLaxItem<TApiSurface>[];
+export type ApiMapInitLax<TSurface extends ApiSurface> = ApiMapInitLaxItem<TSurface>[];
 
-export type ApiMapInitLaxItem<TApiSurface extends ApiSurface> = [
-    name: ApiNames<TApiSurface>,
-    handler: ApiHandlerAny<TApiSurface>,
+export type ApiMapInitLaxItem<TSurface extends ApiSurface> = [
+    name: ApiNames<TSurface>,
+    handler: ApiHandlerAny<TSurface>,
 ];
 
-type ApiMapInitItem<TApiSurface extends ApiSurface, TName extends ApiNames<TApiSurface>> = [
+type ApiMapInitItem<TSurface extends ApiSurface, TName extends ApiNames<TSurface>> = [
     name: TName,
-    handler: ApiHandler<TApiSurface[TName]>,
+    handler: ApiHandler<TSurface[TName]>,
 ];
 
-type ApiMapInitItemAny<TApiSurface extends ApiSurface> = {[key in ApiNames<TApiSurface>]: ApiMapInitItem<TApiSurface, key>}[ApiNames<TApiSurface>];
+type ApiMapInitItemAny<TSurface extends ApiSurface> = {[key in ApiNames<TSurface>]: ApiMapInitItem<TSurface, key>}[ApiNames<TSurface>];

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -15,38 +15,68 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/**
+ * This type describes the structure of an API surface.
+ * It is effectively just an object containing a list of items which describe a basic API functionality.
+ */
 type ApiSurface = {
     [name: string]: ApiDescriptor;
 };
 
+/**
+ * This type describes the structure of a single API function.
+ */
 type ApiDescriptor = {
+    /** The parameters for the function. If there are no parameters, `void` should be used. */
     params: void | {[name: string]: unknown};
+    /** The return type for the function. */
     return: unknown;
 };
 
-export type ApiParams<TDescriptor extends ApiDescriptor> = TDescriptor['params'];
+/**
+ * This type represents a mapping of an entire API surface to its handlers.
+ */
+type ApiHandlerSurface<TSurface extends ApiSurface> = {
+    [name in ApiNames<TSurface>]: ApiHandler<TSurface[name]>;
+};
 
-export type ApiReturn<TDescriptor extends ApiDescriptor> = TDescriptor['return'];
-
-export type ApiHandlerSync<TDescriptor extends ApiDescriptor> = (params: ApiParams<TDescriptor>) => ApiReturn<TDescriptor>;
-
-export type ApiHandlerAsync<TDescriptor extends ApiDescriptor> = (params: ApiParams<TDescriptor>) => Promise<ApiReturn<TDescriptor>>;
-
-export type ApiHandler<TDescriptor extends ApiDescriptor> = (params: ApiParams<TDescriptor>) => ApiReturn<TDescriptor> | Promise<ApiReturn<TDescriptor>>;
-
-type ApiHandlerSurface<TSurface extends ApiSurface> = {[name in ApiNames<TSurface>]: ApiHandler<TSurface[name]>};
-
-export type ApiHandlerAny<TSurface extends ApiSurface> = ApiHandlerSurface<TSurface>[ApiNames<TSurface>];
-
-export type ApiNames<TSurface extends ApiSurface> = keyof TSurface;
-
-export type ApiMap<TSurface extends ApiSurface> = Map<ApiNames<TSurface>, ApiHandlerAny<TSurface>>;
-
-export type ApiMapInit<TSurface extends ApiSurface> = ApiMapInitItemAny<TSurface>[];
-
+/**
+ * This type represents a single API map initializer.
+ * Type safety is enforced by ensuring that the name and handler signature are valid.
+ */
 type ApiMapInitItem<TSurface extends ApiSurface, TName extends ApiNames<TSurface>> = [
     name: TName,
     handler: ApiHandler<TSurface[TName]>,
 ];
 
+/**
+ * This type represents a a union of all API map initializers for a given surface.
+ */
 type ApiMapInitItemAny<TSurface extends ApiSurface> = {[key in ApiNames<TSurface>]: ApiMapInitItem<TSurface, key>}[ApiNames<TSurface>];
+
+/** Type alias for the params member of an descriptor. */
+export type ApiParams<TDescriptor extends ApiDescriptor> = TDescriptor['params'];
+
+/** Type alias for the return member of an descriptor. */
+export type ApiReturn<TDescriptor extends ApiDescriptor> = TDescriptor['return'];
+
+/** A type representing a synchronous handler. */
+export type ApiHandlerSync<TDescriptor extends ApiDescriptor> = (params: ApiParams<TDescriptor>) => ApiReturn<TDescriptor>;
+
+/** A type representing an asynchronous handler. */
+export type ApiHandlerAsync<TDescriptor extends ApiDescriptor> = (params: ApiParams<TDescriptor>) => Promise<ApiReturn<TDescriptor>>;
+
+/** A type representing a generic handler. */
+export type ApiHandler<TDescriptor extends ApiDescriptor> = (params: ApiParams<TDescriptor>) => ApiReturn<TDescriptor> | Promise<ApiReturn<TDescriptor>>;
+
+/** A union of all of the handlers for a given surface. */
+export type ApiHandlerAny<TSurface extends ApiSurface> = ApiHandlerSurface<TSurface>[ApiNames<TSurface>];
+
+/** A union of all of the names for a given surface. */
+export type ApiNames<TSurface extends ApiSurface> = keyof TSurface;
+
+/** A mapping of names to the corresponding handler function. */
+export type ApiMap<TSurface extends ApiSurface> = Map<ApiNames<TSurface>, ApiHandlerAny<TSurface>>;
+
+/** The initialization array structure for populating an API map. */
+export type ApiMapInit<TSurface extends ApiSurface> = ApiMapInitItemAny<TSurface>[];

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -60,13 +60,16 @@ type ApiTExtraParams = unknown[];
 /** Default type for extra params, which is an empty array. */
 type ApiExtraParamsDefault = [];
 
-/** Type alias for the params member of an descriptor. */
+/** Type alias for the params member of a descriptor. */
 export type ApiParams<TDescriptor extends ApiDescriptor> = TDescriptor['params'];
 
-/** Type alias for the params member of an descriptor as an object. If params is void, an empty record is used. */
+/** Type alias for a single param of a descriptor. */
+export type ApiParam<TDescriptor extends ApiDescriptor, TParamName extends ApiParamNames<TDescriptor>> = ApiParams<TDescriptor>[TParamName];
+
+/** Type alias for the params member of a descriptor as an object. If params is void, an empty record is used. */
 export type ApiParamsObject<TDescriptor extends ApiDescriptor> = ApiParams<TDescriptor> extends void ? Record<string, never> : ApiParams<TDescriptor>;
 
-/** Type alias for the union of parameter names in an descriptor. */
+/** Type alias for the union of parameter names in a descriptor. */
 export type ApiParamNames<TDescriptor extends ApiDescriptor> = keyof ApiParams<TDescriptor>;
 
 /** Type alias for a tuple of parameter types for a descriptor. */
@@ -74,7 +77,7 @@ export type ApiOrderedParams<TDescriptor extends ApiDescriptor, TParamNames exte
     [index in keyof TParamNames]: ApiParams<TDescriptor>[TParamNames[index]];
 };
 
-/** Type alias for the return member of an descriptor. */
+/** Type alias for the return member of a descriptor. */
 export type ApiReturn<TDescriptor extends ApiDescriptor> = TDescriptor['return'];
 
 /** A type representing a synchronous handler. */

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -63,6 +63,17 @@ type ApiExtraParamsDefault = [];
 /** Type alias for the params member of an descriptor. */
 export type ApiParams<TDescriptor extends ApiDescriptor> = TDescriptor['params'];
 
+/** Type alias for the params member of an descriptor as an object. If params is void, an empty record is used. */
+export type ApiParamsObject<TDescriptor extends ApiDescriptor> = ApiParams<TDescriptor> extends void ? Record<string, never> : ApiParams<TDescriptor>;
+
+/** Type alias for the union of parameter names in an descriptor. */
+export type ApiParamNames<TDescriptor extends ApiDescriptor> = keyof ApiParams<TDescriptor>;
+
+/** Type alias for a tuple of parameter types for a descriptor. */
+export type ApiOrderedParams<TDescriptor extends ApiDescriptor, TParamNames extends ApiParamNames<TDescriptor>[]> = {
+    [index in keyof TParamNames]: ApiParams<TDescriptor>[TParamNames[index]];
+};
+
 /** Type alias for the return member of an descriptor. */
 export type ApiReturn<TDescriptor extends ApiDescriptor> = TDescriptor['return'];
 
@@ -86,3 +97,13 @@ export type ApiMap<TSurface extends ApiSurface, TExtraParams extends ApiTExtraPa
 
 /** The initialization array structure for populating an API map. */
 export type ApiMapInit<TSurface extends ApiSurface, TExtraParams extends ApiTExtraParams = ApiExtraParamsDefault> = ApiMapInitItemAny<TSurface, TExtraParams>[];
+
+/** The type for a public API function, using a parameters object. */
+export type ApiFunction<TSurface extends ApiSurface, TName extends ApiNames<TSurface>> = (
+    params: ApiParams<TSurface[TName]>,
+) => Promise<ApiReturn<TSurface[TName]>>;
+
+/** The type for a public API function, using ordered parameters. */
+export type ApiFunctionOrdered<TSurface extends ApiSurface, TName extends ApiNames<TSurface>, TParamNames extends ApiParamNames<TSurface[TName]>[]> = (
+    ...params: ApiOrderedParams<TSurface[TName], TParamNames>,
+) => Promise<ApiReturn<TSurface[TName]>>;

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -66,9 +66,6 @@ export type ApiParams<TDescriptor extends ApiDescriptor> = TDescriptor['params']
 /** Type alias for a single param of a descriptor. */
 export type ApiParam<TDescriptor extends ApiDescriptor, TParamName extends ApiParamNames<TDescriptor>> = ApiParams<TDescriptor>[TParamName];
 
-/** Type alias for the params member of a descriptor as an object. If params is void, an empty record is used. */
-export type ApiParamsObject<TDescriptor extends ApiDescriptor> = ApiParams<TDescriptor> extends void ? Record<string, never> : ApiParams<TDescriptor>;
-
 /** Type alias for the union of parameter names in a descriptor. */
 export type ApiParamNames<TDescriptor extends ApiDescriptor> = keyof ApiParams<TDescriptor>;
 
@@ -110,3 +107,9 @@ export type ApiFunction<TSurface extends ApiSurface, TName extends ApiNames<TSur
 export type ApiFunctionOrdered<TSurface extends ApiSurface, TName extends ApiNames<TSurface>, TParamNames extends ApiParamNames<TSurface[TName]>[]> = (
     ...params: ApiOrderedParams<TSurface[TName], TParamNames>,
 ) => Promise<ApiReturn<TSurface[TName]>>;
+
+/** Type alias for a union of all params types. */
+export type ApiParamsAny<TSurface extends ApiSurface> = ApiParams<TSurface[keyof TSurface]>;
+
+/** Type alias for a union of all return types. */
+export type ApiReturnAny<TSurface extends ApiSurface> = ApiReturn<TSurface[keyof TSurface]>;

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -54,8 +54,10 @@ type ApiMapInitItem<TSurface extends ApiSurface, TExtraParams extends ApiTExtraP
  */
 type ApiMapInitItemAny<TSurface extends ApiSurface, TExtraParams extends ApiTExtraParams> = {[key in ApiNames<TSurface>]: ApiMapInitItem<TSurface, TExtraParams, key>}[ApiNames<TSurface>];
 
+/** Base type for extra params, which is just a generic array. */
 type ApiTExtraParams = unknown[];
 
+/** Default type for extra params, which is an empty array. */
 type ApiExtraParamsDefault = [];
 
 /** Type alias for the params member of an descriptor. */

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -16,23 +16,23 @@
  */
 
 type ApiSurface = {
-    [name: string]: ApiItem;
+    [name: string]: ApiDescriptor;
 };
 
-type ApiItem = {
+type ApiDescriptor = {
     params: void | {[name: string]: unknown};
     return: unknown;
 };
 
-export type ApiParams<TApiItem extends ApiItem> = TApiItem['params'];
+export type ApiParams<TApiDescriptor extends ApiDescriptor> = TApiDescriptor['params'];
 
-export type ApiReturn<TApiItem extends ApiItem> = TApiItem['return'];
+export type ApiReturn<TApiDescriptor extends ApiDescriptor> = TApiDescriptor['return'];
 
-export type ApiHandlerSync<TApiItem extends ApiItem> = (params: ApiParams<TApiItem>) => ApiReturn<TApiItem>;
+export type ApiHandlerSync<TApiDescriptor extends ApiDescriptor> = (params: ApiParams<TApiDescriptor>) => ApiReturn<TApiDescriptor>;
 
-export type ApiHandlerAsync<TApiItem extends ApiItem> = (params: ApiParams<TApiItem>) => Promise<ApiReturn<TApiItem>>;
+export type ApiHandlerAsync<TApiDescriptor extends ApiDescriptor> = (params: ApiParams<TApiDescriptor>) => Promise<ApiReturn<TApiDescriptor>>;
 
-export type ApiHandler<TApiItem extends ApiItem> = (params: ApiParams<TApiItem>) => ApiReturn<TApiItem> | Promise<ApiReturn<TApiItem>>;
+export type ApiHandler<TApiDescriptor extends ApiDescriptor> = (params: ApiParams<TApiDescriptor>) => ApiReturn<TApiDescriptor> | Promise<ApiReturn<TApiDescriptor>>;
 
 type ApiHandlerSurface<TApiSurface extends ApiSurface> = {[name in ApiNames<TApiSurface>]: ApiHandler<TApiSurface[name]>};
 

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -44,13 +44,6 @@ export type ApiMap<TSurface extends ApiSurface> = Map<ApiNames<TSurface>, ApiHan
 
 export type ApiMapInit<TSurface extends ApiSurface> = ApiMapInitItemAny<TSurface>[];
 
-export type ApiMapInitLax<TSurface extends ApiSurface> = ApiMapInitLaxItem<TSurface>[];
-
-export type ApiMapInitLaxItem<TSurface extends ApiSurface> = [
-    name: ApiNames<TSurface>,
-    handler: ApiHandlerAny<TSurface>,
-];
-
 type ApiMapInitItem<TSurface extends ApiSurface, TName extends ApiNames<TSurface>> = [
     name: TName,
     handler: ApiHandler<TSurface[TName]>,

--- a/types/ext/offscreen.d.ts
+++ b/types/ext/offscreen.d.ts
@@ -22,7 +22,7 @@ import type * as DictionaryImporter from './dictionary-importer';
 import type * as Environment from './environment';
 import type * as Translation from './translation';
 import type * as Translator from './translator';
-import type {ApiMap, ApiMapInit, ApiHandler, ApiParams, ApiReturn} from './api-map';
+import type {ApiMap, ApiMapInit, ApiHandler, ApiParams, ApiReturn, ApiNames} from './api-map';
 
 type OffscreenApiSurface = {
     databasePrepareOffscreen: {
@@ -99,7 +99,7 @@ export type Message<TName extends MessageType> = (
         {action: TName, params: OffscreenApiParams<TName>}
 );
 
-export type MessageType = keyof OffscreenApiSurface;
+export type MessageType = ApiNames<OffscreenApiSurface>;
 
 export type FindKanjiOptionsOffscreen = Omit<Translation.FindKanjiOptions, 'enabledDictionaryMap'> & {
     enabledDictionaryMap: [
@@ -126,8 +126,8 @@ export type OffscreenApiMap = ApiMap<OffscreenApiSurface>;
 
 export type OffscreenApiMapInit = ApiMapInit<OffscreenApiSurface>;
 
-export type OffscreenApiHandler<TName extends keyof OffscreenApiSurface> = ApiHandler<OffscreenApiSurface[TName]>;
+export type OffscreenApiHandler<TName extends MessageType> = ApiHandler<OffscreenApiSurface[TName]>;
 
-export type OffscreenApiParams<TName extends keyof OffscreenApiSurface> = ApiParams<OffscreenApiSurface, TName>;
+export type OffscreenApiParams<TName extends MessageType> = ApiParams<OffscreenApiSurface[TName]>;
 
-export type OffscreenApiReturn<TName extends keyof OffscreenApiSurface> = ApiReturn<OffscreenApiSurface, TName>;
+export type OffscreenApiReturn<TName extends MessageType> = ApiReturn<OffscreenApiSurface[TName]>;


### PR DESCRIPTION
Further improves the setup of API map types and adds some basic descriptions. API handlers now support a generic `...extraArgs` rest parameters array if needed. The `Backend` component, for example, will need to use this.

https://github.com/themoeway/yomitan/pull/413#pullrequestreview-1793116000
#391