### PR TITLE
WebExtension class

### DIFF
--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -226,7 +226,7 @@ export class Frontend {
         try {
             await this._updateOptionsInternal();
         } catch (e) {
-            if (!yomitan.isExtensionUnloaded) {
+            if (!yomitan.webExtension.unloaded) {
                 throw e;
             }
         }
@@ -368,7 +368,7 @@ export class Frontend {
         const scanningOptions = /** @type {import('settings').ProfileOptions} */ (this._options).scanning;
 
         if (error !== null) {
-            if (yomitan.isExtensionUnloaded) {
+            if (yomitan.webExtension.unloaded) {
                 if (textSource !== null && !passive) {
                     this._showExtensionUnloaded(textSource);
                 }
@@ -655,7 +655,7 @@ export class Frontend {
         try {
             return this._popup !== null && await this._popup.containsPoint(x, y);
         } catch (e) {
-            if (!yomitan.isExtensionUnloaded) {
+            if (!yomitan.webExtension.unloaded) {
                 throw e;
             }
             return false;
@@ -742,7 +742,7 @@ export class Frontend {
             Promise.resolve()
         );
         this._lastShowPromise.catch((error) => {
-            if (yomitan.isExtensionUnloaded) { return; }
+            if (yomitan.webExtension.unloaded) { return; }
             log.error(error);
         });
         return this._lastShowPromise;

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -320,7 +320,7 @@ export class PopupProxy extends EventDispatcher {
         try {
             return await this._invoke(action, params);
         } catch (e) {
-            if (!yomitan.isExtensionUnloaded) { throw e; }
+            if (!yomitan.webExtension.unloaded) { throw e; }
             return defaultReturnValue;
         }
     }

--- a/ext/js/app/popup-window.js
+++ b/ext/js/app/popup-window.js
@@ -274,7 +274,7 @@ export class PopupWindow extends EventDispatcher {
      * @returns {Promise<import('display').DirectApiReturn<TName>|undefined>}
      */
     async _invoke(open, action, params) {
-        if (yomitan.isExtensionUnloaded) {
+        if (yomitan.webExtension.unloaded) {
             return void 0;
         }
 
@@ -290,7 +290,7 @@ export class PopupWindow extends EventDispatcher {
                     message
                 ));
             } catch (e) {
-                if (yomitan.isExtensionUnloaded) {
+                if (yomitan.webExtension.unloaded) {
                     open = false;
                 }
             }

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -714,7 +714,7 @@ export class Popup extends EventDispatcher {
         try {
             return await this._invoke(action, params);
         } catch (e) {
-            if (!yomitan.isExtensionUnloaded) { throw e; }
+            if (!yomitan.webExtension.unloaded) { throw e; }
             return void 0;
         }
     }

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -49,9 +49,11 @@ import {injectStylesheet} from './script-manager.js';
  */
 export class Backend {
     /**
-     * Creates a new instance.
+     * @param {import('../extension/web-extension.js').WebExtension} webExtension
      */
-    constructor() {
+    constructor(webExtension) {
+        /** @type {import('../extension/web-extension.js').WebExtension} */
+        this._webExtension = webExtension;
         /** @type {JapaneseUtil} */
         this._japaneseUtil = new JapaneseUtil(wanakana);
         /** @type {Environment} */
@@ -80,7 +82,7 @@ export class Backend {
             });
         } else {
             /** @type {?OffscreenProxy} */
-            this._offscreen = new OffscreenProxy();
+            this._offscreen = new OffscreenProxy(webExtension);
             /** @type {DictionaryDatabase|DictionaryDatabaseProxy} */
             this._dictionaryDatabase = new DictionaryDatabaseProxy(this._offscreen);
             /** @type {Translator|TranslatorProxy} */
@@ -1902,8 +1904,7 @@ export class Backend {
      * @param {import('application').ApiMessage<TName>} message
      */
     _sendMessageIgnoreResponse(message) {
-        const callback = () => this._checkLastError(chrome.runtime.lastError);
-        chrome.runtime.sendMessage(message, callback);
+        this._webExtension.sendMessagePromise(message);
     }
 
     /**

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1904,7 +1904,7 @@ export class Backend {
      * @param {import('application').ApiMessage<TName>} message
      */
     _sendMessageIgnoreResponse(message) {
-        this._webExtension.sendMessagePromise(message);
+        this._webExtension.sendMessageIgnoreResponse(message);
     }
 
     /**

--- a/ext/js/background/background-main.js
+++ b/ext/js/background/background-main.js
@@ -23,7 +23,7 @@ import {Backend} from './backend.js';
 async function main() {
     yomitan.prepare(true);
 
-    const backend = new Backend();
+    const backend = new Backend(yomitan.webExtension);
     await backend.prepare();
 }
 

--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -16,12 +16,17 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {isObject} from '../core/utilities.js';
 import {ExtensionError} from '../core/extension-error.js';
+import {isObject} from '../core/utilities.js';
 import {ArrayBufferUtil} from '../data/sandbox/array-buffer-util.js';
 
 export class OffscreenProxy {
-    constructor() {
+    /**
+     * @param {import('../extension/web-extension.js').WebExtension} webExtension
+     */
+    constructor(webExtension) {
+        /** @type {import('../extension/web-extension.js').WebExtension} */
+        this._webExtension = webExtension;
         /** @type {?Promise<void>} */
         this._creatingOffscreen = null;
     }
@@ -76,16 +81,9 @@ export class OffscreenProxy {
      * @param {import('offscreen').ApiMessage<TMessageType>} message
      * @returns {Promise<import('offscreen').ApiReturn<TMessageType>>}
      */
-    sendMessagePromise(message) {
-        return new Promise((resolve, reject) => {
-            chrome.runtime.sendMessage(message, (response) => {
-                try {
-                    resolve(this._getMessageResponseResult(response));
-                } catch (error) {
-                    reject(error);
-                }
-            });
-        });
+    async sendMessagePromise(message) {
+        const response = await this._webExtension.sendMessagePromise(message);
+        return this._getMessageResponseResult(/** @type {import('core').Response<import('offscreen').ApiReturn<TMessageType>>} */ (response));
     }
 
     /**

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -390,7 +390,7 @@ export class Display extends EventDispatcher {
      * @param {Error} error
      */
     onError(error) {
-        if (yomitan.isExtensionUnloaded) { return; }
+        if (yomitan.webExtension.unloaded) { return; }
         log.error(error);
     }
 
@@ -727,8 +727,7 @@ export class Display extends EventDispatcher {
 
     /** @type {import('display').WindowApiHandler<'displayExtensionUnloaded'>} */
     _onMessageExtensionUnloaded() {
-        if (yomitan.isExtensionUnloaded) { return; }
-        yomitan.triggerExtensionUnloaded();
+        yomitan.webExtension.triggerUnloaded();
     }
 
     // Private
@@ -1894,7 +1893,7 @@ export class Display extends EventDispatcher {
      * @param {import('text-scanner').SearchedEventDetails} details
      */
     _onContentTextScannerSearched({type, dictionaryEntries, sentence, textSource, optionsContext, error}) {
-        if (error !== null && !yomitan.isExtensionUnloaded) {
+        if (error !== null && !yomitan.webExtension.unloaded) {
             log.error(error);
         }
 

--- a/ext/js/extension/web-extension.js
+++ b/ext/js/extension/web-extension.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {EventDispatcher} from '../core/event-dispatcher.js';
+import {toError} from '../core/to-error.js';
+
+/**
+ * @augments EventDispatcher<import('web-extension').Events>
+ */
+export class WebExtension extends EventDispatcher {
+    constructor() {
+        super();
+        /** @type {boolean} */
+        this._unloaded = false;
+    }
+
+    /** @type {boolean} */
+    get unloaded() {
+        return this._unloaded;
+    }
+
+    /**
+     * @param {string} path
+     * @returns {string}
+     */
+    getUrl(path) {
+        return chrome.runtime.getURL(path);
+    }
+
+    /**
+     * @param {unknown} message
+     * @param {(response: unknown) => void} responseCallback
+     * @throws {Error}
+     */
+    sendMessage(message, responseCallback) {
+        try {
+            chrome.runtime.sendMessage(message, responseCallback);
+        } catch (error) {
+            this.triggerUnloaded();
+            throw toError(error);
+        }
+    }
+
+    /**
+     * @param {unknown} message
+     * @returns {Promise<unknown>}
+     */
+    sendMessagePromise(message) {
+        return new Promise((resolve, reject) => {
+            try {
+                this.sendMessage(message, (response) => {
+                    const error = this.getLastError();
+                    if (error !== null) {
+                        reject(error);
+                    } else {
+                        resolve(response);
+                    }
+                });
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
+
+    /**
+     * @returns {?Error}
+     */
+    getLastError() {
+        const {lastError} = chrome.runtime;
+        if (typeof lastError !== 'undefined') {
+            const {message} = lastError;
+            return new Error(typeof message === 'string' ? message : 'An unknown web extension error occured');
+        }
+        return null;
+    }
+
+    /** */
+    triggerUnloaded() {
+        if (this._unloaded) { return; }
+        this._unloaded = true;
+        this.trigger('unloaded', {});
+    }
+}

--- a/ext/js/extension/web-extension.js
+++ b/ext/js/extension/web-extension.js
@@ -77,6 +77,16 @@ export class WebExtension extends EventDispatcher {
     }
 
     /**
+     * @param {unknown} message
+     */
+    sendMessageIgnoreResponse(message) {
+        this.sendMessage(message, () => {
+            // Clear the last error
+            this.getLastError();
+        });
+    }
+
+    /**
      * @returns {?Error}
      */
     getLastError() {

--- a/ext/js/yomitan.js
+++ b/ext/js/yomitan.js
@@ -77,7 +77,7 @@ export class Yomitan extends EventDispatcher {
         /** @type {?string} */
         this._extensionUrlBase = null;
         try {
-            this._extensionUrlBase = chrome.runtime.getURL('/');
+            this._extensionUrlBase = this._webExtension.getUrl('/');
         } catch (e) {
             // NOP
         }

--- a/ext/js/yomitan.js
+++ b/ext/js/yomitan.js
@@ -23,6 +23,7 @@ import {EventDispatcher} from './core/event-dispatcher.js';
 import {ExtensionError} from './core/extension-error.js';
 import {log} from './core/logger.js';
 import {deferPromise} from './core/utilities.js';
+import {WebExtension} from './extension/web-extension.js';
 
 /**
  * @returns {boolean}
@@ -61,6 +62,9 @@ export class Yomitan extends EventDispatcher {
     constructor() {
         super();
 
+        /** @type {WebExtension} */
+        this._webExtension = new WebExtension();
+
         /** @type {string} */
         this._extensionName = 'Yomitan';
         try {
@@ -85,10 +89,6 @@ export class Yomitan extends EventDispatcher {
         /** @type {?CrossFrameAPI} */
         this._crossFrame = null;
         /** @type {boolean} */
-        this._isExtensionUnloaded = false;
-        /** @type {boolean} */
-        this._isTriggeringExtensionUnloaded = false;
-        /** @type {boolean} */
         this._isReady = false;
 
         const {promise, resolve} = /** @type {import('core').DeferredPromiseDetails<void>} */ (deferPromise());
@@ -110,6 +110,11 @@ export class Yomitan extends EventDispatcher {
         /* eslint-enable no-multi-spaces */
     }
 
+    /** @type {WebExtension} */
+    get webExtension() {
+        return this._webExtension;
+    }
+
     /**
      * Whether the current frame is the background page/service worker or not.
      * @type {boolean}
@@ -117,14 +122,6 @@ export class Yomitan extends EventDispatcher {
     get isBackground() {
         if (this._isBackground === null) { throw new Error('Not prepared'); }
         return /** @type {boolean} */ (this._isBackground);
-    }
-
-    /**
-     * Whether or not the extension is unloaded.
-     * @type {boolean}
-     */
-    get isExtensionUnloaded() {
-        return this._isExtensionUnloaded;
     }
 
     /**
@@ -156,9 +153,9 @@ export class Yomitan extends EventDispatcher {
         chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
 
         if (!isBackground) {
-            this._api = new API(this);
+            this._api = new API(this._webExtension);
 
-            this.sendMessage({action: 'requestBackendReadySignal'});
+            await this._webExtension.sendMessagePromise({action: 'requestBackendReadySignal'});
             await this._isBackendReadyPromise;
 
             this._crossFrame = new CrossFrameAPI();
@@ -174,7 +171,7 @@ export class Yomitan extends EventDispatcher {
      */
     ready() {
         this._isReady = true;
-        this.sendMessage({action: 'applicationReady'});
+        this._webExtension.sendMessagePromise({action: 'applicationReady'});
     }
 
     /**
@@ -184,36 +181,6 @@ export class Yomitan extends EventDispatcher {
      */
     isExtensionUrl(url) {
         return this._extensionUrlBase !== null && url.startsWith(this._extensionUrlBase);
-    }
-
-    // TODO : this function needs type safety
-    /**
-     * Runs `chrome.runtime.sendMessage()` with additional exception handling events.
-     * @param {import('extension').ChromeRuntimeSendMessageArgs} args The arguments to be passed to `chrome.runtime.sendMessage()`.
-     * @throws {Error} Errors thrown by `chrome.runtime.sendMessage()` are re-thrown.
-     */
-    sendMessage(...args) {
-        try {
-            // @ts-expect-error - issue with type conversion, somewhat difficult to resolve in pure JS
-            chrome.runtime.sendMessage(...args);
-        } catch (e) {
-            this.triggerExtensionUnloaded();
-            throw e;
-        }
-    }
-
-    /**
-     * Triggers the extensionUnloaded event.
-     */
-    triggerExtensionUnloaded() {
-        this._isExtensionUnloaded = true;
-        if (this._isTriggeringExtensionUnloaded) { return; }
-        try {
-            this._isTriggeringExtensionUnloaded = true;
-            this.trigger('extensionUnloaded', {});
-        } finally {
-            this._isTriggeringExtensionUnloaded = false;
-        }
     }
 
     /** */

--- a/types/ext/extension.d.ts
+++ b/types/ext/extension.d.ts
@@ -15,38 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import type * as Core from './core';
-
-export type ChromeRuntimeSendMessageArgs1 = [
-    message: Core.SafeAny,
-];
-
-export type ChromeRuntimeSendMessageArgs2 = [
-    message: Core.SafeAny,
-    responseCallback: (response: Core.SafeAny) => void,
-];
-
-export type ChromeRuntimeSendMessageArgs3 = [
-    message: Core.SafeAny,
-    options: chrome.runtime.MessageOptions,
-    responseCallback: (response: Core.SafeAny) => void,
-];
-
-export type ChromeRuntimeSendMessageArgs4 = [
-    extensionId: string | undefined | null,
-    message: Core.SafeAny,
-    responseCallback: (response: Core.SafeAny) => void,
-];
-
-export type ChromeRuntimeSendMessageArgs5 = [
-    extensionId: string | undefined | null,
-    message: Core.SafeAny,
-    options: chrome.runtime.MessageOptions,
-    responseCallback: (response: Core.SafeAny) => void,
-];
-
-export type ChromeRuntimeSendMessageArgs = ChromeRuntimeSendMessageArgs1 | ChromeRuntimeSendMessageArgs2 | ChromeRuntimeSendMessageArgs3 | ChromeRuntimeSendMessageArgs4 | ChromeRuntimeSendMessageArgs5;
-
 export type HtmlElementWithContentWindow = HTMLIFrameElement | HTMLFrameElement | HTMLObjectElement;
 
 export type ContentOrigin = {

--- a/types/ext/web-extension.d.ts
+++ b/types/ext/web-extension.d.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2024  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export type Events = {
+    unloaded: Record<string, never>;
+};


### PR DESCRIPTION
This is a first step towards making a distinction between the `Yomitan` class and some of the web extension functionality it hosts. The `WebExtension` class is intended to isolate some (eventually potentially all) of the web extension APIs and store some limited state information, which currently includes whether or not the extension is unloaded. This value was previously stored on the `Yomitan` class itself, but makes more sense elsewhere.


A longer term goal I have is to better structure the overall application initialization process and to have less unneeded shared-but-not-used code across the frontend and backend. For example, search for `isBackground` in the `Yomitan` class - this code does not need to reside in this class. Another part of this effort is to reduce the number of objects with state initialized outside of the `main` entry point without an owner. I think this only really applies to `logger` and `yomitan`


Eventually, this should make testing a bit cleaner. Right now, the `chrome` object is stubbed in a somewhat messy way. Optimally, we could stub a cleaner test class, which could also allow for better testing of more components that interface with the web extension API.

And this last thing is potentially very far off or perhaps won't ever happen, but abstracting the usage of the `chrome.*` APIs would also potentially make it easier to port to other environments (e.g. desktop electron app? I know this was brought up at some point back in the Yomichan days), but this isn't really a huge consideration of what I'm aiming for right now.


* [x] Merge #552 before this change.