### PR TITLE
Allow `text-shadow` style in dictionary structured content

### DIFF
--- a/ext/data/schemas/dictionary-term-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-bank-v3-schema.json
@@ -320,6 +320,9 @@
                     "enum": ["start", "end", "left", "right", "center", "justify", "justify-all", "match-parent"],
                     "default": "start"
                 },
+                "textShadow": {
+                    "type": "string"
+                },
                 "margin": {
                     "type": "string"
                 },

--- a/ext/js/display/sandbox/structured-content-generator.js
+++ b/ext/js/display/sandbox/structured-content-generator.js
@@ -354,6 +354,7 @@ export class StructuredContentGenerator {
             borderWidth,
             verticalAlign,
             textAlign,
+            textShadow,
             margin,
             marginTop,
             marginLeft,
@@ -376,6 +377,7 @@ export class StructuredContentGenerator {
         if (typeof backgroundColor === 'string') { style.backgroundColor = backgroundColor; }
         if (typeof verticalAlign === 'string') { style.verticalAlign = verticalAlign; }
         if (typeof textAlign === 'string') { style.textAlign = textAlign; }
+        if (typeof textShadow === 'string') { style.textShadow = textShadow; }
         if (typeof textDecorationLine === 'string') {
             style.textDecoration = textDecorationLine;
         } else if (Array.isArray(textDecorationLine)) {

--- a/test/data/dictionaries/valid-dictionary1/term_bank_2.json
+++ b/test/data/dictionaries/valid-dictionary1/term_bank_2.json
@@ -103,6 +103,8 @@
                                                             {
                                                                 "tag": "span",
                                                                 "style": {
+                                                                    "color": "#dd2121",
+                                                                    "textShadow": "0.5px 0.5px 1px gray",
                                                                     "textDecorationLine": "underline",
                                                                     "textDecorationStyle": "wavy",
                                                                     "textDecorationColor": "red"

--- a/types/ext/structured-content.d.ts
+++ b/types/ext/structured-content.d.ts
@@ -63,6 +63,7 @@ export type StructuredContentStyle = {
     borderWidth?: string;
     verticalAlign?: VerticalAlign;
     textAlign?: TextAlign;
+    textShadow?: string;
     margin?: string;
     marginTop?: number | string;
     marginLeft?: number | string;


### PR DESCRIPTION
This style can be used to improve the contrast and legibility of text in some circumstances.

https://github.com/stephenmk/Jitendex/issues/52#issuecomment-1890385065