### PR TITLE
Update offscreen to use invokeApiMapHandler

### DIFF
--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -52,8 +52,8 @@ export class Offscreen {
 
 
         /* eslint-disable no-multi-spaces */
-        /** @type {import('offscreen').OffscreenApiMapInit} */
-        const apiMapInit = [
+        /** @type {import('offscreen').OffscreenApiMap} */
+        this._apiMap = createApiMap([
             ['clipboardGetTextOffscreen',    this._getTextHandler.bind(this)],
             ['clipboardGetImageOffscreen',   this._getImageHandler.bind(this)],
             ['clipboardSetBrowserOffscreen', this._setClipboardBrowser.bind(this)],
@@ -66,9 +66,8 @@ export class Offscreen {
             ['findTermsOffscreen',           this._findTermsHandler.bind(this)],
             ['getTermFrequenciesOffscreen',  this._getTermFrequenciesHandler.bind(this)],
             ['clearDatabaseCachesOffscreen', this._clearDatabaseCachesHandler.bind(this)]
-        ];
-        /** @type {import('offscreen').OffscreenApiMap} */
-        this._apiMap = createApiMap(apiMapInit);
+        ]);
+        /* eslint-enable no-multi-spaces */
 
         /** @type {?Promise<void>} */
         this._prepareDatabasePromise = null;

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -18,8 +18,7 @@
 
 import * as wanakana from '../../lib/wanakana.js';
 import {ClipboardReader} from '../comm/clipboard-reader.js';
-import {invokeMessageHandler} from '../core.js';
-import {createApiMap, getApiMapHandler} from '../core/api-map.js';
+import {createApiMap, invokeApiMapHandler} from '../core/api-map.js';
 import {ArrayBufferUtil} from '../data/sandbox/array-buffer-util.js';
 import {DictionaryDatabase} from '../language/dictionary-database.js';
 import {JapaneseUtil} from '../language/sandbox/japanese-util.js';
@@ -54,7 +53,7 @@ export class Offscreen {
 
         /* eslint-disable no-multi-spaces */
         /** @type {import('offscreen').OffscreenApiMapInit} */
-        const messageHandlersInit = [
+        const apiMapInit = [
             ['clipboardGetTextOffscreen',    this._getTextHandler.bind(this)],
             ['clipboardGetImageOffscreen',   this._getImageHandler.bind(this)],
             ['clipboardSetBrowserOffscreen', this._setClipboardBrowser.bind(this)],
@@ -68,9 +67,8 @@ export class Offscreen {
             ['getTermFrequenciesOffscreen',  this._getTermFrequenciesHandler.bind(this)],
             ['clearDatabaseCachesOffscreen', this._clearDatabaseCachesHandler.bind(this)]
         ];
-
         /** @type {import('offscreen').OffscreenApiMap} */
-        this._messageHandlers = createApiMap(messageHandlersInit);
+        this._apiMap = createApiMap(apiMapInit);
 
         /** @type {?Promise<void>} */
         this._prepareDatabasePromise = null;
@@ -174,10 +172,8 @@ export class Offscreen {
         this._translator.clearDatabaseCaches();
     }
 
-    /** @type {import('extension').ChromeRuntimeOnMessageCallback} */
-    _onMessage({action, params}, sender, callback) {
-        const messageHandler = getApiMapHandler(this._messageHandlers, action);
-        if (typeof messageHandler === 'undefined') { return false; }
-        return invokeMessageHandler(messageHandler, params, callback, sender);
+    /** @type {import('extension').ChromeRuntimeOnMessageCallback<import('offscreen').MessageAny>} */
+    _onMessage({action, params}, _sender, callback) {
+        return invokeApiMapHandler(this._apiMap, action, params, [], callback);
     }
 }

--- a/types/ext/offscreen.d.ts
+++ b/types/ext/offscreen.d.ts
@@ -131,3 +131,5 @@ export type OffscreenApiHandler<TName extends MessageType> = ApiHandler<Offscree
 export type OffscreenApiParams<TName extends MessageType> = ApiParams<OffscreenApiSurface[TName]>;
 
 export type OffscreenApiReturn<TName extends MessageType> = ApiReturn<OffscreenApiSurface[TName]>;
+
+export type MessageAny = Message<MessageType>;


### PR DESCRIPTION
`invokeApiMapHandler` is more type-safe than `invokeMessageHandler`.