### PR TITLE
Add border styling options for structured content images

### DIFF
--- a/ext/data/schemas/dictionary-term-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-bank-v3-schema.json
@@ -204,21 +204,13 @@
                                     "description": "The vertical alignment of the image.",
                                     "enum": ["baseline", "sub", "super", "text-top", "text-bottom", "middle", "top", "bottom"]
                                 },
+                                "border": {
+                                    "type": "string",
+                                    "description": "Shorthand for border width, style, and color."
+                                },
                                 "borderRadius": {
                                     "type": "string",
                                     "description": "Roundness of the corners of the image's outer border edge."
-                                },
-                                "borderStyle": {
-                                    "type": "string",
-                                    "description": "Line style for all four sides of the image's border."
-                                },
-                                "borderWidth": {
-                                    "type": "string",
-                                    "description": "Width of the image's border."
-                                },
-                                "borderColor": {
-                                    "type": "string",
-                                    "description": "Color of the image's border."
                                 },
                                 "sizeUnits": {
                                     "type": "string",

--- a/ext/data/schemas/dictionary-term-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-bank-v3-schema.json
@@ -152,7 +152,7 @@
                                 },
                                 "height": {
                                     "type": "number",
-                                    "description": "Preferred width of the image.",
+                                    "description": "Preferred height of the image.",
                                     "minimum": 0
                                 },
                                 "title": {
@@ -203,6 +203,22 @@
                                     "type": "string",
                                     "description": "The vertical alignment of the image.",
                                     "enum": ["baseline", "sub", "super", "text-top", "text-bottom", "middle", "top", "bottom"]
+                                },
+                                "borderRadius": {
+                                    "type": "string",
+                                    "description": "Roundness of the corners of the image's outer border edge."
+                                },
+                                "borderStyle": {
+                                    "type": "string",
+                                    "description": "Line style for all four sides of the image's border."
+                                },
+                                "borderWidth": {
+                                    "type": "string",
+                                    "description": "Width of the image's border."
+                                },
+                                "borderColor": {
+                                    "type": "string",
+                                    "description": "Color of the image's border."
                                 },
                                 "sizeUnits": {
                                     "type": "string",
@@ -485,7 +501,7 @@
                                         },
                                         "height": {
                                             "type": "integer",
-                                            "description": "Preferred width of the image.",
+                                            "description": "Preferred height of the image.",
                                             "minimum": 1
                                         },
                                         "title": {

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -486,9 +486,20 @@ export class DictionaryImporter {
      * @param {import('dictionary-database').DatabaseTermEntry} entry
      */
     async _resolveStructuredContentImage(context, target, source, entry) {
-        const {verticalAlign, sizeUnits} = source;
+        const {
+            verticalAlign,
+            borderRadius,
+            borderStyle,
+            borderWidth,
+            borderColor,
+            sizeUnits
+        } = source;
         await this._createImageData(context, target, source, entry);
         if (typeof verticalAlign === 'string') { target.verticalAlign = verticalAlign; }
+        if (typeof borderRadius === 'string') { target.borderRadius = borderRadius; }
+        if (typeof borderStyle === 'string') { target.borderStyle = borderStyle; }
+        if (typeof borderWidth === 'string') { target.borderWidth = borderWidth; }
+        if (typeof borderColor === 'string') { target.borderColor = borderColor; }
         if (typeof sizeUnits === 'string') { target.sizeUnits = sizeUnits; }
     }
 

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -488,18 +488,14 @@ export class DictionaryImporter {
     async _resolveStructuredContentImage(context, target, source, entry) {
         const {
             verticalAlign,
+            border,
             borderRadius,
-            borderStyle,
-            borderWidth,
-            borderColor,
             sizeUnits
         } = source;
         await this._createImageData(context, target, source, entry);
         if (typeof verticalAlign === 'string') { target.verticalAlign = verticalAlign; }
+        if (typeof border === 'string') { target.border = border; }
         if (typeof borderRadius === 'string') { target.borderRadius = borderRadius; }
-        if (typeof borderStyle === 'string') { target.borderStyle = borderStyle; }
-        if (typeof borderWidth === 'string') { target.borderWidth = borderWidth; }
-        if (typeof borderColor === 'string') { target.borderColor = borderColor; }
         if (typeof sizeUnits === 'string') { target.sizeUnits = sizeUnits; }
     }
 

--- a/ext/js/display/sandbox/structured-content-generator.js
+++ b/ext/js/display/sandbox/structured-content-generator.js
@@ -73,6 +73,10 @@ export class StructuredContentGenerator {
             collapsed,
             collapsible,
             verticalAlign,
+            borderRadius,
+            borderStyle,
+            borderWidth,
+            borderColor,
             sizeUnits
         } = data;
 
@@ -130,6 +134,10 @@ export class StructuredContentGenerator {
         }
 
         imageContainer.style.width = `${usedWidth}em`;
+        if (typeof borderRadius === 'string') { imageContainer.style.borderRadius = borderRadius; }
+        if (typeof borderStyle === 'string') { imageContainer.style.borderStyle = borderStyle; }
+        if (typeof borderWidth === 'string') { imageContainer.style.borderWidth = borderWidth; }
+        if (typeof borderColor === 'string') { imageContainer.style.borderColor = borderColor; }
         if (typeof title === 'string') {
             imageContainer.title = title;
         }

--- a/ext/js/display/sandbox/structured-content-generator.js
+++ b/ext/js/display/sandbox/structured-content-generator.js
@@ -73,10 +73,8 @@ export class StructuredContentGenerator {
             collapsed,
             collapsible,
             verticalAlign,
+            border,
             borderRadius,
-            borderStyle,
-            borderWidth,
-            borderColor,
             sizeUnits
         } = data;
 
@@ -134,10 +132,8 @@ export class StructuredContentGenerator {
         }
 
         imageContainer.style.width = `${usedWidth}em`;
+        if (typeof border === 'string') { imageContainer.style.border = border; }
         if (typeof borderRadius === 'string') { imageContainer.style.borderRadius = borderRadius; }
-        if (typeof borderStyle === 'string') { imageContainer.style.borderStyle = borderStyle; }
-        if (typeof borderWidth === 'string') { imageContainer.style.borderWidth = borderWidth; }
-        if (typeof borderColor === 'string') { imageContainer.style.borderColor = borderColor; }
         if (typeof title === 'string') {
             imageContainer.title = title;
         }

--- a/test/data/dictionaries/valid-dictionary1/term_bank_1.json
+++ b/test/data/dictionaries/valid-dictionary1/term_bank_1.json
@@ -81,7 +81,7 @@
                 "Image alt text tests.\n𬵪 = Unicode character\n",
                 {"tag": "img", "alt": "𬵪", "path": "aosaba_mono.png", "height": 1.0, "width": 1.0, "background": false, "sizeUnits": "em", "collapsed": false, "collapsible": false, "appearance": "monochrome"},
                 " = monochrome PNG\n",
-                {"tag": "img", "alt": "𬵪", "path": "aosaba_auto.png", "height": 1.0, "width": 1.0, "background": false, "sizeUnits": "em", "collapsed": false, "collapsible": false, "appearance": "auto", "borderRadius": "20%", "borderStyle": "solid", "borderWidth": "1px", "borderColor": "red"},
+                {"tag": "img", "alt": "𬵪", "path": "aosaba_auto.png", "height": 1.0, "width": 1.0, "background": false, "sizeUnits": "em", "collapsed": false, "collapsible": false, "appearance": "auto", "borderRadius": "20%", "border": "solid 1px red"},
                 " = color PNG"
             ]},
             {"type": "structured-content", "content": [

--- a/test/data/dictionaries/valid-dictionary1/term_bank_1.json
+++ b/test/data/dictionaries/valid-dictionary1/term_bank_1.json
@@ -81,7 +81,7 @@
                 "Image alt text tests.\n𬵪 = Unicode character\n",
                 {"tag": "img", "alt": "𬵪", "path": "aosaba_mono.png", "height": 1.0, "width": 1.0, "background": false, "sizeUnits": "em", "collapsed": false, "collapsible": false, "appearance": "monochrome"},
                 " = monochrome PNG\n",
-                {"tag": "img", "alt": "𬵪", "path": "aosaba_auto.png", "height": 1.0, "width": 1.0, "background": false, "sizeUnits": "em", "collapsed": false, "collapsible": false, "appearance": "auto"},
+                {"tag": "img", "alt": "𬵪", "path": "aosaba_auto.png", "height": 1.0, "width": 1.0, "background": false, "sizeUnits": "em", "collapsed": false, "collapsible": false, "appearance": "auto", "borderRadius": "20%", "borderStyle": "solid", "borderWidth": "1px", "borderColor": "red"},
                 " = color PNG"
             ]},
             {"type": "structured-content", "content": [

--- a/types/ext/dictionary-data.d.ts
+++ b/types/ext/dictionary-data.d.ts
@@ -113,6 +113,10 @@ export type TermGlossaryDeinflection = [
 export type TermImage = StructuredContent.ImageElementBase & {
     // Compatibility properties
     verticalAlign?: undefined;
+    borderRadius?: undefined;
+    borderStyle?: undefined;
+    borderWidth?: undefined;
+    borderColor?: undefined;
     sizeUnits?: undefined;
 };
 

--- a/types/ext/dictionary-data.d.ts
+++ b/types/ext/dictionary-data.d.ts
@@ -113,10 +113,8 @@ export type TermGlossaryDeinflection = [
 export type TermImage = StructuredContent.ImageElementBase & {
     // Compatibility properties
     verticalAlign?: undefined;
+    border?: undefined;
     borderRadius?: undefined;
-    borderStyle?: undefined;
-    borderWidth?: undefined;
-    borderColor?: undefined;
     sizeUnits?: undefined;
 };
 

--- a/types/ext/structured-content.d.ts
+++ b/types/ext/structured-content.d.ts
@@ -41,6 +41,10 @@ export type ImageAppearance = 'auto' | 'monochrome';
 
 export type Image = DictionaryData.TermImage & {
     verticalAlign: VerticalAlign;
+    borderRadius: string;
+    borderStyle: string;
+    borderWidth: string;
+    borderColor: string;
     sizeUnits: SizeUnits;
 };
 
@@ -142,7 +146,7 @@ export type ImageElementBase = {
      */
     width?: number;
     /**
-     * Preferred width of the image.
+     * Preferred height of the image.
      */
     height?: number;
     /**
@@ -151,7 +155,7 @@ export type ImageElementBase = {
      */
     preferredWidth?: number;
     /**
-     * Preferred width of the image.
+     * Preferred height of the image.
      * This is only used in the internal database.
      */
     preferredHeight?: number;
@@ -203,6 +207,22 @@ export type ImageElement = ImageElementBase & {
      * The vertical alignment of the image.
      */
     verticalAlign?: VerticalAlign;
+    /**
+     * Roundness of the corners of the image's outer border edge.
+     */
+    borderRadius?: string;
+    /**
+     * Line style for all four sides of the image's border.
+     */
+    borderStyle?: string;
+    /**
+     * Width of the image's border.
+     */
+    borderWidth?: string;
+    /**
+     * Color of the image's border.
+     */
+    borderColor?: string;
     /**
      * The units for the width and height.
      */

--- a/types/ext/structured-content.d.ts
+++ b/types/ext/structured-content.d.ts
@@ -41,10 +41,8 @@ export type ImageAppearance = 'auto' | 'monochrome';
 
 export type Image = DictionaryData.TermImage & {
     verticalAlign: VerticalAlign;
+    border: string;
     borderRadius: string;
-    borderStyle: string;
-    borderWidth: string;
-    borderColor: string;
     sizeUnits: SizeUnits;
 };
 
@@ -208,21 +206,13 @@ export type ImageElement = ImageElementBase & {
      */
     verticalAlign?: VerticalAlign;
     /**
+     * Shorthand for border width, style, and color.
+     */
+    border?: string;
+    /**
      * Roundness of the corners of the image's outer border edge.
      */
     borderRadius?: string;
-    /**
-     * Line style for all four sides of the image's border.
-     */
-    borderStyle?: string;
-    /**
-     * Width of the image's border.
-     */
-    borderWidth?: string;
-    /**
-     * Color of the image's border.
-     */
-    borderColor?: string;
     /**
      * The units for the width and height.
      */


### PR DESCRIPTION
I'd like to be able to style graphics with borders.

<table>
<tr><th width="50%">Without Border</th><th>With Border</th></tr>
<tr>
<td width="50%"><img src="https://github.com/themoeway/yomitan/assets/8003332/492b2f6c-9bdf-4ea4-a5b1-c2ce090f8166"/></td>
<td><img src="https://github.com/themoeway/yomitan/assets/8003332/a2012c57-c091-49c1-9fe6-9c18f0a8c148"/></td>
</tr>
</table>

I tested this in Chromium and exported a test card to Anki (see the image below). Seems to work okay.

<details>
  <summary>Test Anki card</summary>

![anki](https://github.com/themoeway/yomitan/assets/8003332/2557e35e-1244-4098-8c99-71d01257dc8b)
</details>
