### PR TITLE
Script manager cleanup

### DIFF
--- a/ext/js/accessibility/accessibility-controller.js
+++ b/ext/js/accessibility/accessibility-controller.js
@@ -16,19 +16,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import {isContentScriptRegistered, registerContentScript, unregisterContentScript} from '../background/script-manager.js';
 import {log} from '../core.js';
 
 /**
  * This class controls the registration of accessibility handlers.
  */
 export class AccessibilityController {
-    /**
-     * Creates a new instance.
-     * @param {import('../background/script-manager.js').ScriptManager} scriptManager An instance of the `ScriptManager` class.
-     */
-    constructor(scriptManager) {
-        /** @type {import('../background/script-manager.js').ScriptManager} */
-        this._scriptManager = scriptManager;
+    constructor() {
         /** @type {?import('core').TokenObject} */
         this._updateGoogleDocsAccessibilityToken = null;
         /** @type {?Promise<void>} */
@@ -90,7 +85,7 @@ export class AccessibilityController {
         const id = 'googleDocsAccessibility';
         try {
             if (forceGoogleDocsHtmlRenderingAny) {
-                if (await this._scriptManager.isContentScriptRegistered(id)) { return; }
+                if (await isContentScriptRegistered(id)) { return; }
                 /** @type {import('script-manager').RegistrationDetails} */
                 const details = {
                     allFrames: true,
@@ -98,9 +93,9 @@ export class AccessibilityController {
                     runAt: 'document_start',
                     js: ['js/accessibility/google-docs.js']
                 };
-                await this._scriptManager.registerContentScript(id, details);
+                await registerContentScript(id, details);
             } else {
-                await this._scriptManager.unregisterContentScript(id);
+                await unregisterContentScript(id);
             }
         } catch (e) {
             log.error(e);

--- a/ext/js/accessibility/accessibility-controller.js
+++ b/ext/js/accessibility/accessibility-controller.js
@@ -94,9 +94,7 @@ export class AccessibilityController {
                 /** @type {import('script-manager').RegistrationDetails} */
                 const details = {
                     allFrames: true,
-                    matchAboutBlank: true,
                     matches: ['*://docs.google.com/*'],
-                    urlMatches: '^[^:]*://docs\\.google\\.com/[\\w\\W]*$',
                     runAt: 'document_start',
                     js: ['js/accessibility/google-docs.js']
                 };

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -40,7 +40,7 @@ import {MediaUtil} from '../media/media-util.js';
 import {ClipboardReaderProxy, DictionaryDatabaseProxy, OffscreenProxy, TranslatorProxy} from './offscreen-proxy.js';
 import {ProfileConditionsUtil} from './profile-conditions-util.js';
 import {RequestBuilder} from './request-builder.js';
-import {ScriptManager} from './script-manager.js';
+import {injectStylesheet} from './script-manager.js';
 
 /**
  * This class controls the core logic of the extension, including API calls
@@ -110,10 +110,8 @@ export class Backend {
         });
         /** @type {OptionsUtil} */
         this._optionsUtil = new OptionsUtil();
-        /** @type {ScriptManager} */
-        this._scriptManager = new ScriptManager();
         /** @type {AccessibilityController} */
-        this._accessibilityController = new AccessibilityController(this._scriptManager);
+        this._accessibilityController = new AccessibilityController();
 
         /** @type {?number} */
         this._searchPopupTabId = null;
@@ -650,7 +648,7 @@ export class Backend {
     async _onApiInjectStylesheet({type, value}, sender) {
         const {frameId, tab} = sender;
         if (typeof tab !== 'object' || tab === null || typeof tab.id !== 'number') { throw new Error('Invalid tab'); }
-        return await this._scriptManager.injectStylesheet(type, value, tab.id, frameId, false);
+        return await injectStylesheet(type, value, tab.id, frameId, false);
     }
 
     /** @type {import('api').ApiHandler<'getStylesheetContent'>} */

--- a/ext/js/background/script-manager.js
+++ b/ext/js/background/script-manager.js
@@ -183,7 +183,7 @@ export class ScriptManager {
      * @returns {chrome.scripting.RegisteredContentScript}
      */
     _createContentScriptRegistrationOptionsChrome(details, id) {
-        const {css, js} = details;
+        const {css, js, allFrames, excludeMatches, matches, runAt} = details;
         /** @type {chrome.scripting.RegisteredContentScript} */
         const options = {
             id: id,
@@ -195,16 +195,6 @@ export class ScriptManager {
         if (Array.isArray(js)) {
             options.js = [...js];
         }
-        this._initializeContentScriptRegistrationOptionsGeneric(details, options);
-        return options;
-    }
-
-    /**
-     * @param {import('script-manager').RegistrationDetails} details
-     * @param {chrome.scripting.RegisteredContentScript|browser.contentScripts.RegisteredContentScriptOptions} options
-     */
-    _initializeContentScriptRegistrationOptionsGeneric(details, options) {
-        const {allFrames, excludeMatches, matches, runAt} = details;
         if (typeof allFrames !== 'undefined') {
             options.allFrames = allFrames;
         }
@@ -217,5 +207,6 @@ export class ScriptManager {
         if (typeof runAt !== 'undefined') {
             options.runAt = runAt;
         }
+        return options;
     }
 }

--- a/ext/js/background/script-manager.js
+++ b/ext/js/background/script-manager.js
@@ -154,19 +154,6 @@ export class ScriptManager {
         return true;
     }
 
-    /**
-     * Gets the optional permissions required to register a content script.
-     * @returns {string[]} An array of the required permissions, which may be empty.
-     */
-    getRequiredContentScriptRegistrationPermissions() {
-        if (isObject(chrome.scripting) && typeof chrome.scripting.registerContentScripts === 'function') {
-            return [];
-        }
-
-        // Fallback
-        return ['webNavigation'];
-    }
-
     // Private
 
     /**
@@ -253,27 +240,6 @@ export class ScriptManager {
 
     /**
      * @param {import('script-manager').RegistrationDetails} details
-     * @returns {browser.contentScripts.RegisteredContentScriptOptions}
-     */
-    _createContentScriptRegistrationOptionsFirefox(details) {
-        const {css, js, matchAboutBlank} = details;
-        /** @type {browser.contentScripts.RegisteredContentScriptOptions} */
-        const options = {};
-        if (typeof matchAboutBlank !== 'undefined') {
-            options.matchAboutBlank = matchAboutBlank;
-        }
-        if (Array.isArray(css)) {
-            options.css = css.map((file) => ({file}));
-        }
-        if (Array.isArray(js)) {
-            options.js = js.map((file) => ({file}));
-        }
-        this._initializeContentScriptRegistrationOptionsGeneric(details, options);
-        return options;
-    }
-
-    /**
-     * @param {import('script-manager').RegistrationDetails} details
      * @param {string} id
      * @returns {chrome.scripting.RegisteredContentScript}
      */
@@ -312,15 +278,6 @@ export class ScriptManager {
         if (typeof runAt !== 'undefined') {
             options.runAt = runAt;
         }
-    }
-
-    /**
-     * @param {string[]} array
-     * @param {boolean} firefoxConvention
-     * @returns {string[]|browser.extensionTypes.ExtensionFileOrCode[]}
-     */
-    _convertFileArray(array, firefoxConvention) {
-        return firefoxConvention ? array.map((file) => ({file})) : [...array];
     }
 
     /**

--- a/ext/js/background/script-manager.js
+++ b/ext/js/background/script-manager.js
@@ -183,7 +183,7 @@ export class ScriptManager {
      * @returns {chrome.scripting.RegisteredContentScript}
      */
     _createContentScriptRegistrationOptionsChrome(details, id) {
-        const {css, js, allFrames, excludeMatches, matches, runAt} = details;
+        const {css, js, allFrames, matches, runAt} = details;
         /** @type {chrome.scripting.RegisteredContentScript} */
         const options = {
             id: id,
@@ -197,9 +197,6 @@ export class ScriptManager {
         }
         if (typeof allFrames !== 'undefined') {
             options.allFrames = allFrames;
-        }
-        if (Array.isArray(excludeMatches)) {
-            options.excludeMatches = [...excludeMatches];
         }
         if (Array.isArray(matches)) {
             options.matches = [...matches];

--- a/ext/js/background/script-manager.js
+++ b/ext/js/background/script-manager.js
@@ -130,15 +130,19 @@ export class ScriptManager {
     /**
      * Unregisters a previously registered content script.
      * @param {string} id The identifier passed to a previous call to `registerContentScript`.
-     * @returns {Promise<boolean>} `true` if the content script was unregistered, `false` otherwise.
+     * @returns {Promise<void>}
      */
     async unregisterContentScript(id) {
-        try {
-            await this._unregisterContentScriptMV3(id);
-            return true;
-        } catch (e) {
-            return false;
-        }
+        return new Promise((resolve, reject) => {
+            chrome.scripting.unregisterContentScripts({ids: [id]}, () => {
+                const e = chrome.runtime.lastError;
+                if (e) {
+                    reject(new Error(e.message));
+                } else {
+                    resolve();
+                }
+            });
+        });
     }
 
     // Private
@@ -168,23 +172,6 @@ export class ScriptManager {
                 } else {
                     const {frameId: frameId2, result} = results[0];
                     resolve({frameId: frameId2, result});
-                }
-            });
-        });
-    }
-
-    /**
-     * @param {string} id
-     * @returns {Promise<void>}
-     */
-    _unregisterContentScriptMV3(id) {
-        return new Promise((resolve, reject) => {
-            chrome.scripting.unregisterContentScripts({ids: [id]}, () => {
-                const e = chrome.runtime.lastError;
-                if (e) {
-                    reject(new Error(e.message));
-                } else {
-                    resolve();
                 }
             });
         });

--- a/ext/js/background/script-manager.js
+++ b/ext/js/background/script-manager.js
@@ -55,37 +55,6 @@ export function injectStylesheet(type, content, tabId, frameId, allFrames) {
 }
 
 /**
- * Injects a script into a tab.
- * @param {string} file The path to a file to inject.
- * @param {number} tabId The id of the tab to inject into.
- * @param {number|undefined} frameId The id of the frame to inject into.
- * @param {boolean} allFrames Whether or not the script should be injected into all frames.
- * @returns {Promise<{frameId: number|undefined, result: unknown}>} The id of the frame and the result of the script injection.
- */
-export function injectScript(file, tabId, frameId, allFrames) {
-    return new Promise((resolve, reject) => {
-        /** @type {chrome.scripting.ScriptInjection<unknown[], unknown>} */
-        const details = {
-            injectImmediately: true,
-            files: [file],
-            target: {tabId, allFrames}
-        };
-        if (!allFrames && typeof frameId === 'number') {
-            details.target.frameIds = [frameId];
-        }
-        chrome.scripting.executeScript(details, (results) => {
-            const e = chrome.runtime.lastError;
-            if (e) {
-                reject(new Error(e.message));
-            } else {
-                const {frameId: frameId2, result} = results[0];
-                resolve({frameId: frameId2, result});
-            }
-        });
-    });
-}
-
-/**
  * Checks whether or not a content script is registered.
  * @param {string} id The identifier used with a call to `registerContentScript`.
  * @returns {Promise<boolean>} `true` if a script is registered, `false` otherwise.

--- a/types/ext/script-manager.d.ts
+++ b/types/ext/script-manager.d.ts
@@ -21,26 +21,12 @@ export type RunAt = 'document_start' | 'document_end' | 'document_idle';
 export type RegistrationDetails = {
     /** Same as `matches` in the `content_scripts` manifest key. */
     matches: string[];
-
-    /** Regex match pattern to use as a fallback when native content script registration isn't supported. */
-    /** Should be equivalent to `matches`. */
-    urlMatches: string;
-
     /** Same as `run_at` in the `content_scripts` manifest key. */
     runAt: RunAt;
-
-    /** Same as `exclude_matches` in the `content_scripts` manifest key. */
-    excludeMatches?: string[];
-
-    /** Same as `match_about_blank` in the `content_scripts` manifest key. */
-    matchAboutBlank: boolean;
-
     /** Same as `all_frames` in the `content_scripts` manifest key. */
     allFrames: boolean;
-
     /** List of CSS paths. */
     css?: string[];
-
     /** List of script paths. */
     js?: string[];
 };


### PR DESCRIPTION
Simplify the script manager by removing old non-MV3 stuff. This is also an effort to more succinctly fix the google docs issues.

#235; #451