### PR TITLE
improve dictionary validation

### DIFF
--- a/dev/dictionary-validate.js
+++ b/dev/dictionary-validate.js
@@ -39,7 +39,7 @@ function readSchema(relativeFileName) {
 /**
  * @param {import('dev/schema-validate').ValidateMode} mode
  * @param {import('jszip')} zip
- * @param {import('dev/dictionary-validate').SchemasDetail[]} schemasDetails
+ * @param {import('dev/dictionary-validate').SchemasDetails} schemasDetails
  */
 async function validateDictionaryBanks(mode, zip, schemasDetails) {
     for (const [fileName, file] of Object.entries(zip.files)) {
@@ -95,7 +95,7 @@ export async function validateDictionary(mode, archive, schemas) {
         throw e2;
     }
 
-    /** @type {import('dev/dictionary-validate').SchemasDetail[]} */
+    /** @type {import('dev/dictionary-validate').SchemasDetails} */
     const schemasDetails = [
         [/^term_bank_(\d+)\.json$/, version === 1 ? schemas.termBankV1 : schemas.termBankV3],
         [/^term_meta_bank_(\d+)\.json$/, schemas.termMetaBankV3],

--- a/dev/dictionary-validate.js
+++ b/dev/dictionary-validate.js
@@ -95,7 +95,7 @@ export async function validateDictionary(mode, archive, schemas) {
         throw e2;
     }
 
-    /** @type {import('dev/dictionary-validate').SchemasDetails} */
+    /** @type {import('dev/dictionary-validate').SchemasDetail[]} */
     const schemasDetails = [
         [/^term_bank_(\d+)\.json$/, version === 1 ? schemas.termBankV1 : schemas.termBankV3],
         [/^term_meta_bank_(\d+)\.json$/, schemas.termMetaBankV3],

--- a/dev/dictionary-validate.js
+++ b/dev/dictionary-validate.js
@@ -39,7 +39,7 @@ function readSchema(relativeFileName) {
 /**
  * @param {import('dev/schema-validate').ValidateMode} mode
  * @param {import('jszip')} zip
- * @param {import('dev/dictionary-validate').SchemasDetails} schemasDetails
+ * @param {import('dev/dictionary-validate').SchemasDetail[]} schemasDetails
  */
 async function validateDictionaryBanks(mode, zip, schemasDetails) {
     for (const [fileName, file] of Object.entries(zip.files)) {

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -693,16 +693,16 @@ export class DictionaryImporter {
         const results = new Map();
         for (const [fileName, fileEntry] of fileMap.entries()) {
             for (const [fileType, fileNameFormat] of queryDetails) {
-                if (!fileNameFormat.test(fileName)) { continue; }
-
                 let entries = results.get(fileType);
                 if (typeof entries === 'undefined') {
                     entries = [];
                     results.set(fileType, entries);
                 }
 
-                entries.push(fileEntry);
-                break;
+                if (fileNameFormat.test(fileName)) {
+                    entries.push(fileEntry);
+                    break;
+                }
             }
         }
         return results;

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -114,13 +114,13 @@ export class DictionaryImporter {
 
         // Files
         /** @type {import('dictionary-importer').QueryDetails} */
-        const queryDetails = new Map([
+        const queryDetails = [
             ['termFiles', /^term_bank_(\d+)\.json$/],
             ['termMetaFiles', /^term_meta_bank_(\d+)\.json$/],
             ['kanjiFiles', /^kanji_bank_(\d+)\.json$/],
             ['kanjiMetaFiles', /^kanji_meta_bank_(\d+)\.json$/],
             ['tagFiles', /^tag_bank_(\d+)\.json$/]
-        ]);
+        ];
         const {termFiles, termMetaFiles, kanjiFiles, kanjiMetaFiles, tagFiles} = Object.fromEntries(this._getArchiveFiles(fileMap, queryDetails));
 
         // Load data
@@ -691,18 +691,18 @@ export class DictionaryImporter {
     _getArchiveFiles(fileMap, queryDetails) {
         /** @type {import('dictionary-importer').QueryResult} */
         const results = new Map();
-        for (const [name, value] of fileMap.entries()) {
-            for (const [fileType, fileNameFormat] of queryDetails.entries()) {
+        for (const [fileName, fileEntry] of fileMap.entries()) {
+            for (const [fileType, fileNameFormat] of queryDetails) {
+                if (!fileNameFormat.test(fileName)) { continue; }
+
                 let entries = results.get(fileType);
                 if (typeof entries === 'undefined') {
                     entries = [];
                     results.set(fileType, entries);
                 }
 
-                if (fileNameFormat.test(name)) {
-                    entries.push(value);
-                    break;
-                }
+                entries.push(fileEntry);
+                break;
             }
         }
         return results;

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -691,18 +691,19 @@ export class DictionaryImporter {
     _getArchiveFiles(fileMap, queryDetails) {
         /** @type {import('dictionary-importer').QueryResult} */
         const results = new Map();
+
+        for (const [fileType] of queryDetails) {
+            results.set(fileType, []);
+        }
+
         for (const [fileName, fileEntry] of fileMap.entries()) {
             for (const [fileType, fileNameFormat] of queryDetails) {
-                let entries = results.get(fileType);
-                if (typeof entries === 'undefined') {
-                    entries = [];
-                    results.set(fileType, entries);
-                }
+                if (!fileNameFormat.test(fileName)) { continue; }
+                const entries = results.get(fileType);
 
-                if (fileNameFormat.test(fileName)) {
-                    entries.push(fileEntry);
-                    break;
-                }
+                // @ts-expect-error - entries should be initialized
+                entries.push(fileEntry);
+                break;
             }
         }
         return results;

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -113,7 +113,7 @@ export class DictionaryImporter {
         const dataBankSchemas = this._getDataBankSchemas(version);
 
         // Files
-        /** @type {import('dictionary-importer').QueryDetail[]} */
+        /** @type {import('dictionary-importer').QueryDetails} */
         const queryDetails = [
             ['termFiles', /^term_bank_(\d+)\.json$/],
             ['termMetaFiles', /^term_meta_bank_(\d+)\.json$/],
@@ -685,7 +685,7 @@ export class DictionaryImporter {
 
     /**
      * @param {import('dictionary-importer').ArchiveFileMap} fileMap
-     * @param {import('dictionary-importer').QueryDetail[]} queryDetails
+     * @param {import('dictionary-importer').QueryDetails} queryDetails
      * @returns {import('dictionary-importer').QueryResult}
      */
     _getArchiveFiles(fileMap, queryDetails) {

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -113,7 +113,7 @@ export class DictionaryImporter {
         const dataBankSchemas = this._getDataBankSchemas(version);
 
         // Files
-        /** @type {import('dictionary-importer').QueryDetails} */
+        /** @type {import('dictionary-importer').QueryDetail[]} */
         const queryDetails = [
             ['termFiles', /^term_bank_(\d+)\.json$/],
             ['termMetaFiles', /^term_meta_bank_(\d+)\.json$/],
@@ -685,7 +685,7 @@ export class DictionaryImporter {
 
     /**
      * @param {import('dictionary-importer').ArchiveFileMap} fileMap
-     * @param {import('dictionary-importer').QueryDetails} queryDetails
+     * @param {import('dictionary-importer').QueryDetail[]} queryDetails
      * @returns {import('dictionary-importer').QueryResult}
      */
     _getArchiveFiles(fileMap, queryDetails) {

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -701,9 +701,10 @@ export class DictionaryImporter {
                 if (!fileNameFormat.test(fileName)) { continue; }
                 const entries = results.get(fileType);
 
-                // @ts-expect-error - entries should be initialized
-                entries.push(fileEntry);
-                break;
+                if (typeof entries !== 'undefined') {
+                    entries.push(fileEntry);
+                    break;
+                }
             }
         }
         return results;

--- a/types/dev/dictionary-validate.d.ts
+++ b/types/dev/dictionary-validate.d.ts
@@ -31,6 +31,6 @@ export type Schemas = {
 };
 
 /**
- * A map of regular expression identifiers of file types inside a dictionary and its corresponding schemas.
+ * A tuple of a regular expression identifier of file types inside a dictionary and its corresponding schema.
  */
-export type SchemasDetails = [RegExp, unknown][];
+export type SchemasDetail = [RegExp, unknown];

--- a/types/dev/dictionary-validate.d.ts
+++ b/types/dev/dictionary-validate.d.ts
@@ -29,3 +29,8 @@ export type Schemas = {
     termBankV3: Schema;
     termMetaBankV3: Schema;
 };
+
+/**
+ * A map of regular expression identifiers of file types inside a dictionary and its corresponding schemas.
+ */
+export type SchemasDetails = [RegExp, unknown][];

--- a/types/dev/dictionary-validate.d.ts
+++ b/types/dev/dictionary-validate.d.ts
@@ -31,6 +31,6 @@ export type Schemas = {
 };
 
 /**
- * A tuple of a regular expression identifier of file types inside a dictionary and its corresponding schema.
+ * An array of tuples of a regular expression for file types inside a dictionary and its corresponding schema.
  */
-export type SchemasDetail = [RegExp, unknown];
+export type SchemasDetails = [fileNameFormat: RegExp, schema: unknown][];

--- a/types/ext/dictionary-importer.d.ts
+++ b/types/ext/dictionary-importer.d.ts
@@ -113,9 +113,9 @@ export type ImportRequirementContext = {
 export type ArchiveFileMap = Map<string, ZipJS.Entry>;
 
 /**
- * A map of file types inside a dictionary and its corresponding regular expressions.
+ * A tuple of a file type inside a dictionary and its corresponding regular expression.
  */
-export type QueryDetails = [string, RegExp][];
+export type QueryDetail = [string, RegExp];
 
 /**
  * A map of file types inside a dictionary and its matching entries.

--- a/types/ext/dictionary-importer.d.ts
+++ b/types/ext/dictionary-importer.d.ts
@@ -115,7 +115,7 @@ export type ArchiveFileMap = Map<string, ZipJS.Entry>;
 /**
  * A map of file types inside a dictionary and its corresponding regular expressions.
  */
-export type QueryDetails = Map<string, RegExp>;
+export type QueryDetails = [string, RegExp][];
 
 /**
  * A map of file types inside a dictionary and its matching entries.

--- a/types/ext/dictionary-importer.d.ts
+++ b/types/ext/dictionary-importer.d.ts
@@ -113,9 +113,9 @@ export type ImportRequirementContext = {
 export type ArchiveFileMap = Map<string, ZipJS.Entry>;
 
 /**
- * A tuple of a file type inside a dictionary and its corresponding regular expression.
+ * An array of tuples of a file type inside a dictionary and its corresponding regular expression.
  */
-export type QueryDetail = [string, RegExp];
+export type QueryDetails = [fileType: string, fileNameFormat: RegExp][];
 
 /**
  * A map of file types inside a dictionary and its matching entries.


### PR DESCRIPTION
Solves #507 (dev dictionary validation now validates files with skipped indexes).
  Also changed the `QueryDetails` in dictionary-import.js `_getArchiveFiles` to be a simple 2d array as opposed to a Map because it is more performant when looped over.