### PR TITLE
Remove note to zip or rename settings json in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -17,4 +17,4 @@ assignees: ''
 (e.g. 20.11.1.1)
 
 **Exported settings file**
-(If you think it might be relevant, create a settings export file using the _Export Settings_ button on the settings page; zip or rename the resulting file to .txt to attach to the issue.)
+(If you think it might be relevant, create a settings export file using the _Export Settings_ button on the settings page.)

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -17,4 +17,4 @@ assignees: ''
 (e.g. 20.11.1.1)
 
 **Exported settings file**
-(If you think it might be relevant, create a settings export file using the _Export Settings_ button on the settings page.)
+(If you think it might be relevant, create a settings export file using the _Export Settings_ button on the settings page and attach it to this issue.)


### PR DESCRIPTION
Github now supports directly uploading JSON files into issues. This note is no longer needed and may add confusion for some users.