### PR TITLE
API map updates

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -371,7 +371,7 @@ export class Backend {
         });
     }
 
-    /** @type {import('extension').ChromeRuntimeOnMessageCallback<import('api').MessageAny>} */
+    /** @type {import('extension').ChromeRuntimeOnMessageCallback<import('api').ApiMessageAny>} */
     _onMessageWrapper(message, sender, sendResponse) {
         if (this._isPrepared) {
             return this._onMessage(message, sender, sendResponse);
@@ -394,7 +394,7 @@ export class Backend {
     }
 
     /**
-     * @param {import('api').MessageAny} message
+     * @param {import('api').ApiMessageAny} message
      * @param {chrome.runtime.MessageSender} sender
      * @param {(response?: unknown) => void} callback
      * @returns {boolean}

--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -73,7 +73,7 @@ export class OffscreenProxy {
 
     /**
      * @template {import('offscreen').MessageType} TMessageType
-     * @param {import('offscreen').Message<TMessageType>} message
+     * @param {import('offscreen').ApiMessage<TMessageType>} message
      * @returns {Promise<import('offscreen').OffscreenApiReturn<TMessageType>>}
      */
     sendMessagePromise(message) {

--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -72,9 +72,9 @@ export class OffscreenProxy {
     }
 
     /**
-     * @template {import('offscreen').MessageType} TMessageType
+     * @template {import('offscreen').ApiNames} TMessageType
      * @param {import('offscreen').ApiMessage<TMessageType>} message
-     * @returns {Promise<import('offscreen').OffscreenApiReturn<TMessageType>>}
+     * @returns {Promise<import('offscreen').ApiReturn<TMessageType>>}
      */
     sendMessagePromise(message) {
         return new Promise((resolve, reject) => {

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -171,7 +171,7 @@ export class Offscreen {
         this._translator.clearDatabaseCaches();
     }
 
-    /** @type {import('extension').ChromeRuntimeOnMessageCallback<import('offscreen').MessageAny>} */
+    /** @type {import('extension').ChromeRuntimeOnMessageCallback<import('offscreen').ApiMessageAny>} */
     _onMessage({action, params}, _sender, callback) {
         return invokeApiMapHandler(this._apiMap, action, params, [], callback);
     }

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -52,7 +52,7 @@ export class Offscreen {
 
 
         /* eslint-disable no-multi-spaces */
-        /** @type {import('offscreen').OffscreenApiMap} */
+        /** @type {import('offscreen').ApiMap} */
         this._apiMap = createApiMap([
             ['clipboardGetTextOffscreen',    this._getTextHandler.bind(this)],
             ['clipboardGetImageOffscreen',   this._getImageHandler.bind(this)],
@@ -78,22 +78,22 @@ export class Offscreen {
         chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
     }
 
-    /** @type {import('offscreen').OffscreenApiHandler<'clipboardGetTextOffscreen'>} */
+    /** @type {import('offscreen').ApiHandler<'clipboardGetTextOffscreen'>} */
     async _getTextHandler({useRichText}) {
         return await this._clipboardReader.getText(useRichText);
     }
 
-    /** @type {import('offscreen').OffscreenApiHandler<'clipboardGetImageOffscreen'>} */
+    /** @type {import('offscreen').ApiHandler<'clipboardGetImageOffscreen'>} */
     async _getImageHandler() {
         return await this._clipboardReader.getImage();
     }
 
-    /** @type {import('offscreen').OffscreenApiHandler<'clipboardSetBrowserOffscreen'>} */
+    /** @type {import('offscreen').ApiHandler<'clipboardSetBrowserOffscreen'>} */
     _setClipboardBrowser({value}) {
         this._clipboardReader.browser = value;
     }
 
-    /** @type {import('offscreen').OffscreenApiHandler<'databasePrepareOffscreen'>} */
+    /** @type {import('offscreen').ApiHandler<'databasePrepareOffscreen'>} */
     _prepareDatabaseHandler() {
         if (this._prepareDatabasePromise !== null) {
             return this._prepareDatabasePromise;
@@ -102,29 +102,29 @@ export class Offscreen {
         return this._prepareDatabasePromise;
     }
 
-    /** @type {import('offscreen').OffscreenApiHandler<'getDictionaryInfoOffscreen'>} */
+    /** @type {import('offscreen').ApiHandler<'getDictionaryInfoOffscreen'>} */
     async _getDictionaryInfoHandler() {
         return await this._dictionaryDatabase.getDictionaryInfo();
     }
 
-    /** @type {import('offscreen').OffscreenApiHandler<'databasePurgeOffscreen'>} */
+    /** @type {import('offscreen').ApiHandler<'databasePurgeOffscreen'>} */
     async _purgeDatabaseHandler() {
         return await this._dictionaryDatabase.purge();
     }
 
-    /** @type {import('offscreen').OffscreenApiHandler<'databaseGetMediaOffscreen'>} */
+    /** @type {import('offscreen').ApiHandler<'databaseGetMediaOffscreen'>} */
     async _getMediaHandler({targets}) {
         const media = await this._dictionaryDatabase.getMedia(targets);
         const serializedMedia = media.map((m) => ({...m, content: ArrayBufferUtil.arrayBufferToBase64(m.content)}));
         return serializedMedia;
     }
 
-    /** @type {import('offscreen').OffscreenApiHandler<'translatorPrepareOffscreen'>} */
+    /** @type {import('offscreen').ApiHandler<'translatorPrepareOffscreen'>} */
     _prepareTranslatorHandler({deinflectionReasons}) {
         this._translator.prepare(deinflectionReasons);
     }
 
-    /** @type {import('offscreen').OffscreenApiHandler<'findKanjiOffscreen'>} */
+    /** @type {import('offscreen').ApiHandler<'findKanjiOffscreen'>} */
     async _findKanjiHandler({text, options}) {
         /** @type {import('translation').FindKanjiOptions} */
         const modifiedOptions = {
@@ -134,7 +134,7 @@ export class Offscreen {
         return await this._translator.findKanji(text, modifiedOptions);
     }
 
-    /** @type {import('offscreen').OffscreenApiHandler<'findTermsOffscreen'>} */
+    /** @type {import('offscreen').ApiHandler<'findTermsOffscreen'>} */
     async _findTermsHandler({mode, text, options}) {
         const enabledDictionaryMap = new Map(options.enabledDictionaryMap);
         const excludeDictionaryDefinitions = (
@@ -161,12 +161,12 @@ export class Offscreen {
         return this._translator.findTerms(mode, text, modifiedOptions);
     }
 
-    /** @type {import('offscreen').OffscreenApiHandler<'getTermFrequenciesOffscreen'>} */
+    /** @type {import('offscreen').ApiHandler<'getTermFrequenciesOffscreen'>} */
     _getTermFrequenciesHandler({termReadingList, dictionaries}) {
         return this._translator.getTermFrequencies(termReadingList, dictionaries);
     }
 
-    /** @type {import('offscreen').OffscreenApiHandler<'clearDatabaseCachesOffscreen'>} */
+    /** @type {import('offscreen').ApiHandler<'clearDatabaseCachesOffscreen'>} */
     _clearDatabaseCachesHandler() {
         this._translator.clearDatabaseCaches();
     }

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -381,7 +381,7 @@ export class API {
      * @returns {Promise<import('api').ApiReturn<TAction>>}
      */
     _invoke(action, params) {
-        /** @type {import('api').ApiMessageAny} */
+        /** @type {import('api').ApiMessage<TAction>} */
         const data = {action, params};
         return new Promise((resolve, reject) => {
             try {

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -381,7 +381,7 @@ export class API {
      * @returns {Promise<import('api').ApiReturn<TAction>>}
      */
     _invoke(action, params) {
-        /** @type {import('api').MessageAny} */
+        /** @type {import('api').ApiMessageAny} */
         const data = {action, params};
         return new Promise((resolve, reject) => {
             try {

--- a/types/ext/api-map.d.ts
+++ b/types/ext/api-map.d.ts
@@ -109,7 +109,7 @@ export type ApiFunctionOrdered<TSurface extends ApiSurface, TName extends ApiNam
 ) => Promise<ApiReturn<TSurface[TName]>>;
 
 /** Type alias for a union of all params types. */
-export type ApiParamsAny<TSurface extends ApiSurface> = ApiParams<TSurface[keyof TSurface]>;
+export type ApiParamsAny<TSurface extends ApiSurface> = {[name in ApiNames<TSurface>]: ApiParams<TSurface[name]>}[ApiNames<TSurface>];
 
 /** Type alias for a union of all return types. */
-export type ApiReturnAny<TSurface extends ApiSurface> = ApiReturn<TSurface[keyof TSurface]>;
+export type ApiReturnAny<TSurface extends ApiSurface> = {[name in ApiNames<TSurface>]: ApiReturn<TSurface[name]>}[ApiNames<TSurface>];

--- a/types/ext/api.d.ts
+++ b/types/ext/api.d.ts
@@ -405,7 +405,7 @@ export type ApiReturn<TName extends ApiNames> = BaseApiReturn<ApiSurface[TName]>
 
 export type ApiParamsAny = BaseApiParamsAny<ApiSurface>;
 
-export type ApiMessageAny = ApiMessage<ApiNames>;
+export type ApiMessageAny = {[name in ApiNames]: ApiMessage<name>}[ApiNames];
 
 type ApiMessage<TName extends ApiNames> = {
     action: TName;

--- a/types/ext/api.d.ts
+++ b/types/ext/api.d.ts
@@ -405,9 +405,9 @@ export type ApiReturn<TName extends ApiNames> = BaseApiReturn<ApiSurface[TName]>
 
 export type ApiParamsAny = BaseApiParamsAny<ApiSurface>;
 
-export type MessageAny = Message<ApiNames>;
+export type ApiMessageAny = ApiMessage<ApiNames>;
 
-type Message<TName extends ApiNames> = {
+type ApiMessage<TName extends ApiNames> = {
     action: TName;
     params: ApiParams<TName>;
 };

--- a/types/ext/offscreen.d.ts
+++ b/types/ext/offscreen.d.ts
@@ -95,7 +95,7 @@ type OffscreenApiSurface = {
 
 export type ApiMessage<TName extends MessageType> = (
     OffscreenApiParams<TName> extends void ?
-        {action: TName} :
+        {action: TName, params?: never} :
         {action: TName, params: OffscreenApiParams<TName>}
 );
 
@@ -131,4 +131,4 @@ export type OffscreenApiParams<TName extends MessageType> = ApiParams<OffscreenA
 
 export type OffscreenApiReturn<TName extends MessageType> = ApiReturn<OffscreenApiSurface[TName]>;
 
-export type ApiMessageAny = ApiMessage<MessageType>;
+export type ApiMessageAny = {[name in MessageType]: ApiMessage<name>}[MessageType];

--- a/types/ext/offscreen.d.ts
+++ b/types/ext/offscreen.d.ts
@@ -22,9 +22,16 @@ import type * as DictionaryImporter from './dictionary-importer';
 import type * as Environment from './environment';
 import type * as Translation from './translation';
 import type * as Translator from './translator';
-import type {ApiMap, ApiMapInit, ApiHandler, ApiParams, ApiReturn, ApiNames} from './api-map';
+import type {
+    ApiMap as BaseApiMap,
+    ApiMapInit as BaseApiMapInit,
+    ApiHandler as BaseApiHandler,
+    ApiParams as BaseApiParams,
+    ApiReturn as BaseApiReturn,
+    ApiNames as BaseApiNames,
+} from './api-map';
 
-type OffscreenApiSurface = {
+type ApiSurface = {
     databasePrepareOffscreen: {
         params: void;
         return: void;
@@ -93,13 +100,13 @@ type OffscreenApiSurface = {
     };
 };
 
-export type ApiMessage<TName extends MessageType> = (
-    OffscreenApiParams<TName> extends void ?
+export type ApiMessage<TName extends ApiNames> = (
+    ApiParams<TName> extends void ?
         {action: TName, params?: never} :
-        {action: TName, params: OffscreenApiParams<TName>}
+        {action: TName, params: ApiParams<TName>}
 );
 
-export type MessageType = ApiNames<OffscreenApiSurface>;
+export type ApiNames = BaseApiNames<ApiSurface>;
 
 export type FindKanjiOptionsOffscreen = Omit<Translation.FindKanjiOptions, 'enabledDictionaryMap'> & {
     enabledDictionaryMap: [
@@ -121,14 +128,14 @@ export type FindTermsTextReplacementOffscreen = Omit<Translation.FindTermsTextRe
     pattern: string;
 };
 
-export type OffscreenApiMap = ApiMap<OffscreenApiSurface>;
+export type ApiMap = BaseApiMap<ApiSurface>;
 
-export type OffscreenApiMapInit = ApiMapInit<OffscreenApiSurface>;
+export type ApiMapInit = BaseApiMapInit<ApiSurface>;
 
-export type OffscreenApiHandler<TName extends MessageType> = ApiHandler<OffscreenApiSurface[TName]>;
+export type ApiHandler<TName extends ApiNames> = BaseApiHandler<ApiSurface[TName]>;
 
-export type OffscreenApiParams<TName extends MessageType> = ApiParams<OffscreenApiSurface[TName]>;
+export type ApiParams<TName extends ApiNames> = BaseApiParams<ApiSurface[TName]>;
 
-export type OffscreenApiReturn<TName extends MessageType> = ApiReturn<OffscreenApiSurface[TName]>;
+export type ApiReturn<TName extends ApiNames> = BaseApiReturn<ApiSurface[TName]>;
 
-export type ApiMessageAny = {[name in MessageType]: ApiMessage<name>}[MessageType];
+export type ApiMessageAny = {[name in ApiNames]: ApiMessage<name>}[ApiNames];

--- a/types/ext/offscreen.d.ts
+++ b/types/ext/offscreen.d.ts
@@ -93,7 +93,7 @@ type OffscreenApiSurface = {
     };
 };
 
-export type Message<TName extends MessageType> = (
+export type ApiMessage<TName extends MessageType> = (
     OffscreenApiParams<TName> extends void ?
         {action: TName} :
         {action: TName, params: OffscreenApiParams<TName>}
@@ -131,4 +131,4 @@ export type OffscreenApiParams<TName extends MessageType> = ApiParams<OffscreenA
 
 export type OffscreenApiReturn<TName extends MessageType> = ApiReturn<OffscreenApiSurface[TName]>;
 
-export type MessageAny = Message<MessageType>;
+export type ApiMessageAny = ApiMessage<MessageType>;


### PR DESCRIPTION
This changes some of the `[something]Any` types which were improperly defined. It also renames the `Offscreen*` API map types to not have the `Offscreen` prefix, for consistency with the other API maps. If a prefix is needed, it should be aliased where it is imported, otherwise it is redundant, especially in JS code.