### PR TITLE
Remove benchmark merge queue event

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-  merge_group:
   workflow_dispatch:
 jobs:
   benchmark:


### PR DESCRIPTION
CodSpeed benchmarks does not work on merge queue. 
`Error Event merge_group is not supported by CodSpeed`