### PR TITLE
Change inflection info style

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -812,6 +812,7 @@ button.action-button:active {
 .inflection-rule-chains {
     padding-inline-start: 0;
     list-style-type: none;
+    display: inline-block;
 }
 .inflection-rule-chain {
     color: var(--reason-text-color);
@@ -823,26 +824,6 @@ button.action-button:active {
     content: var(--inflection-separator);
     padding: 0 0.25em;
 }
-.inflection-source-icon {
-    display: inline-block;
-    white-space: nowrap;
-    text-align: center;
-    width: 1.4em;
-    margin-right: 0.2em;
-}
-.inflection-source-icon[data-inflection-source='dictionary']::after {
-    content: '📖';
-}
-.inflection-source-icon[data-inflection-source='algorithm']::after {
-    content: '🧩';
-}
-.inflection-source-icon[data-inflection-source='both'] {
-    width: 2.8em;
-}
-.inflection-source-icon[data-inflection-source='both']::after {
-    content: '🧩📖';
-}
-
 
 /* Headwords */
 .headword-list {

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -361,37 +361,12 @@ export class DisplayGenerator {
      * @returns {?HTMLElement}
      */
     _createInflectionRuleChain(inflectionRuleChain) {
-        const {source, inflectionRules} = inflectionRuleChain;
+        const {inflectionRules} = inflectionRuleChain;
         if (!Array.isArray(inflectionRules) || inflectionRules.length === 0) { return null; }
         const fragment = this._instantiate('inflection-rule-chain');
 
-        const sourceIcon = this._getInflectionSourceIcon(source);
-
-        fragment.appendChild(sourceIcon);
-
         this._appendMultiple(fragment, this._createTermInflection.bind(this), inflectionRules);
         return fragment;
-    }
-
-    /**
-     * @param {import('dictionary').InflectionSource} source
-     * @returns {HTMLElement}
-     */
-    _getInflectionSourceIcon(source) {
-        const icon = document.createElement('span');
-        icon.classList.add('inflection-source-icon');
-        icon.dataset.inflectionSource = source;
-        switch (source) {
-            case 'dictionary':
-                icon.title = 'Dictionary Deinflection';
-                return icon;
-            case 'algorithm':
-                icon.title = 'Algorithm Deinflection';
-                return icon;
-            case 'both':
-                icon.title = 'Dictionary and Algorithm Deinflection';
-                return icon;
-        }
     }
 
     /**


### PR DESCRIPTION
Simplifies inflection info layout.

The inflection info is taking a bit too much space, especially for non-Japanese languages that can have a lot of possible inflections. The dictionary and algorithm emojis are also a bit distracting, and I don't think that users really need to know where their inflection info comes from.

![japanese-two-inflections](https://github.com/themoeway/yomitan/assets/83692925/3d1adf8a-b28a-40a7-a037-e22108c632b5)
![spanish-two-inflections](https://github.com/themoeway/yomitan/assets/83692925/5369b753-21d2-46fa-b1a3-365270cc0b3d)
![spanish-one-inflection](https://github.com/themoeway/yomitan/assets/83692925/3a7b5849-b385-4557-8698-6cc9075ea368)

Longer inflection info still gets moved below the headword:

![spanish-long-inflection](https://github.com/themoeway/yomitan/assets/83692925/485aa9da-3a54-48f7-9529-939a4aad97c3)
