### PR TITLE
Adding a handlebar to return pitch accent categories of a word

### DIFF
--- a/ext/data/templates/default-anki-field-templates.handlebars
+++ b/ext/data/templates/default-anki-field-templates.handlebars
@@ -227,6 +227,10 @@
 {{#*inline "pitch-accent-positions"}}
     {{~> pitch-accent-list format='position'~}}
 {{/inline}}
+
+{{~#*inline "pitch-accent-categories"~}}
+    {{~#each (pitchCategories @root)~}}{{~.~}}{{~#unless @last~}},{{~/unless~}}{{~/each~}}
+{{~/inline~}}
 {{! End Pitch Accents }}
 
 {{#*inline "phonetic-transcriptions"}}

--- a/ext/js/dictionary/dictionary-data-util.js
+++ b/ext/js/dictionary/dictionary-data-util.js
@@ -287,7 +287,7 @@ export class DictionaryDataUtil {
                 case 'vs':
                     isVerbOrAdjective = true;
                     isSuruVerb = true;
-                    break;
+                    // falls through
                 case 'n':
                     isNoun = true;
                     break;

--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -147,6 +147,7 @@ export class AnkiController {
                     'pitch-accents',
                     'pitch-accent-graphs',
                     'pitch-accent-positions',
+                    'pitch-accent-categories',
                     'phonetic-transcriptions',
                     'reading',
                     'screenshot',


### PR DESCRIPTION
There's a function hidden in the source code called pitchCategories, which returns the pitch accent categories of a word in string format. This pull request adds a new handlebar, called "pitch-accent-categories" which uses this function to return a comma delimited list of pitch accent categories for a word.

For instance, with my set of pitch accent dictionaries, running "pitch-accent-categories" on the word 「推量」returns "heiban,nakadaka", while running it on 「読め」returns "kifuku".

In order to make this work, I needed to fix a logic error in the function isNonNounVerbOrAdjective. As it was, the function would return an incorrect result if the word was both a suru verb and a noun (which is quite a lot of words!) For these words, it should return False, but it was actually returning True. To see the problem, note that in the final return statement, it contains the following expression: `!(isSuruVerb && isNoun)`. With the old logic, there is never a situation where this will evaluate False, it will always return True.