### PR TITLE
Narrow down enum types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -384,7 +384,8 @@
         ],
         "@typescript-eslint/no-this-alias": "error",
         "@typescript-eslint/no-unused-vars": "off",
-        "@typescript-eslint/no-var-requires": "off"
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/switch-exhaustiveness-check": "error"
     },
     "overrides": [
         {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -384,8 +384,7 @@
         ],
         "@typescript-eslint/no-this-alias": "error",
         "@typescript-eslint/no-unused-vars": "off",
-        "@typescript-eslint/no-var-requires": "off",
-        "@typescript-eslint/switch-exhaustiveness-check": "error"
+        "@typescript-eslint/no-var-requires": "off"
     },
     "overrides": [
         {

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -342,7 +342,8 @@ export class Backend {
      */
     _onLog({level}) {
         const levelValue = log.getLogErrorLevelValue(level);
-        if (levelValue <= log.getLogErrorLevelValue(this._logErrorLevel)) { return; }
+        const currentLogErrorLevel = this._logErrorLevel !== null ? log.getLogErrorLevelValue(this._logErrorLevel) : 0;
+        if (levelValue <= currentLogErrorLevel) { return; }
 
         this._logErrorLevel = level;
         this._updateBadge();

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -341,8 +341,8 @@ export class Backend {
      * @param {{level: import('log').LogLevel}} params
      */
     _onLog({level}) {
-        const levelValue = this._getErrorLevelValue(level);
-        if (levelValue <= this._getErrorLevelValue(this._logErrorLevel)) { return; }
+        const levelValue = log.getLogErrorLevelValue(level);
+        if (levelValue <= log.getLogErrorLevelValue(this._logErrorLevel)) { return; }
 
         this._logErrorLevel = level;
         this._updateBadge();
@@ -1450,20 +1450,6 @@ export class Backend {
             results.push([name, result]);
         }
         return results;
-    }
-
-    /**
-     * @param {?import('log').LogLevel} errorLevel
-     * @returns {number}
-     */
-    _getErrorLevelValue(errorLevel) {
-        switch (errorLevel) {
-            case 'info': return 0;
-            case 'debug': return 0;
-            case 'warn': return 1;
-            case 'error': return 2;
-            default: return 0;
-        }
     }
 
     /**

--- a/ext/js/core.js
+++ b/ext/js/core.js
@@ -734,6 +734,20 @@ export class Logger extends EventDispatcher {
     error(error, context = null) {
         this.log(error, 'error', context);
     }
+
+    /**
+     * @param {?import('log').LogLevel} errorLevel
+     * @returns {number}
+     */
+    getLogErrorLevelValue(errorLevel) {
+        switch (errorLevel) {
+            case 'info': return 0;
+            case 'debug': return 0;
+            case 'warn': return 1;
+            case 'error': return 2;
+            default: return 0;
+        }
+    }
 }
 
 /**

--- a/ext/js/core.js
+++ b/ext/js/core.js
@@ -736,16 +736,17 @@ export class Logger extends EventDispatcher {
     }
 
     /**
-     * @param {?import('log').LogLevel} errorLevel
-     * @returns {number}
+     * @param {import('log').LogLevel} errorLevel
+     * @returns {import('log').LogErrorLevelValue}
      */
     getLogErrorLevelValue(errorLevel) {
         switch (errorLevel) {
-            case 'info': return 0;
-            case 'debug': return 0;
+            case 'log':
+            case 'info':
+            case 'debug':
+                return 0;
             case 'warn': return 1;
             case 'error': return 2;
-            default: return 0;
         }
     }
 }

--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -184,15 +184,12 @@ export class DOMTextScanner {
 
             matchCharAttributes: switch (charAttributes) {
                 case 0:
-                    // Character should be ignored
                     continue probeForward;
                 case 1:
-                    // Character is collapsible whitespace
                     lineHasWhitespace = true;
                     break matchCharAttributes;
                 case 2:
                 case 3:
-                    // Character should be added to the content
                     if (newlines > 0) {
                         if (content.length > 0) {
                             const useNewlineCount = Math.min(remainder, newlines);
@@ -273,15 +270,12 @@ export class DOMTextScanner {
 
             matchCharAttributes: switch (charAttributes) {
                 case 0:
-                    // Character should be ignored
                     continue probeBackward;
                 case 1:
-                    // Character is collapsible whitespace
                     lineHasWhitespace = true;
                     break matchCharAttributes;
                 case 2:
                 case 3:
-                    // Character should be added to the content
                     if (newlines > 0) {
                         if (content.length > 0) {
                             const useNewlineCount = Math.min(remainder, newlines);

--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -160,129 +160,6 @@ export class DOMTextScanner {
     // Private
 
     /**
-     * @param {string} char
-     * @param {import('dom-text-scanner').CharacterAttributesEnum} charAttributes
-     * @param {import('dom-text-scanner').SeekTextNoteDetails} seekTextNoteDetails
-     * @returns {import('dom-text-scanner').SeekTextNoteDetails}
-     */
-    _checkCharacterForward(char, charAttributes, seekTextNoteDetails) {
-        let {done, lineHasWhitespace, lineHasContent, content, offset, remainder, newlines} = seekTextNoteDetails;
-
-        switch (charAttributes) {
-            case 0:
-                break;
-            case 1:
-                lineHasWhitespace = true;
-                break;
-            case 2:
-            case 3:
-                if (newlines > 0) {
-                    if (content.length > 0) {
-                        const useNewlineCount = Math.min(remainder, newlines);
-                        content += '\n'.repeat(useNewlineCount);
-                        remainder -= useNewlineCount;
-                        newlines -= useNewlineCount;
-                    } else {
-                        newlines = 0;
-                    }
-                    lineHasContent = false;
-                    lineHasWhitespace = false;
-                    if (remainder <= 0) {
-                        offset -= char.length; // Revert character offset
-                        done = true;
-                        break;
-                    }
-                }
-
-                lineHasContent = (charAttributes === 2); // 3 = character is a newline
-
-                if (lineHasWhitespace) {
-                    if (lineHasContent) {
-                        content += ' ';
-                        lineHasWhitespace = false;
-                        if (--remainder <= 0) {
-                            offset -= char.length; // Revert character offset
-                            done = true;
-                            break;
-                        }
-                    } else {
-                        lineHasWhitespace = false;
-                    }
-                }
-
-                content += char;
-
-                if (--remainder <= 0) {
-                    done = true;
-                    break;
-                }
-        }
-
-        return {done, lineHasWhitespace, lineHasContent, content, offset, remainder, newlines};
-    }
-    /**
-     * @param {string} char
-     * @param {import('dom-text-scanner').CharacterAttributesEnum} charAttributes
-     * @param {import('dom-text-scanner').SeekTextNoteDetails} seekTextNoteDetails
-     * @returns {import('dom-text-scanner').SeekTextNoteDetails}
-     */
-    _checkCharacterBackward(char, charAttributes, seekTextNoteDetails) {
-        let {done, lineHasWhitespace, lineHasContent, content, offset, remainder, newlines} = seekTextNoteDetails;
-
-        switch (charAttributes) {
-            case 0:
-                break;
-            case 1:
-                lineHasWhitespace = true;
-                break;
-            case 2:
-            case 3:
-                if (newlines > 0) {
-                    if (content.length > 0) {
-                        const useNewlineCount = Math.min(remainder, newlines);
-                        content = '\n'.repeat(useNewlineCount) + content;
-                        remainder -= useNewlineCount;
-                        newlines -= useNewlineCount;
-                    } else {
-                        newlines = 0;
-                    }
-                    lineHasContent = false;
-                    lineHasWhitespace = false;
-                    if (remainder <= 0) {
-                        offset += char.length; // Revert character offset
-                        done = true;
-                        break;
-                    }
-                }
-
-                lineHasContent = (charAttributes === 2); // 3 = character is a newline
-
-                if (lineHasWhitespace) {
-                    if (lineHasContent) {
-                        content = ' ' + content;
-                        lineHasWhitespace = false;
-                        if (--remainder <= 0) {
-                            offset += char.length; // Revert character offset
-                            done = true;
-                            break;
-                        }
-                    } else {
-                        lineHasWhitespace = false;
-                    }
-                }
-
-                content = char + content;
-
-                if (--remainder <= 0) {
-                    done = true;
-                    break;
-                }
-        }
-
-        return {done, lineHasWhitespace, lineHasContent, content, offset, remainder, newlines};
-    }
-
-    /**
      * Seeks forward in a text node.
      * @param {Text} textNode The text node to use.
      * @param {boolean} resetOffset Whether or not the text offset should be reset.
@@ -394,6 +271,130 @@ export class DOMTextScanner {
             }
         }
         return {preserveNewlines: false, preserveWhitespace: false};
+    }
+
+    /**
+     * @param {string} char
+     * @param {import('dom-text-scanner').CharacterAttributesEnum} charAttributes
+     * @param {import('dom-text-scanner').SeekTextNoteDetails} seekTextNoteDetails
+     * @returns {import('dom-text-scanner').SeekTextNoteDetails}
+     */
+    _checkCharacterForward(char, charAttributes, seekTextNoteDetails) {
+        let {done, lineHasWhitespace, lineHasContent, content, offset, remainder, newlines} = seekTextNoteDetails;
+
+        switch (charAttributes) {
+            case 0:
+                break;
+            case 1:
+                lineHasWhitespace = true;
+                break;
+            case 2:
+            case 3:
+                if (newlines > 0) {
+                    if (content.length > 0) {
+                        const useNewlineCount = Math.min(remainder, newlines);
+                        content += '\n'.repeat(useNewlineCount);
+                        remainder -= useNewlineCount;
+                        newlines -= useNewlineCount;
+                    } else {
+                        newlines = 0;
+                    }
+                    lineHasContent = false;
+                    lineHasWhitespace = false;
+                    if (remainder <= 0) {
+                        offset -= char.length; // Revert character offset
+                        done = true;
+                        break;
+                    }
+                }
+
+                lineHasContent = (charAttributes === 2); // 3 = character is a newline
+
+                if (lineHasWhitespace) {
+                    if (lineHasContent) {
+                        content += ' ';
+                        lineHasWhitespace = false;
+                        if (--remainder <= 0) {
+                            offset -= char.length; // Revert character offset
+                            done = true;
+                            break;
+                        }
+                    } else {
+                        lineHasWhitespace = false;
+                    }
+                }
+
+                content += char;
+
+                if (--remainder <= 0) {
+                    done = true;
+                    break;
+                }
+        }
+
+        return {done, lineHasWhitespace, lineHasContent, content, offset, remainder, newlines};
+    }
+
+    /**
+     * @param {string} char
+     * @param {import('dom-text-scanner').CharacterAttributesEnum} charAttributes
+     * @param {import('dom-text-scanner').SeekTextNoteDetails} seekTextNoteDetails
+     * @returns {import('dom-text-scanner').SeekTextNoteDetails}
+     */
+    _checkCharacterBackward(char, charAttributes, seekTextNoteDetails) {
+        let {done, lineHasWhitespace, lineHasContent, content, offset, remainder, newlines} = seekTextNoteDetails;
+
+        switch (charAttributes) {
+            case 0:
+                break;
+            case 1:
+                lineHasWhitespace = true;
+                break;
+            case 2:
+            case 3:
+                if (newlines > 0) {
+                    if (content.length > 0) {
+                        const useNewlineCount = Math.min(remainder, newlines);
+                        content = '\n'.repeat(useNewlineCount) + content;
+                        remainder -= useNewlineCount;
+                        newlines -= useNewlineCount;
+                    } else {
+                        newlines = 0;
+                    }
+                    lineHasContent = false;
+                    lineHasWhitespace = false;
+                    if (remainder <= 0) {
+                        offset += char.length; // Revert character offset
+                        done = true;
+                        break;
+                    }
+                }
+
+                lineHasContent = (charAttributes === 2); // 3 = character is a newline
+
+                if (lineHasWhitespace) {
+                    if (lineHasContent) {
+                        content = ' ' + content;
+                        lineHasWhitespace = false;
+                        if (--remainder <= 0) {
+                            offset += char.length; // Revert character offset
+                            done = true;
+                            break;
+                        }
+                    } else {
+                        lineHasWhitespace = false;
+                    }
+                }
+
+                content = char + content;
+
+                if (--remainder <= 0) {
+                    done = true;
+                    break;
+                }
+        }
+
+        return {done, lineHasWhitespace, lineHasContent, content, offset, remainder, newlines};
     }
 
     // Static helpers

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -137,8 +137,8 @@ export class TextScanner extends EventDispatcher {
         this._preventNextClick = false;
         /** @type {boolean} */
         this._preventScroll = false;
-        /** @type {0|1|2|3} */
-        this._penPointerState = 0; // 0 = not active; 1 = hovering; 2 = touching; 3 = hovering after touching
+        /** @type {import('text-scanner').PenPointerState} */
+        this._penPointerState = 0;
         /** @type {Map<number, string>} */
         this._pointerIdTypeMap = new Map();
 

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -1388,7 +1388,7 @@ export class TextScanner extends EventDispatcher {
                 return input.scanOnPenMove;
             case 3: // hovering after touching
                 return input.scanOnPenReleaseHover;
-            default: // not active
+            case 0: // not active
                 return false;
         }
     }

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -1382,13 +1382,13 @@ export class TextScanner extends EventDispatcher {
                 return input.scanOnPenRelease;
         }
         switch (this._penPointerState) {
-            case 1: // hovering
+            case 1:
                 return input.scanOnPenHover;
-            case 2: // touching
+            case 2:
                 return input.scanOnPenMove;
-            case 3: // hovering after touching
+            case 3:
                 return input.scanOnPenReleaseHover;
-            case 0: // not active
+            case 0:
                 return false;
         }
     }

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -179,8 +179,8 @@ export class DictionaryImportController {
                 for (const label of statusLabels) { label.textContent = statusString; }
 
                 switch (stepIndex2) {
-                    case -2: // Initialize
-                    case 5: // Data import
+                    case -2:
+                    case 5:
                         this._triggerStorageChanged();
                         break;
                 }

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -216,7 +216,7 @@ export class DictionaryImportController {
      */
     _getImportLabel(stepIndex) {
         switch (stepIndex) {
-            case -2:
+            case -2: return '';
             case -1:
             case 0: return 'Loading dictionary';
             case 1: return 'Loading schemas';

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -161,6 +161,7 @@ export class DictionaryImportController {
             };
 
             let statusPrefix = '';
+            /** @type {import('dictionary-importer.js').ImportStep} */
             let stepIndex = -2;
             /** @type {import('dictionary-worker').ImportProgressCallback} */
             const onProgress = (data) => {
@@ -210,11 +211,12 @@ export class DictionaryImportController {
     }
 
     /**
-     * @param {number} stepIndex
+     * @param {import('dictionary-importer').ImportStep} stepIndex
      * @returns {string}
      */
     _getImportLabel(stepIndex) {
         switch (stepIndex) {
+            case -2:
             case -1:
             case 0: return 'Loading dictionary';
             case 1: return 'Loading schemas';
@@ -222,7 +224,6 @@ export class DictionaryImportController {
             case 3: return 'Formatting data';
             case 4: return 'Importing media';
             case 5: return 'Importing data';
-            default: return '';
         }
     }
 

--- a/types/ext/dictionary-importer.d.ts
+++ b/types/ext/dictionary-importer.d.ts
@@ -23,9 +23,30 @@ import type * as StructuredContent from './structured-content';
 
 export type OnProgressCallback = (data: ProgressData) => void;
 
+/**
+ * An enum representing the import step.
+ *
+ * `-2` `-1` Dictionary import is uninitialized.
+ *
+ * `0` Load dictionary archive and validate index step.
+ *
+ * `1` Load schemas and get archive files step.
+ *
+ * `2` Load and validate dictionary data step.
+ *
+ * `3` Format dictionary data and extended data support step.
+ *
+ * `4` Resolve async requirements and import media step.
+ *
+ * `5` Add dictionary descriptor and import data step.
+ */
+export type ImportStep = -2 | -1 | 0 | 1 | 2 | 3 | 4 | 5;
+
+export type ImportStepCount = 6;
+
 export type ProgressData = {
-    stepIndex: number;
-    stepCount: number;
+    stepIndex: ImportStep;
+    stepCount: ImportStepCount;
     index: number;
     count: number;
 };

--- a/types/ext/dom-text-scanner.d.ts
+++ b/types/ext/dom-text-scanner.d.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * An enum representing the attributes of the character.
+ *
+ * `0` Character should be ignored.
+ *
+ * `1` Character is collapsible whitespace.
+ *
+ * `2` Character should be added to the content.
+ *
+ * `3` Character should be added to the content and is a newline.
+ */
+export type CharacterAttributesEnum = 0 | 1 | 2 | 3;

--- a/types/ext/dom-text-scanner.d.ts
+++ b/types/ext/dom-text-scanner.d.ts
@@ -27,3 +27,13 @@
  * `3` Character should be added to the content and is a newline.
  */
 export type CharacterAttributesEnum = 0 | 1 | 2 | 3;
+
+export type SeekTextNoteDetails = {
+    done: boolean;
+    lineHasWhitespace: boolean;
+    lineHasContent: boolean;
+    content: string;
+    offset: number;
+    remainder: number;
+    newlines: number;
+};

--- a/types/ext/log.d.ts
+++ b/types/ext/log.d.ts
@@ -22,3 +22,14 @@ export type LoggerEventType = 'log';
 export type LogContext = {
     url: string;
 };
+
+/**
+ * An enum representing the log error level.
+ *
+ * `0` _log_, _info_, _debug_ level.
+ *
+ * `1` _warn_ level.
+ *
+ * `2` _error_ level.
+ */
+export type LogErrorLevelValue = 0 | 1 | 2;

--- a/types/ext/text-scanner.d.ts
+++ b/types/ext/text-scanner.d.ts
@@ -185,6 +185,19 @@ export type PointerEventType = (
     'script'
 );
 
+/**
+ * An enum representing the pen pointer state.
+ *
+ * `0` Not active.
+ *
+ * `1` Hovering.
+ *
+ * `2` Touching.
+ *
+ * `3` Hovering after touching.
+ */
+export type PenPointerState = 0 | 1 | 2 | 3;
+
 export type SentenceTerminatorMap = Map<string, [includeCharacterAtStart: boolean, includeCharacterAtEnd: boolean]>;
 
 export type SentenceForwardQuoteMap = Map<string, [character: string, includeCharacterAtStart: boolean]>;


### PR DESCRIPTION
This change narrows down the number type to an union of number literals to represent an enum. It also changes the if else matching pattern to switch statements to more closely match the enum matching patterns in other programming languages, as well as already existing code inside the project.

Part of the movement towards type safety. 