### PR TITLE
Add 出来る/できる as inflections of する

### DIFF
--- a/ext/data/deinflect.json
+++ b/ext/data/deinflect.json
@@ -539,6 +539,7 @@
         {"kanaIn": "べる", "kanaOut": "ぶ", "rulesIn": ["v1"], "rulesOut": ["v5"]},
         {"kanaIn": "める", "kanaOut": "む", "rulesIn": ["v1"], "rulesOut": ["v5"]},
         {"kanaIn": "できる", "kanaOut": "する", "rulesIn": ["v1"], "rulesOut": ["vs"]},
+        {"kanaIn": "出来る", "kanaOut": "する", "rulesIn": ["v1"], "rulesOut": ["vs"]},
         {"kanaIn": "これる", "kanaOut": "くる", "rulesIn": ["v1"], "rulesOut": ["vk"]},
         {"kanaIn": "来れる", "kanaOut": "来る", "rulesIn": ["v1"], "rulesOut": ["vk"]},
         {"kanaIn": "來れる", "kanaOut": "來る", "rulesIn": ["v1"], "rulesOut": ["vk"]}

--- a/ext/data/deinflect.json
+++ b/ext/data/deinflect.json
@@ -538,6 +538,7 @@
         {"kanaIn": "ねる", "kanaOut": "ぬ", "rulesIn": ["v1"], "rulesOut": ["v5"]},
         {"kanaIn": "べる", "kanaOut": "ぶ", "rulesIn": ["v1"], "rulesOut": ["v5"]},
         {"kanaIn": "める", "kanaOut": "む", "rulesIn": ["v1"], "rulesOut": ["v5"]},
+        {"kanaIn": "できる", "kanaOut": "する", "rulesIn": ["v1"], "rulesOut": ["vs"]},
         {"kanaIn": "これる", "kanaOut": "くる", "rulesIn": ["v1"], "rulesOut": ["vk"]},
         {"kanaIn": "来れる", "kanaOut": "来る", "rulesIn": ["v1"], "rulesOut": ["vk"]},
         {"kanaIn": "來れる", "kanaOut": "來る", "rulesIn": ["v1"], "rulesOut": ["vk"]}

--- a/test/deinflector.test.js
+++ b/test/deinflector.test.js
@@ -562,6 +562,7 @@ function testDeinflections() {
                 {term: 'する', source: 'した',           rule: 'vs', reasons: ['past']},
                 {term: 'する', source: 'しました',       rule: 'vs', reasons: ['polite past']},
                 {term: 'する', source: 'して',           rule: 'vs', reasons: ['-te']},
+                {term: 'する', source: 'できる',         rule: 'vs', reasons: ['potential']},
                 {term: 'する', source: 'せられる',       rule: 'vs', reasons: ['potential or passive']},
                 {term: 'する', source: 'される',         rule: 'vs', reasons: ['passive']},
                 {term: 'する', source: 'させる',         rule: 'vs', reasons: ['causative']},

--- a/test/deinflector.test.js
+++ b/test/deinflector.test.js
@@ -563,6 +563,7 @@ function testDeinflections() {
                 {term: 'する', source: 'しました',       rule: 'vs', reasons: ['polite past']},
                 {term: 'する', source: 'して',           rule: 'vs', reasons: ['-te']},
                 {term: 'する', source: 'できる',         rule: 'vs', reasons: ['potential']},
+                {term: 'する', source: '出来る',         rule: 'vs', reasons: ['potential']},
                 {term: 'する', source: 'せられる',       rule: 'vs', reasons: ['potential or passive']},
                 {term: 'する', source: 'される',         rule: 'vs', reasons: ['passive']},
                 {term: 'する', source: 'させる',         rule: 'vs', reasons: ['causative']},


### PR DESCRIPTION
This change rebases the yomichan PR https://github.com/FooSoft/yomichan/pull/2266 for yomitan.
- できる and 出来る correctly matches 出来る as first entry
![image](https://github.com/themoeway/yomitan/assets/52880648/bae7aad1-7a6c-4fd1-8292-da540be3391a)
- 全うできる correctly matches to 全うする 
![image](https://github.com/themoeway/yomitan/assets/52880648/87e2b2dc-c7d8-43cd-ba02-6097fb14a8d4)
- 口を糊できる correctly matches to 口を糊する
