### PR TITLE
Add warning if available storage space is low

### DIFF
--- a/ext/settings.html
+++ b/ext/settings.html
@@ -140,6 +140,12 @@
                         </span>
                         <span class="storage-use-finite" hidden>
                             Yomitan is using approximately <span class="storage-usage">?</span> of <span class="storage-quota">?</span>.
+                            <div class="storage-exhaustion-alert warning-text margin-above">
+                                <div>
+                                    <b>Your system is running low on storage space.</b><br>
+                                    Importing dictionaries may fail.
+                                </div>
+                            </div>
                         </span>
                         <span class="storage-use-infinite" hidden>
                             Yomitan is permitted unlimited storage.

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -142,7 +142,7 @@
                             Yomitan is using approximately <span class="storage-usage">?</span> of <span class="storage-quota">?</span>.
                             <div class="storage-exhaustion-alert warning-text margin-above">
                                 <div>
-                                    <b>Your system is running low on storage space.</b><br>
+                                    <strong>Your system is running low on storage space.</strong><br>
                                     Importing dictionaries may fail.
                                 </div>
                             </div>


### PR DESCRIPTION
Adds a small warning if the users is running low on storage space.
For now, the threshold for rendering the alert is set/hardcoded to `3GB`.  

It will be rendered like this:
![yomitan-space-warning-image](https://github.com/themoeway/yomitan/assets/13659371/8aea7910-f090-4f2f-9cba-c5105f5795e7)

This PR indirectly addresses #356 and #395.