### PR TITLE
Replace `text-decoration` with `bottom-border` in links with ruby text

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -288,12 +288,12 @@ a {
     color: var(--link-color);
     text-decoration: underline;
     cursor: pointer;
-    text-underline-offset: 0.2rem;
-    text-decoration-thickness: 2px;
+    text-underline-offset: calc(4em / var(--font-size-no-units));
+    text-decoration-thickness: calc(1em / var(--font-size-no-units));
 }
 a:has(rt) {
     text-decoration: none;
-    border-bottom: solid 2px var(--link-color);
+    border-bottom: solid calc(1em / var(--font-size-no-units)) var(--link-color);
 }
 
 

--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -288,6 +288,12 @@ a {
     color: var(--link-color);
     text-decoration: underline;
     cursor: pointer;
+    text-underline-offset: 0.2rem;
+    text-decoration-thickness: 2px;
+}
+a:has(rt) {
+    text-decoration: none;
+    border-bottom: solid 2px var(--link-color);
 }
 
 


### PR DESCRIPTION
There's an [annoying](https://bugs.webkit.org/show_bug.cgi?id=78957) [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1421450) in WebKit that causes the text decoration line to split when the link contains ruby text that is wider than the base ruby character. See the link to "慎重" in the image below to see what I mean. The line underneath 重 is not wide enough.

![chrome_before](https://github.com/themoeway/yomitan/assets/8003332/6d7f581a-c50e-426f-9813-e906d6b76113)

(This bug doesn't affect Firefox.)

I propose replacing the text decoration line with a bottom-border when a hyperlink contains ruby text. You might ask why we should limit it to only the links that contain ruby text. If we use a bottom border style all the time, then the external hyperlink icons (visible in the lower right corner) will also be underlined.

I also suggest adding a small amount of padding (`text-underline-offset`) to all hyperlinks. This is the same amount of padding (`0.2rem`) that GitHub uses in its hyperlink styles. It can help prevent 十 from looking like 士, for example.

Here's an image of the same entry with my proposed new styles.

![chrome_after](https://github.com/themoeway/yomitan/assets/8003332/abee8641-17f6-4d07-ad68-d0a5250f8978)
