### PR TITLE
Add explicit passive option to touchstart event

### DIFF
--- a/ext/js/display/display-resizer.js
+++ b/ext/js/display/display-resizer.js
@@ -45,7 +45,7 @@ export class DisplayResizer {
         if (this._handle === null) { return; }
 
         this._handle.addEventListener('mousedown', this._onFrameResizerMouseDown.bind(this), false);
-        this._handle.addEventListener('touchstart', this._onFrameResizerTouchStart.bind(this), false);
+        this._handle.addEventListener('touchstart', this._onFrameResizerTouchStart.bind(this), {passive: false, capture: false});
     }
 
     // Private

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -1099,7 +1099,7 @@ export class TextScanner extends EventDispatcher {
     _getTouchEventListeners(capture) {
         return [
             [this._node, 'auxclick', this._onAuxClick.bind(this), capture],
-            [this._node, 'touchstart', this._onTouchStart.bind(this), capture],
+            [this._node, 'touchstart', this._onTouchStart.bind(this), {passive: true, capture}],
             [this._node, 'touchend', this._onTouchEnd.bind(this), capture],
             [this._node, 'touchcancel', this._onTouchCancel.bind(this), capture],
             [this._node, 'touchmove', this._onTouchMove.bind(this), {passive: false, capture}],
@@ -1130,7 +1130,7 @@ export class TextScanner extends EventDispatcher {
         if (documentElement !== null) {
             entries.push([documentElement, 'mousedown', this._onSearchClickMouseDown.bind(this), capture]);
             if (this._touchInputEnabled) {
-                entries.push([documentElement, 'touchstart', this._onSearchClickTouchStart.bind(this), capture]);
+                entries.push([documentElement, 'touchstart', this._onSearchClickTouchStart.bind(this), {passive: true, capture}]);
             }
         }
         return entries;


### PR DESCRIPTION
This change suppresses some warnings:

```
display-resizer.js:48 [Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event.
Consider marking event handler as 'passive' to make the page more responsive.
See https://www.chromestatus.com/feature/5745543795965952

core.js:460 [Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event.
Consider marking event handler as 'passive' to make the page more responsive.
See https://www.chromestatus.com/feature/5745543795965952
```