### PR TITLE
Update application init process

### DIFF
--- a/ext/js/app/content-script-main.js
+++ b/ext/js/app/content-script-main.js
@@ -17,49 +17,36 @@
  */
 
 import {Application} from '../application.js';
-import {log} from '../core/logger.js';
 import {HotkeyHandler} from '../input/hotkey-handler.js';
 import {Frontend} from './frontend.js';
 import {PopupFactory} from './popup-factory.js';
 
-/** Entry point. */
-async function main() {
-    try {
-        const application = new Application();
-        await application.prepare();
-
-        const {tabId, frameId} = await application.api.frameInformationGet();
-        if (typeof frameId !== 'number') {
-            throw new Error('Failed to get frameId');
-        }
-
-        const hotkeyHandler = new HotkeyHandler();
-        hotkeyHandler.prepare(application.crossFrame);
-
-        const popupFactory = new PopupFactory(application, frameId);
-        popupFactory.prepare();
-
-        const frontend = new Frontend({
-            application,
-            tabId,
-            frameId,
-            popupFactory,
-            depth: 0,
-            parentPopupId: null,
-            parentFrameId: null,
-            useProxyPopup: false,
-            pageType: 'web',
-            canUseWindowPopup: true,
-            allowRootFramePopupProxy: true,
-            childrenSupported: true,
-            hotkeyHandler
-        });
-        await frontend.prepare();
-
-        application.ready();
-    } catch (e) {
-        log.error(e);
+await Application.main(async (application) => {
+    const {tabId, frameId} = await application.api.frameInformationGet();
+    if (typeof frameId !== 'number') {
+        throw new Error('Failed to get frameId');
     }
-}
 
-await main();
+    const hotkeyHandler = new HotkeyHandler();
+    hotkeyHandler.prepare(application.crossFrame);
+
+    const popupFactory = new PopupFactory(application, frameId);
+    popupFactory.prepare();
+
+    const frontend = new Frontend({
+        application,
+        tabId,
+        frameId,
+        popupFactory,
+        depth: 0,
+        parentPopupId: null,
+        parentFrameId: null,
+        useProxyPopup: false,
+        pageType: 'web',
+        canUseWindowPopup: true,
+        allowRootFramePopupProxy: true,
+        childrenSupported: true,
+        hotkeyHandler
+    });
+    await frontend.prepare();
+});

--- a/ext/js/background/background-main.js
+++ b/ext/js/background/background-main.js
@@ -16,15 +16,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {Application} from '../application.js';
+import {WebExtension} from '../extension/web-extension.js';
 import {Backend} from './backend.js';
 
 /** Entry point. */
 async function main() {
-    const application = new Application();
-    application.prepare(true);
+    const webExtension = new WebExtension();
 
-    const backend = new Backend(application.webExtension);
+    const backend = new Backend(webExtension);
     await backend.prepare();
 }
 

--- a/ext/js/comm/cross-frame-api.js
+++ b/ext/js/comm/cross-frame-api.js
@@ -291,8 +291,10 @@ export class CrossFrameAPIPort extends EventDispatcher {
 export class CrossFrameAPI {
     /**
      * @param {import('../comm/api.js').API} api
+     * @param {?number} tabId
+     * @param {?number} frameId
      */
-    constructor(api) {
+    constructor(api, tabId, frameId) {
         /** @type {import('../comm/api.js').API} */
         this._api = api;
         /** @type {number} */
@@ -306,15 +308,14 @@ export class CrossFrameAPI {
         /** @type {(port: CrossFrameAPIPort) => void} */
         this._onDisconnectBind = this._onDisconnect.bind(this);
         /** @type {?number} */
-        this._tabId = null;
+        this._tabId = tabId;
         /** @type {?number} */
-        this._frameId = null;
+        this._frameId = frameId;
     }
 
     /** */
-    async prepare() {
+    prepare() {
         chrome.runtime.onConnect.addListener(this._onConnect.bind(this));
-        ({tabId: this._tabId = null, frameId: this._frameId = null} = await this._api.frameInformationGet());
     }
 
     /**

--- a/ext/js/pages/action-popup-main.js
+++ b/ext/js/pages/action-popup-main.js
@@ -305,17 +305,9 @@ class DisplayController {
     }
 }
 
-/** Entry point. */
-async function main() {
-    const application = new Application();
-    await application.prepare();
-
+await Application.main(async (application) => {
     application.api.logIndicatorClear();
 
     const displayController = new DisplayController(application.api);
     displayController.prepare();
-
-    application.ready();
-}
-
-await main();
+});

--- a/ext/js/pages/settings/popup-preview-frame-main.js
+++ b/ext/js/pages/settings/popup-preview-frame-main.js
@@ -18,37 +18,26 @@
 
 import {PopupFactory} from '../../app/popup-factory.js';
 import {Application} from '../../application.js';
-import {log} from '../../core/logger.js';
 import {HotkeyHandler} from '../../input/hotkey-handler.js';
 import {PopupPreviewFrame} from './popup-preview-frame.js';
 
-/** Entry point. */
-async function main() {
-    try {
-        const application = new Application();
-        await application.prepare();
-
-        const {tabId, frameId} = await application.api.frameInformationGet();
-        if (typeof tabId === 'undefined') {
-            throw new Error('Failed to get tabId');
-        }
-        if (typeof frameId === 'undefined') {
-            throw new Error('Failed to get frameId');
-        }
-
-        const hotkeyHandler = new HotkeyHandler();
-        hotkeyHandler.prepare(application.crossFrame);
-
-        const popupFactory = new PopupFactory(application, frameId);
-        popupFactory.prepare();
-
-        const preview = new PopupPreviewFrame(application, tabId, frameId, popupFactory, hotkeyHandler);
-        await preview.prepare();
-
-        document.documentElement.dataset.loaded = 'true';
-    } catch (e) {
-        log.error(e);
+await Application.main(async (application) => {
+    const {tabId, frameId} = await application.api.frameInformationGet();
+    if (typeof tabId === 'undefined') {
+        throw new Error('Failed to get tabId');
     }
-}
+    if (typeof frameId === 'undefined') {
+        throw new Error('Failed to get frameId');
+    }
 
-await main();
+    const hotkeyHandler = new HotkeyHandler();
+    hotkeyHandler.prepare(application.crossFrame);
+
+    const popupFactory = new PopupFactory(application, frameId);
+    popupFactory.prepare();
+
+    const preview = new PopupPreviewFrame(application, tabId, frameId, popupFactory, hotkeyHandler);
+    await preview.prepare();
+
+    document.documentElement.dataset.loaded = 'true';
+});

--- a/ext/js/pages/settings/settings-main.js
+++ b/ext/js/pages/settings/settings-main.js
@@ -17,7 +17,6 @@
  */
 
 import {Application} from '../../application.js';
-import {log} from '../../core/logger.js';
 import {DocumentFocusController} from '../../dom/document-focus-controller.js';
 import {querySelectorNotNull} from '../../dom/query-selector.js';
 import {ExtensionContentController} from '../common/extension-content-controller.js';
@@ -58,124 +57,114 @@ async function setupGenericSettingController(genericSettingController) {
     await genericSettingController.refresh();
 }
 
-/** Entry point. */
-async function main() {
-    try {
-        const documentFocusController = new DocumentFocusController();
-        documentFocusController.prepare();
+await Application.main(async (application) => {
+    const documentFocusController = new DocumentFocusController();
+    documentFocusController.prepare();
 
-        const extensionContentController = new ExtensionContentController();
-        extensionContentController.prepare();
+    const extensionContentController = new ExtensionContentController();
+    extensionContentController.prepare();
 
-        /** @type {HTMLElement} */
-        const statusFooterElement = querySelectorNotNull(document, '.status-footer-container');
-        const statusFooter = new StatusFooter(statusFooterElement);
-        statusFooter.prepare();
+    /** @type {HTMLElement} */
+    const statusFooterElement = querySelectorNotNull(document, '.status-footer-container');
+    const statusFooter = new StatusFooter(statusFooterElement);
+    statusFooter.prepare();
 
-        /** @type {?number} */
-        let prepareTimer = window.setTimeout(() => {
-            prepareTimer = null;
-            document.documentElement.dataset.loadingStalled = 'true';
-        }, 1000);
+    /** @type {?number} */
+    let prepareTimer = window.setTimeout(() => {
+        prepareTimer = null;
+        document.documentElement.dataset.loadingStalled = 'true';
+    }, 1000);
 
-        const application = new Application();
-        await application.prepare();
-
-        if (prepareTimer !== null) {
-            clearTimeout(prepareTimer);
-            prepareTimer = null;
-        }
-        delete document.documentElement.dataset.loadingStalled;
-
-        const preparePromises = [];
-
-        const modalController = new ModalController();
-        modalController.prepare();
-
-        const settingsController = new SettingsController(application);
-        await settingsController.prepare();
-
-        const persistentStorageController = new PersistentStorageController(application);
-        persistentStorageController.prepare();
-
-        const storageController = new StorageController(persistentStorageController);
-        storageController.prepare();
-
-        const dictionaryController = new DictionaryController(settingsController, modalController, statusFooter);
-        dictionaryController.prepare();
-
-        const dictionaryImportController = new DictionaryImportController(settingsController, modalController, statusFooter);
-        dictionaryImportController.prepare();
-
-        const genericSettingController = new GenericSettingController(settingsController);
-        preparePromises.push(setupGenericSettingController(genericSettingController));
-
-        const audioController = new AudioController(settingsController, modalController);
-        audioController.prepare();
-
-        const profileController = new ProfileController(settingsController, modalController);
-        profileController.prepare();
-
-        const settingsBackup = new BackupController(settingsController, modalController);
-        settingsBackup.prepare();
-
-        const ankiController = new AnkiController(settingsController);
-        ankiController.prepare();
-
-        const ankiTemplatesController = new AnkiTemplatesController(settingsController, modalController, ankiController);
-        ankiTemplatesController.prepare();
-
-        const popupPreviewController = new PopupPreviewController(settingsController);
-        popupPreviewController.prepare();
-
-        const scanInputsController = new ScanInputsController(settingsController);
-        scanInputsController.prepare();
-
-        const simpleScanningInputController = new ScanInputsSimpleController(settingsController);
-        simpleScanningInputController.prepare();
-
-        const nestedPopupsController = new NestedPopupsController(settingsController);
-        nestedPopupsController.prepare();
-
-        const permissionsToggleController = new PermissionsToggleController(settingsController);
-        permissionsToggleController.prepare();
-
-        const secondarySearchDictionaryController = new SecondarySearchDictionaryController(settingsController);
-        secondarySearchDictionaryController.prepare();
-
-        const translationTextReplacementsController = new TranslationTextReplacementsController(settingsController);
-        translationTextReplacementsController.prepare();
-
-        const sentenceTerminationCharactersController = new SentenceTerminationCharactersController(settingsController);
-        sentenceTerminationCharactersController.prepare();
-
-        const keyboardShortcutController = new KeyboardShortcutController(settingsController);
-        keyboardShortcutController.prepare();
-
-        const extensionKeyboardShortcutController = new ExtensionKeyboardShortcutController(settingsController);
-        extensionKeyboardShortcutController.prepare();
-
-        const popupWindowController = new PopupWindowController(application.api);
-        popupWindowController.prepare();
-
-        const mecabController = new MecabController(application.api);
-        mecabController.prepare();
-
-        const collapsibleDictionaryController = new CollapsibleDictionaryController(settingsController);
-        collapsibleDictionaryController.prepare();
-
-        const sortFrequencyDictionaryController = new SortFrequencyDictionaryController(settingsController);
-        sortFrequencyDictionaryController.prepare();
-
-        await Promise.all(preparePromises);
-
-        document.documentElement.dataset.loaded = 'true';
-
-        const settingsDisplayController = new SettingsDisplayController(settingsController, modalController);
-        settingsDisplayController.prepare();
-    } catch (e) {
-        log.error(e);
+    if (prepareTimer !== null) {
+        clearTimeout(prepareTimer);
+        prepareTimer = null;
     }
-}
+    delete document.documentElement.dataset.loadingStalled;
 
-await main();
+    const preparePromises = [];
+
+    const modalController = new ModalController();
+    modalController.prepare();
+
+    const settingsController = new SettingsController(application);
+    await settingsController.prepare();
+
+    const persistentStorageController = new PersistentStorageController(application);
+    persistentStorageController.prepare();
+
+    const storageController = new StorageController(persistentStorageController);
+    storageController.prepare();
+
+    const dictionaryController = new DictionaryController(settingsController, modalController, statusFooter);
+    dictionaryController.prepare();
+
+    const dictionaryImportController = new DictionaryImportController(settingsController, modalController, statusFooter);
+    dictionaryImportController.prepare();
+
+    const genericSettingController = new GenericSettingController(settingsController);
+    preparePromises.push(setupGenericSettingController(genericSettingController));
+
+    const audioController = new AudioController(settingsController, modalController);
+    audioController.prepare();
+
+    const profileController = new ProfileController(settingsController, modalController);
+    profileController.prepare();
+
+    const settingsBackup = new BackupController(settingsController, modalController);
+    settingsBackup.prepare();
+
+    const ankiController = new AnkiController(settingsController);
+    ankiController.prepare();
+
+    const ankiTemplatesController = new AnkiTemplatesController(settingsController, modalController, ankiController);
+    ankiTemplatesController.prepare();
+
+    const popupPreviewController = new PopupPreviewController(settingsController);
+    popupPreviewController.prepare();
+
+    const scanInputsController = new ScanInputsController(settingsController);
+    scanInputsController.prepare();
+
+    const simpleScanningInputController = new ScanInputsSimpleController(settingsController);
+    simpleScanningInputController.prepare();
+
+    const nestedPopupsController = new NestedPopupsController(settingsController);
+    nestedPopupsController.prepare();
+
+    const permissionsToggleController = new PermissionsToggleController(settingsController);
+    permissionsToggleController.prepare();
+
+    const secondarySearchDictionaryController = new SecondarySearchDictionaryController(settingsController);
+    secondarySearchDictionaryController.prepare();
+
+    const translationTextReplacementsController = new TranslationTextReplacementsController(settingsController);
+    translationTextReplacementsController.prepare();
+
+    const sentenceTerminationCharactersController = new SentenceTerminationCharactersController(settingsController);
+    sentenceTerminationCharactersController.prepare();
+
+    const keyboardShortcutController = new KeyboardShortcutController(settingsController);
+    keyboardShortcutController.prepare();
+
+    const extensionKeyboardShortcutController = new ExtensionKeyboardShortcutController(settingsController);
+    extensionKeyboardShortcutController.prepare();
+
+    const popupWindowController = new PopupWindowController(application.api);
+    popupWindowController.prepare();
+
+    const mecabController = new MecabController(application.api);
+    mecabController.prepare();
+
+    const collapsibleDictionaryController = new CollapsibleDictionaryController(settingsController);
+    collapsibleDictionaryController.prepare();
+
+    const sortFrequencyDictionaryController = new SortFrequencyDictionaryController(settingsController);
+    sortFrequencyDictionaryController.prepare();
+
+    await Promise.all(preparePromises);
+
+    document.documentElement.dataset.loaded = 'true';
+
+    const settingsDisplayController = new SettingsDisplayController(settingsController, modalController);
+    settingsDisplayController.prepare();
+});


### PR DESCRIPTION
Further trying to standardize the application initialization process and the Application class. This change makes it so `Application` is no longer used on the Backend, and there is a common method of initializing all frontend pages. The goal of this is to make it so that the objects have to do less inside of their own prepare function, and it's instead moved outside of it. To this end, the tabId and frameId are now computed up before constructing some of the classes that need it. This can still be further improved, as I think there are other places that still redundantly request the frame ID, but that is a separate issue.

Note: this PR will be easier to review if whitespace diffs are disabled.

* [x] Marking as a draft for now until I test it a bit more.