### PR TITLE
Template helper function improvements

### DIFF
--- a/types/ext/template-renderer.d.ts
+++ b/types/ext/template-renderer.d.ts
@@ -55,8 +55,8 @@ export type DataType = {
 export type HelperOptionsFunction<TResult = unknown> = (context: unknown) => TResult;
 
 export type HelperOptions = {
-    fn: HelperOptionsFunction;
-    inverse: HelperOptionsFunction;
+    fn?: HelperOptionsFunction;
+    inverse?: HelperOptionsFunction;
     hash: Core.SafeAny;
     data?: Core.SafeAny;
 };


### PR DESCRIPTION
Fixes #437. Was due to the different modalities that helpers can be used in:

The following would work:

```handlebars
{{~#*inline "test"~}}
    {{~#scope~}}
        {{~#regexMatch "test" "gu"~}}test{{~/regexMatch~}}
    {{~/scope~}}
{{~/inline~}}
{{~> (lookup . "marker") ~}}
```

The following would not work:

```handlebars
{{~#*inline "test"~}}
    {{~#scope~}}
        {{~set "value" (regexMatch "test" "gu" "test")}}
    {{~/scope~}}
{{~/inline~}}
{{~> (lookup . "marker") ~}}
```