### PR TITLE
Changes to welcome page configuration

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -97,7 +97,7 @@
                                     "popupScalingFactor",
                                     "popupScaleRelativeToPageZoom",
                                     "popupScaleRelativeToVisualViewport",
-                                    "showGuide",
+                                    "showWelcomePage",
                                     "compactTags",
                                     "glossaryLayoutMode",
                                     "mainDictionary",
@@ -197,9 +197,9 @@
                                         "type": "boolean",
                                         "default": true
                                     },
-                                    "showGuide": {
+                                    "showWelcomePage": {
                                         "type": "boolean",
-                                        "default": true
+                                        "default": false
                                     },
                                     "compactTags": {
                                         "type": "boolean",

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -293,8 +293,8 @@ export class Backend {
             this._applyOptions('background');
 
             const options = this._getProfileOptions({current: true}, false);
-            if (options.general.showGuide) {
-                this._openWelcomeGuidePageOnce();
+            if (options.general.showWelcomePage) {
+                this._openWelcomePage();
             }
 
             this._clipboardMonitor.on('change', this._onClipboardTextChange.bind(this));
@@ -420,6 +420,7 @@ export class Backend {
     _onInstalled({reason}) {
         if (reason !== 'install') { return; }
         this._requestPersistentStorage();
+        this._openWelcomePageOnce();
     }
 
     // Message handlers
@@ -2518,19 +2519,19 @@ export class Backend {
     /**
      * @returns {Promise<void>}
      */
-    async _openWelcomeGuidePageOnce() {
-        chrome.storage.session.get(['openedWelcomePage']).then((result) => {
-            if (!result.openedWelcomePage) {
-                this._openWelcomeGuidePage();
-                chrome.storage.session.set({'openedWelcomePage': true});
-            }
-        });
+    async _openWelcomePageOnce() {
+        const {openedWelcomePage} = await chrome.storage.local.get(['openedWelcomePage']);
+
+        if (!openedWelcomePage) {
+            this._openWelcomePage();
+            chrome.storage.local.set({'openedWelcomePage': true});
+        }
     }
 
     /**
      * @returns {Promise<void>}
      */
-    async _openWelcomeGuidePage() {
+    async _openWelcomePage() {
         await this._createTab(chrome.runtime.getURL('/welcome.html'));
     }
 

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -189,7 +189,7 @@ export class OptionsUtil {
                 options.general.audioSource = options.general.audioPlayback ? 'jpod101' : 'disabled';
             },
             (options) => {
-                options.general.showGuide = false;
+                options.general.showWelcomePage = false;
             },
             (options) => {
                 options.scanning.modifier = options.scanning.requireShift ? 'shift' : 'none';
@@ -294,7 +294,7 @@ export class OptionsUtil {
                 popupScalingFactor: 1,
                 popupScaleRelativeToPageZoom: false,
                 popupScaleRelativeToVisualViewport: true,
-                showGuide: true,
+                showWelcomePage: false,
                 compactTags: false,
                 compactGlossaries: false,
                 mainDictionary: '',
@@ -1129,7 +1129,7 @@ export class OptionsUtil {
         if (customTemplates && isObject(chrome.storage)) {
             chrome.storage.session.set({'needsCustomTemplatesWarning': true});
             await this._createTab(chrome.runtime.getURL('/welcome.html'));
-            chrome.storage.session.set({'openedWelcomePage': true});
+            chrome.storage.local.set({'openedWelcomePage': true});
         }
     }
 

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -211,7 +211,7 @@
                 <div class="settings-item-label">Show the <a href="/welcome.html" target="_blank" rel="noopener">welcome guide</a> on browser startup</div>
             </div>
             <div class="settings-item-right">
-                <label class="toggle"><input type="checkbox" data-setting="general.showGuide"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                <label class="toggle"><input type="checkbox" data-setting="general.showWelcomePage"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
         <div class="settings-item">

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -133,10 +133,10 @@
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner">
             <div class="settings-item-left">
-                <div class="settings-item-label">Show this welcome guide on browser startup</div>
+                <div class="settings-item-label">Show this welcome page on browser startup</div>
             </div>
             <div class="settings-item-right">
-                <label class="toggle"><input type="checkbox" data-setting="general.showGuide"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                <label class="toggle"><input type="checkbox" data-setting="general.showWelcomePage"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
         <div class="settings-item">

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -21,7 +21,7 @@
 import fs from 'fs';
 import {fileURLToPath} from 'node:url';
 import path from 'path';
-import {expect, test, describe, vi} from 'vitest';
+import {describe, expect, test, vi} from 'vitest';
 import {OptionsUtil} from '../ext/js/data/options-util.js';
 import {TemplatePatcher} from '../ext/js/templates/template-patcher.js';
 import {chrome, fetch} from './mocks/common.js';
@@ -56,7 +56,7 @@ function createProfileOptionsTestData1() {
             popupScalingFactor: 1,
             popupScaleRelativeToPageZoom: false,
             popupScaleRelativeToVisualViewport: true,
-            showGuide: true,
+            showWelcomePage: true,
             compactTags: false,
             compactGlossaries: false,
             mainDictionary: '',
@@ -259,7 +259,7 @@ function createProfileOptionsUpdatedTestData1() {
             popupScalingFactor: 1,
             popupScaleRelativeToPageZoom: false,
             popupScaleRelativeToVisualViewport: true,
-            showGuide: true,
+            showWelcomePage: true,
             compactTags: false,
             glossaryLayoutMode: 'default',
             mainDictionary: '',

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -117,7 +117,7 @@ export type GeneralOptions = {
     popupScalingFactor: number;
     popupScaleRelativeToPageZoom: boolean;
     popupScaleRelativeToVisualViewport: boolean;
-    showGuide: boolean;
+    showWelcomePage: boolean;
     compactTags: boolean;
     glossaryLayoutMode: GlossaryLayoutMode;
     mainDictionary: string;


### PR DESCRIPTION
Part of #470 to reconfigure settings to the welcome page.

- Default to not showing welcome page on browser start-up
- Open welcome page on extension installed event
- Use `chrome.storage.local` to persist user options for opening the welcome page
- Rename `showGuide` to `showWelcomePage` for readability/understanding

@toasted-nutbread let me know what you think? I know there is a setting for disabling the welcome page but personally I think it should be default turned off, and only on extension start up. However, as part of the issue we could make it more obvious where to find the welcome page, should you need to.