### PR TITLE
Fix auto hide search popup

### DIFF
--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -382,7 +382,7 @@ export class Frontend {
             } else {
                 log.error(error);
             }
-        } if (type !== null && optionsContext !== null) {
+        } if (type !== null && optionsContext !== null && textSource !== null) {
             this._stopClearSelectionDelayed();
             let focus = (eventType === 'mouseMove');
             if (typeof inputInfoDetail === 'object' && inputInfoDetail !== null) {

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -183,7 +183,9 @@ export class Frontend {
         chrome.runtime.onMessage.addListener(this._onRuntimeMessage.bind(this));
 
         this._textScanner.on('clear', this._onTextScannerClear.bind(this));
-        this._textScanner.on('searched', this._onSearched.bind(this));
+        this._textScanner.on('searchSuccess', this._onSearchSuccess.bind(this));
+        this._textScanner.on('searchEmpty', this._onSearchEmpty.bind(this));
+        this._textScanner.on('searchError', this._onSearchError.bind(this));
 
         /* eslint-disable no-multi-spaces */
         this._application.crossFrame.registerHandlers([
@@ -369,31 +371,36 @@ export class Frontend {
     }
 
     /**
-     * @param {import('text-scanner').SearchedEventDetails} details
+     * @param {import('text-scanner').EventArgument<'searchSuccess'>} details
      */
-    _onSearched({type, dictionaryEntries, sentence, inputInfo: {eventType, passive, detail: inputInfoDetail}, textSource, optionsContext, detail, error}) {
-        const scanningOptions = /** @type {import('settings').ProfileOptions} */ (this._options).scanning;
+    _onSearchSuccess({type, dictionaryEntries, sentence, inputInfo: {eventType, detail: inputInfoDetail}, textSource, optionsContext, detail}) {
+        this._stopClearSelectionDelayed();
+        let focus = (eventType === 'mouseMove');
+        if (typeof inputInfoDetail === 'object' && inputInfoDetail !== null) {
+            const focus2 = inputInfoDetail.focus;
+            if (typeof focus2 === 'boolean') { focus = focus2; }
+        }
+        this._showContent(textSource, focus, dictionaryEntries, type, sentence, detail !== null ? detail.documentTitle : null, optionsContext);
+    }
 
-        if (error !== null) {
-            if (this._application.webExtension.unloaded) {
-                if (textSource !== null && !passive) {
-                    this._showExtensionUnloaded(textSource);
-                }
-            } else {
-                log.error(error);
+    /** */
+    _onSearchEmpty() {
+        const scanningOptions = /** @type {import('settings').ProfileOptions} */ (this._options).scanning;
+        if (scanningOptions.autoHideResults) {
+            this._clearSelectionDelayed(scanningOptions.hideDelay, false, false);
+        }
+    }
+
+    /**
+     * @param {import('text-scanner').EventArgument<'searchError'>} details
+     */
+    _onSearchError({error, textSource, inputInfo: {passive}}) {
+        if (this._application.webExtension.unloaded) {
+            if (textSource !== null && !passive) {
+                this._showExtensionUnloaded(textSource);
             }
-        } if (type !== null && optionsContext !== null && textSource !== null) {
-            this._stopClearSelectionDelayed();
-            let focus = (eventType === 'mouseMove');
-            if (typeof inputInfoDetail === 'object' && inputInfoDetail !== null) {
-                const focus2 = inputInfoDetail.focus;
-                if (typeof focus2 === 'boolean') { focus = focus2; }
-            }
-            this._showContent(textSource, focus, dictionaryEntries, type, sentence, detail !== null ? detail.documentTitle : null, optionsContext);
         } else {
-            if (scanningOptions.autoHideResults) {
-                this._clearSelectionDelayed(scanningOptions.hideDelay, false, false);
-            }
+            log.error(error);
         }
     }
 
@@ -888,7 +895,7 @@ export class Frontend {
     }
 
     /**
-     * @returns {Promise<{optionsContext: import('settings').OptionsContext, detail?: import('text-scanner').SearchResultDetail}>}
+     * @returns {Promise<import('text-scanner').SearchContext>}
      */
     async _getSearchContext() {
         let url = window.location.href;

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1850,7 +1850,8 @@ export class Display extends EventDispatcher {
             this._contentTextScanner.excludeSelector = '.scan-disable,.scan-disable *';
             this._contentTextScanner.prepare();
             this._contentTextScanner.on('clear', this._onContentTextScannerClear.bind(this));
-            this._contentTextScanner.on('searched', this._onContentTextScannerSearched.bind(this));
+            this._contentTextScanner.on('searchSuccess', this._onContentTextScannerSearchSuccess.bind(this));
+            this._contentTextScanner.on('searchError', this._onContentTextScannerSearchError.bind(this));
         }
 
         const {scanning: scanningOptions, sentenceParsing: sentenceParsingOptions} = options;
@@ -1895,15 +1896,9 @@ export class Display extends EventDispatcher {
     }
 
     /**
-     * @param {import('text-scanner').SearchedEventDetails} details
+     * @param {import('text-scanner').EventArgument<'searchSuccess'>} details
      */
-    _onContentTextScannerSearched({type, dictionaryEntries, sentence, textSource, optionsContext, error}) {
-        if (error !== null && !this._application.webExtension.unloaded) {
-            log.error(error);
-        }
-
-        if (type === null || textSource === null) { return; }
-
+    _onContentTextScannerSearchSuccess({type, dictionaryEntries, sentence, textSource, optionsContext}) {
         const query = textSource.text();
         const url = window.location.href;
         const documentTitle = document.title;
@@ -1933,10 +1928,24 @@ export class Display extends EventDispatcher {
     }
 
     /**
+     * @param {import('text-scanner').EventArgument<'searchError'>} details
+     */
+    _onContentTextScannerSearchError({error}) {
+        if (!this._application.webExtension.unloaded) {
+            log.error(error);
+        }
+    }
+
+    /**
      * @type {import('display').GetSearchContextCallback}
      */
     _getSearchContext() {
-        return {optionsContext: this.getOptionsContext()};
+        return {
+            optionsContext: this.getOptionsContext(),
+            detail: {
+                documentTitle: document.title
+            }
+        };
     }
 
     /**

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1902,7 +1902,7 @@ export class Display extends EventDispatcher {
             log.error(error);
         }
 
-        if (type === null) { return; }
+        if (type === null || textSource === null) { return; }
 
         const query = textSource.text();
         const url = window.location.href;

--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -82,7 +82,8 @@ export class QueryParser extends EventDispatcher {
     prepare() {
         this._textScanner.prepare();
         this._textScanner.on('clear', this._onTextScannerClear.bind(this));
-        this._textScanner.on('searched', this._onSearched.bind(this));
+        this._textScanner.on('searchSuccess', this._onSearchSuccess.bind(this));
+        this._textScanner.on('searchError', this._onSearchError.bind(this));
         this._queryParserModeSelect.addEventListener('change', this._onParserChange.bind(this), false);
     }
 
@@ -147,28 +148,11 @@ export class QueryParser extends EventDispatcher {
     }
 
     /**
-     * @param {import('text-scanner').SearchedEventDetails} e
+     * @param {import('text-scanner').EventArgument<'searchSuccess'>} details
      */
-    _onSearched(e) {
-        const {error} = e;
-        if (error !== null) {
-            log.error(error);
-            return;
-        }
-
-        const {
-            textScanner,
-            type,
-            dictionaryEntries,
-            sentence,
-            inputInfo,
-            textSource,
-            optionsContext
-        } = e;
-        if (type === null || dictionaryEntries === null || sentence === null || optionsContext === null || textSource === null) { return; }
-
+    _onSearchSuccess({type, dictionaryEntries, sentence, inputInfo, textSource, optionsContext}) {
         this.trigger('searched', {
-            textScanner,
+            textScanner: this._textScanner,
             type,
             dictionaryEntries,
             sentence,
@@ -177,6 +161,13 @@ export class QueryParser extends EventDispatcher {
             optionsContext,
             sentenceOffset: this._getSentenceOffset(textSource)
         });
+    }
+
+    /**
+     * @param {import('text-scanner').EventArgument<'searchError'>} details
+     */
+    _onSearchError({error}) {
+        log.error(error);
     }
 
     /**

--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -165,7 +165,7 @@ export class QueryParser extends EventDispatcher {
             textSource,
             optionsContext
         } = e;
-        if (type === null || dictionaryEntries === null || sentence === null || optionsContext === null) { return; }
+        if (type === null || dictionaryEntries === null || sentence === null || optionsContext === null || textSource === null) { return; }
 
         this.trigger('searched', {
             textScanner,
@@ -175,7 +175,7 @@ export class QueryParser extends EventDispatcher {
             inputInfo,
             textSource,
             optionsContext,
-            sentenceOffset: this._getSentenceOffset(e.textSource)
+            sentenceOffset: this._getSentenceOffset(textSource)
         });
     }
 

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -1296,10 +1296,10 @@ export class TextScanner extends EventDispatcher {
                 try {
                     await this._search(textSource, searchTerms, searchKanji, inputInfo);
                 } finally {
-                    if (textSource !== null) {
-                        textSource.cleanup();
-                    }
+                    textSource.cleanup();
                 }
+            } else {
+                this._triggerSearched(null, null, null, inputInfo, null, null, null, null);
             }
         } catch (e) {
             log.error(e);

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -482,8 +482,21 @@ export class TextScanner extends EventDispatcher {
 
         if (!searched) { return; }
 
-        /** @type {import('text-scanner').SearchedEventDetails} */
-        const results = {
+        this._triggerSearched(type, dictionaryEntries, sentence, inputInfo, textSource, optionsContext, detail, error);
+    }
+
+    /**
+     * @param {?import('display').PageType} type
+     * @param {?import('dictionary').DictionaryEntry[]} dictionaryEntries
+     * @param {?import('display').HistoryStateSentence} sentence
+     * @param {import('text-scanner').InputInfo} inputInfo
+     * @param {?import('text-source').TextSource} textSource
+     * @param {?import('settings').OptionsContext} optionsContext
+     * @param {?import('text-scanner').SearchResultDetail} detail
+     * @param {?Error} error
+     */
+    _triggerSearched(type, dictionaryEntries, sentence, inputInfo, textSource, optionsContext, detail, error) {
+        this.trigger('searched', {
             textScanner: this,
             type,
             dictionaryEntries,
@@ -493,8 +506,7 @@ export class TextScanner extends EventDispatcher {
             optionsContext,
             detail,
             error
-        };
-        this.trigger('searched', results);
+        });
     }
 
     /** */

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -395,11 +395,10 @@ export class TextScanner extends EventDispatcher {
     /**
      * @param {import('text-source').TextSource} textSource
      * @param {import('text-scanner').InputInfoDetail} [inputDetail]
-     * @returns {Promise<?import('text-scanner').SearchedEventDetails>}
      */
     async search(textSource, inputDetail) {
         const inputInfo = this._createInputInfo(null, 'script', 'script', true, [], [], inputDetail);
-        return await this._search(textSource, this._searchTerms, this._searchKanji, inputInfo);
+        await this._search(textSource, this._searchTerms, this._searchKanji, inputInfo);
     }
 
     // Private
@@ -422,7 +421,6 @@ export class TextScanner extends EventDispatcher {
      * @param {boolean} searchTerms
      * @param {boolean} searchKanji
      * @param {import('text-scanner').InputInfo} inputInfo
-     * @returns {Promise<?import('text-scanner').SearchedEventDetails>}
      */
     async _search(textSource, searchTerms, searchKanji, inputInfo) {
         /** @type {?import('dictionary').DictionaryEntry[]} */
@@ -448,7 +446,7 @@ export class TextScanner extends EventDispatcher {
             );
 
             if (this._textSourceCurrent !== null && this._textSourceCurrent.hasSameStart(textSource)) {
-                return null;
+                return;
             }
 
             const getSearchContextPromise = this._getSearchContext();
@@ -482,7 +480,7 @@ export class TextScanner extends EventDispatcher {
             error = e instanceof Error ? e : new Error(`A search error occurred: ${e}`);
         }
 
-        if (!searched) { return null; }
+        if (!searched) { return; }
 
         /** @type {import('text-scanner').SearchedEventDetails} */
         const results = {
@@ -497,7 +495,6 @@ export class TextScanner extends EventDispatcher {
             error
         };
         this.trigger('searched', results);
-        return results;
     }
 
     /** */

--- a/types/ext/text-scanner.d.ts
+++ b/types/ext/text-scanner.d.ts
@@ -94,6 +94,7 @@ export type InputConfig = {
     preventPenScrolling: boolean;
 };
 
+// TODO : this event should be split into 3 different types : searchSuccess, searchEmpty, searchError
 export type SearchedEventDetails = {
     textScanner: TextScanner;
     type: Display.PageType | null;

--- a/types/ext/text-scanner.d.ts
+++ b/types/ext/text-scanner.d.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import type {TextScanner} from '../../ext/js/language/text-scanner';
 import type {TextSourceGenerator} from '../../ext/js/dom/text-source-generator';
 import type {API} from '../../ext/js/comm/api';
 import type * as Dictionary from './dictionary';
@@ -94,19 +93,6 @@ export type InputConfig = {
     preventPenScrolling: boolean;
 };
 
-// TODO : this event should be split into 3 different types : searchSuccess, searchEmpty, searchError
-export type SearchedEventDetails = {
-    textScanner: TextScanner;
-    type: Display.PageType | null;
-    dictionaryEntries: Dictionary.DictionaryEntry[] | null;
-    sentence: Display.HistoryStateSentence | null;
-    inputInfo: InputInfo;
-    textSource: TextSource.TextSource | null;
-    optionsContext: Settings.OptionsContext | null;
-    detail: SearchResultDetail | null;
-    error: Error | null;
-};
-
 export type InputInfo = {
     input: InputConfig | null;
     pointerType: PointerType;
@@ -123,9 +109,25 @@ export type InputInfoDetail = {
 };
 
 export type Events = {
-    searched: SearchedEventDetails;
     clear: {
         reason: ClearReason;
+    };
+    searchSuccess: {
+        type: 'terms' | 'kanji';
+        dictionaryEntries: Dictionary.DictionaryEntry[];
+        sentence: Display.HistoryStateSentence;
+        inputInfo: InputInfo;
+        textSource: TextSource.TextSource;
+        optionsContext: Settings.OptionsContext;
+        detail: SearchResultDetail;
+    };
+    searchEmpty: {
+        inputInfo: InputInfo;
+    };
+    searchError: {
+        error: Error;
+        textSource: TextSource.TextSource;
+        inputInfo: InputInfo;
     };
 };
 
@@ -154,7 +156,7 @@ export type ConstructorDetails = {
 
 export type SearchContext = {
     optionsContext: Settings.OptionsContext;
-    detail?: SearchResultDetail;
+    detail: SearchResultDetail;
 };
 
 export type SelectionRestoreInfo = {

--- a/types/ext/text-scanner.d.ts
+++ b/types/ext/text-scanner.d.ts
@@ -100,7 +100,7 @@ export type SearchedEventDetails = {
     dictionaryEntries: Dictionary.DictionaryEntry[] | null;
     sentence: Display.HistoryStateSentence | null;
     inputInfo: InputInfo;
-    textSource: TextSource.TextSource;
+    textSource: TextSource.TextSource | null;
     optionsContext: Settings.OptionsContext | null;
     detail: SearchResultDetail | null;
     error: Error | null;


### PR DESCRIPTION
Fixes #580.

The issue was that the `_search` function wasn't invoked when there was no text source, which resulted in the `searched` event never being invoked for that situation. This change happened during the type annotations conversion due to some confusion about how nulls should be handled.

In this change, I've done a little bit of refactoring to make this less likely to occur. The `searched` event has been split into three different events to clarify the intent:
* `searchSuccess` - happens when the search was successful and should have something displayed in the popup. This could be dictionary results, or the query parser.
* `searchEmpty` - no text source was present, or no search results were found.
* `searchError` - some error occurred.