### PR TITLE
Show all duplicate notes on click

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -1187,7 +1187,7 @@
                                             {"action": "addNoteTermKanji",  "argument": "",  "key": "KeyE",      "modifiers": ["alt"],  "scopes": ["popup", "search"], "enabled": true},
                                             {"action": "addNoteTermKana",   "argument": "",  "key": "KeyR",      "modifiers": ["alt"],  "scopes": ["popup", "search"], "enabled": true},
                                             {"action": "playAudio",         "argument": "",  "key": "KeyP",      "modifiers": ["alt"],  "scopes": ["popup", "search"], "enabled": true},
-                                            {"action": "viewNote",          "argument": "",  "key": "KeyV",      "modifiers": ["alt"],  "scopes": ["popup", "search"], "enabled": true},
+                                            {"action": "viewNotes",         "argument": "",  "key": "KeyV",      "modifiers": ["alt"],  "scopes": ["popup", "search"], "enabled": true},
                                             {"action": "copyHostSelection", "argument": "",  "key": "KeyC",      "modifiers": ["ctrl"], "scopes": ["popup"], "enabled": true}
                                         ]
                                     }

--- a/ext/display-templates.html
+++ b/ext/display-templates.html
@@ -8,7 +8,7 @@
             <button type="button" class="action-button action-button-collapsible" data-action="view-tags" hidden disabled>
                 <span class="action-icon icon" data-icon="tag"></span>
             </button>
-            <button type="button" class="action-button" data-action="view-note" hidden disabled title="View added note" data-hotkey='["viewNote","title","View added note ({0})"]' data-menu-position="left below h-cover v-cover">
+            <button type="button" class="action-button" data-action="view-note" hidden disabled title="View added note" data-hotkey='["viewNotes","title","View added note ({0})"]' data-menu-position="left below h-cover v-cover">
                 <span class="action-icon icon color-icon" data-icon="view-note"></span>
                 <span class="action-button-badge icon" hidden></span>
             </button>
@@ -111,7 +111,7 @@
     <div class="entry-current-indicator" title="Current entry"><span class="entry-current-indicator-inner"></span></div>
     <div class="entry-header">
         <div class="actions">
-            <button type="button" class="action-button" data-action="view-note" hidden disabled title="View added note" data-hotkey='["viewNote","title","View added note ({0})"]'>
+            <button type="button" class="action-button" data-action="view-note" hidden disabled title="View added note" data-hotkey='["viewNotes","title","View added note ({0})"]'>
                 <span class="action-icon icon color-icon" data-icon="view-note"></span>
             </button>
             <button type="button" class="action-button" data-action="add-note" hidden disabled data-mode="kanji" title="Add kanji" data-hotkey='["addNoteKanji","title","Add kanji ({0})"]'>

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -155,6 +155,7 @@ export class Backend {
             ['getAnkiNoteInfo',              this._onApiGetAnkiNoteInfo.bind(this)],
             ['injectAnkiNoteMedia',          this._onApiInjectAnkiNoteMedia.bind(this)],
             ['noteView',                     this._onApiNoteView.bind(this)],
+            ['notesView',                    this._onApiNotesView.bind(this)],
             ['suspendAnkiCardsForNote',      this._onApiSuspendAnkiCardsForNote.bind(this)],
             ['commandExec',                  this._onApiCommandExec.bind(this)],
             ['getTermAudioInfoList',         this._onApiGetTermAudioInfoList.bind(this)],
@@ -596,6 +597,24 @@ export class Backend {
         }
         // Fallback
         await this._anki.guiBrowseNote(noteId);
+        return 'browse';
+    }
+
+    /** @type {import('api').ApiHandler<'notesView'>} */
+    async _onApiNotesView({noteIds, mode, allowFallback}) {
+        if (noteIds.length === 1 && mode === 'edit') {
+            try {
+                await this._anki.guiEditNote(noteIds[0]);
+                return 'edit';
+            } catch (e) {
+                if (!(e instanceof Error && this._anki.isErrorUnsupportedAction(e))) {
+                    throw e;
+                } else if (!allowFallback) {
+                    throw new Error('Mode not supported');
+                }
+            }
+        }
+        await this._anki.guiBrowseNotes(noteIds);
         return 'browse';
     }
 

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -155,7 +155,7 @@ export class Backend {
             ['getAnkiNoteInfo',              this._onApiGetAnkiNoteInfo.bind(this)],
             ['injectAnkiNoteMedia',          this._onApiInjectAnkiNoteMedia.bind(this)],
             ['noteView',                     this._onApiNoteView.bind(this)],
-            ['notesView',                    this._onApiNotesView.bind(this)],
+            ['viewNotes',                    this._onApiViewNotes.bind(this)],
             ['suspendAnkiCardsForNote',      this._onApiSuspendAnkiCardsForNote.bind(this)],
             ['commandExec',                  this._onApiCommandExec.bind(this)],
             ['getTermAudioInfoList',         this._onApiGetTermAudioInfoList.bind(this)],
@@ -600,8 +600,8 @@ export class Backend {
         return 'browse';
     }
 
-    /** @type {import('api').ApiHandler<'notesView'>} */
-    async _onApiNotesView({noteIds, mode, allowFallback}) {
+    /** @type {import('api').ApiHandler<'viewNotes'>} */
+    async _onApiViewNotes({noteIds, mode, allowFallback}) {
         if (noteIds.length === 1 && mode === 'edit') {
             try {
                 await this._anki.guiEditNote(noteIds[0]);

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -154,7 +154,6 @@ export class Backend {
             ['addAnkiNote',                  this._onApiAddAnkiNote.bind(this)],
             ['getAnkiNoteInfo',              this._onApiGetAnkiNoteInfo.bind(this)],
             ['injectAnkiNoteMedia',          this._onApiInjectAnkiNoteMedia.bind(this)],
-            ['noteView',                     this._onApiNoteView.bind(this)],
             ['viewNotes',                    this._onApiViewNotes.bind(this)],
             ['suspendAnkiCardsForNote',      this._onApiSuspendAnkiCardsForNote.bind(this)],
             ['commandExec',                  this._onApiCommandExec.bind(this)],
@@ -579,25 +578,6 @@ export class Backend {
             clipboardDetails,
             dictionaryMediaDetails
         );
-    }
-
-    /** @type {import('api').ApiHandler<'noteView'>} */
-    async _onApiNoteView({noteId, mode, allowFallback}) {
-        if (mode === 'edit') {
-            try {
-                await this._anki.guiEditNote(noteId);
-                return 'edit';
-            } catch (e) {
-                if (!(e instanceof Error && this._anki.isErrorUnsupportedAction(e))) {
-                    throw e;
-                } else if (!allowFallback) {
-                    throw new Error('Mode not supported');
-                }
-            }
-        }
-        // Fallback
-        await this._anki.guiBrowseNote(noteId);
-        return 'browse';
     }
 
     /** @type {import('api').ApiHandler<'viewNotes'>} */

--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -201,6 +201,14 @@ export class AnkiConnect {
     }
 
     /**
+     * @param {import('anki').NoteId[]} noteIds
+     * @returns {Promise<import('anki').CardId[]>}
+     */
+    async guiBrowseNotes(noteIds) {
+        return await this.guiBrowse(`nid:${noteIds.join(',')}`);
+    }
+
+    /**
      * Opens the note editor GUI.
      * @param {import('anki').NoteId} noteId The ID of the note.
      * @returns {Promise<void>} Nothing is returned.

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -128,13 +128,13 @@ export class API {
     }
 
     /**
-     * @param {import('api').ApiParam<'notesView', 'noteIds'>} noteIds
-     * @param {import('api').ApiParam<'noteView', 'mode'>} mode
-     * @param {import('api').ApiParam<'noteView', 'allowFallback'>} allowFallback
+     * @param {import('api').ApiParam<'viewNotes', 'noteIds'>} noteIds
+     * @param {import('api').ApiParam<'viewNotes', 'mode'>} mode
+     * @param {import('api').ApiParam<'viewNotes', 'allowFallback'>} allowFallback
      * @returns {Promise<import('api').ApiReturn<'noteView'>>}
      */
-    notesView(noteIds, mode, allowFallback) {
-        return this._invoke('notesView', {noteIds, mode, allowFallback});
+    viewNotes(noteIds, mode, allowFallback) {
+        return this._invoke('viewNotes', {noteIds, mode, allowFallback});
     }
 
     /**

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -118,20 +118,10 @@ export class API {
     }
 
     /**
-     * @param {import('api').ApiParam<'noteView', 'noteId'>} noteId
-     * @param {import('api').ApiParam<'noteView', 'mode'>} mode
-     * @param {import('api').ApiParam<'noteView', 'allowFallback'>} allowFallback
-     * @returns {Promise<import('api').ApiReturn<'noteView'>>}
-     */
-    noteView(noteId, mode, allowFallback) {
-        return this._invoke('noteView', {noteId, mode, allowFallback});
-    }
-
-    /**
      * @param {import('api').ApiParam<'viewNotes', 'noteIds'>} noteIds
      * @param {import('api').ApiParam<'viewNotes', 'mode'>} mode
      * @param {import('api').ApiParam<'viewNotes', 'allowFallback'>} allowFallback
-     * @returns {Promise<import('api').ApiReturn<'noteView'>>}
+     * @returns {Promise<import('api').ApiReturn<'viewNotes'>>}
      */
     viewNotes(noteIds, mode, allowFallback) {
         return this._invoke('viewNotes', {noteIds, mode, allowFallback});

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -128,6 +128,16 @@ export class API {
     }
 
     /**
+     * @param {import('api').ApiParam<'notesView', 'noteIds'>} noteIds
+     * @param {import('api').ApiParam<'noteView', 'mode'>} mode
+     * @param {import('api').ApiParam<'noteView', 'allowFallback'>} allowFallback
+     * @returns {Promise<import('api').ApiReturn<'noteView'>>}
+     */
+    notesView(noteIds, mode, allowFallback) {
+        return this._invoke('notesView', {noteIds, mode, allowFallback});
+    }
+
+    /**
      * @param {import('api').ApiParam<'suspendAnkiCardsForNote', 'noteId'>} noteId
      * @returns {Promise<import('api').ApiReturn<'suspendAnkiCardsForNote'>>}
      */

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -521,7 +521,8 @@ export class OptionsUtil {
             this._updateVersion21,
             this._updateVersion22,
             this._updateVersion23,
-            this._updateVersion24
+            this._updateVersion24,
+            this._updateVersion25
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1134,6 +1135,20 @@ export class OptionsUtil {
             if (Array.isArray(profileOptions.dictionaries)) {
                 for (const dictionary of profileOptions.dictionaries) {
                     dictionary.useDeinflections = true;
+                }
+            }
+        }
+    }
+
+    /**
+     * - Change 'viewNote' action to 'viewNotes'.
+     * @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion25(options) {
+        for (const profile of options.profiles) {
+            for (const hotkey of profile.options.inputs.hotkeys) {
+                if (hotkey.action === 'viewNote') {
+                    hotkey.action = 'viewNotes';
                 }
             }
         }

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -802,11 +802,6 @@ export class DisplayAnki {
     _onViewNoteButtonMenuClose(e) {
         const {detail: {action, item}} = e;
         switch (action) {
-            case 'viewNote':
-                if (item !== null) {
-                    this._viewNote(item);
-                }
-                break;
             case 'viewNotes':
                 if (item !== null) {
                     this._viewNotes(item);
@@ -847,25 +842,6 @@ export class DisplayAnki {
                 delete badgeData.icon;
                 badge.hidden = true;
             }
-        }
-    }
-
-    /**
-     * @param {HTMLElement} node
-     */
-    async _viewNote(node) {
-        const noteIds = this._getNodeNoteIds(node);
-        if (noteIds.length === 0) { return; }
-        try {
-            await this._display.application.api.viewNotes([noteIds[0]], this._noteGuiMode, false);
-        } catch (e) {
-            const displayErrors = (
-                toError(e).message === 'Mode not supported' ?
-                [this._display.displayGenerator.instantiateTemplateFragment('footer-notification-anki-view-note-error')] :
-                void 0
-            );
-            this._showErrorNotification([toError(e)], displayErrors);
-            return;
         }
     }
 
@@ -949,7 +925,7 @@ export class DisplayAnki {
         const index = this._display.selectedIndex;
         const button = this._getViewNoteButton(index);
         if (button !== null) {
-            this._viewNote(button);
+            this._viewNotes(button);
         }
     }
 

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -857,7 +857,7 @@ export class DisplayAnki {
         const noteIds = this._getNodeNoteIds(node);
         if (noteIds.length === 0) { return; }
         try {
-            await this._display.application.api.noteView(noteIds[0], this._noteGuiMode, false);
+            await this._display.application.api.viewNotes([noteIds[0]], this._noteGuiMode, false);
         } catch (e) {
             const displayErrors = (
                 toError(e).message === 'Mode not supported' ?

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -114,7 +114,7 @@ export class DisplayAnki {
             ['addNoteKanji',      () => { this._tryAddAnkiNoteForSelectedEntry('kanji'); }],
             ['addNoteTermKanji',  () => { this._tryAddAnkiNoteForSelectedEntry('term-kanji'); }],
             ['addNoteTermKana',   () => { this._tryAddAnkiNoteForSelectedEntry('term-kana'); }],
-            ['viewNote',          this._viewNoteForSelectedEntry.bind(this)]
+            ['viewNotes',         this._viewNoteForSelectedEntry.bind(this)]
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
         this._display.on('optionsUpdated', this._onOptionsUpdated.bind(this));
@@ -907,7 +907,7 @@ export class DisplayAnki {
             /** @type {Element} */
             const label = querySelectorNotNull(item, '.popup-menu-item-label');
             label.textContent = `Note ${i + 1}: ${noteId}`;
-            item.dataset.menuAction = 'viewNote';
+            item.dataset.menuAction = 'viewNotes';
             item.dataset.noteIds = `${noteId}`;
             menuBodyNode.appendChild(item);
         }

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -807,6 +807,11 @@ export class DisplayAnki {
                     this._viewNote(item);
                 }
                 break;
+            case 'viewNotes':
+                if (item !== null) {
+                    this._viewNotes(item);
+                }
+                break;
         }
     }
 
@@ -871,7 +876,7 @@ export class DisplayAnki {
         const noteIds = this._getNodeNoteIds(node);
         if (noteIds.length === 0) { return; }
         try {
-            await this._display.application.api.notesView(noteIds, this._noteGuiMode, false);
+            await this._display.application.api.viewNotes(noteIds, this._noteGuiMode, false);
         } catch (e) {
             const displayErrors = (
                 toError(e).message === 'Mode not supported' ?

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -99,11 +99,11 @@ export class DisplayAnki {
         /** @type {(event: MouseEvent) => void} */
         this._onNoteAddBind = this._onNoteAdd.bind(this);
         /** @type {(event: MouseEvent) => void} */
-        this._onViewNoteButtonClickBind = this._onViewNoteButtonClick.bind(this);
+        this._onViewNotesButtonClickBind = this._onViewNotesButtonClick.bind(this);
         /** @type {(event: MouseEvent) => void} */
-        this._onViewNoteButtonContextMenuBind = this._onViewNoteButtonContextMenu.bind(this);
+        this._onViewNotesButtonContextMenuBind = this._onViewNotesButtonContextMenu.bind(this);
         /** @type {(event: import('popup-menu').MenuCloseEvent) => void} */
-        this._onViewNoteButtonMenuCloseBind = this._onViewNoteButtonMenuClose.bind(this);
+        this._onViewNotesButtonMenuCloseBind = this._onViewNotesButtonMenuClose.bind(this);
     }
 
     /** */
@@ -114,7 +114,7 @@ export class DisplayAnki {
             ['addNoteKanji',      () => { this._tryAddAnkiNoteForSelectedEntry('kanji'); }],
             ['addNoteTermKanji',  () => { this._tryAddAnkiNoteForSelectedEntry('term-kanji'); }],
             ['addNoteTermKana',   () => { this._tryAddAnkiNoteForSelectedEntry('term-kana'); }],
-            ['viewNotes',         this._viewNoteForSelectedEntry.bind(this)]
+            ['viewNotes',         this._viewNotesForSelectedEntry.bind(this)]
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
         this._display.on('optionsUpdated', this._onOptionsUpdated.bind(this));
@@ -249,9 +249,9 @@ export class DisplayAnki {
             eventListeners.addEventListener(node, 'click', this._onNoteAddBind);
         }
         for (const node of element.querySelectorAll('.action-button[data-action=view-note]')) {
-            eventListeners.addEventListener(node, 'click', this._onViewNoteButtonClickBind);
-            eventListeners.addEventListener(node, 'contextmenu', this._onViewNoteButtonContextMenuBind);
-            eventListeners.addEventListener(node, 'menuClose', this._onViewNoteButtonMenuCloseBind);
+            eventListeners.addEventListener(node, 'click', this._onViewNotesButtonClickBind);
+            eventListeners.addEventListener(node, 'contextmenu', this._onViewNotesButtonContextMenuBind);
+            eventListeners.addEventListener(node, 'menuClose', this._onViewNotesButtonMenuCloseBind);
         }
     }
 
@@ -777,11 +777,11 @@ export class DisplayAnki {
     /**
      * @param {MouseEvent} e
      */
-    _onViewNoteButtonClick(e) {
+    _onViewNotesButtonClick(e) {
         const element = /** @type {HTMLElement} */ (e.currentTarget);
         e.preventDefault();
         if (e.shiftKey) {
-            this._showViewNoteMenu(element);
+            this._showViewNotesMenu(element);
         } else {
             this._viewNotes(element);
         }
@@ -790,16 +790,16 @@ export class DisplayAnki {
     /**
      * @param {MouseEvent} e
      */
-    _onViewNoteButtonContextMenu(e) {
+    _onViewNotesButtonContextMenu(e) {
         const element = /** @type {HTMLElement} */ (e.currentTarget);
         e.preventDefault();
-        this._showViewNoteMenu(element);
+        this._showViewNotesMenu(element);
     }
 
     /**
      * @param {import('popup-menu').MenuCloseEvent} e
      */
-    _onViewNoteButtonMenuClose(e) {
+    _onViewNotesButtonMenuClose(e) {
         const {detail: {action, item}} = e;
         switch (action) {
             case 'viewNotes':
@@ -867,7 +867,7 @@ export class DisplayAnki {
     /**
      * @param {HTMLElement} node
      */
-    _showViewNoteMenu(node) {
+    _showViewNotesMenu(node) {
         const noteIds = this._getNodeNoteIds(node);
         if (noteIds.length === 0) { return; }
 
@@ -920,8 +920,10 @@ export class DisplayAnki {
         return entry !== null ? entry.querySelector('.action-button[data-action=view-note]') : null;
     }
 
-    /** */
-    _viewNoteForSelectedEntry() {
+    /**
+     * Shows notes for selected pop-up entry when "View Notes" hotkey is used.
+     */
+    _viewNotesForSelectedEntry() {
         const index = this._display.selectedIndex;
         const button = this._getViewNoteButton(index);
         if (button !== null) {

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -783,7 +783,7 @@ export class DisplayAnki {
         if (e.shiftKey) {
             this._showViewNoteMenu(element);
         } else {
-            this._viewNote(element);
+            this._viewNotes(element);
         }
     }
 
@@ -853,6 +853,25 @@ export class DisplayAnki {
         if (noteIds.length === 0) { return; }
         try {
             await this._display.application.api.noteView(noteIds[0], this._noteGuiMode, false);
+        } catch (e) {
+            const displayErrors = (
+                toError(e).message === 'Mode not supported' ?
+                [this._display.displayGenerator.instantiateTemplateFragment('footer-notification-anki-view-note-error')] :
+                void 0
+            );
+            this._showErrorNotification([toError(e)], displayErrors);
+            return;
+        }
+    }
+
+    /**
+     * @param {HTMLElement} node
+     */
+    async _viewNotes(node) {
+        const noteIds = this._getNodeNoteIds(node);
+        if (noteIds.length === 0) { return; }
+        try {
+            await this._display.application.api.notesView(noteIds, this._noteGuiMode, false);
         } catch (e) {
             const displayErrors = (
                 toError(e).message === 'Mode not supported' ?

--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -455,7 +455,7 @@ export class AnkiController {
             throw new Error('Could not find a note to test with');
         }
 
-        await this._settingsController.application.api.noteView(noteId, mode, false);
+        await this._settingsController.application.api.viewNotes([noteId], mode, false);
     }
 
     /**

--- a/ext/js/pages/settings/keyboard-shortcuts-controller.js
+++ b/ext/js/pages/settings/keyboard-shortcuts-controller.js
@@ -62,7 +62,7 @@ export class KeyboardShortcutController {
             ['addNoteKanji',                     {scopes: new Set(['popup', 'search'])}],
             ['addNoteTermKanji',                 {scopes: new Set(['popup', 'search'])}],
             ['addNoteTermKana',                  {scopes: new Set(['popup', 'search'])}],
-            ['viewNote',                         {scopes: new Set(['popup', 'search'])}],
+            ['viewNotes',                        {scopes: new Set(['popup', 'search'])}],
             ['playAudio',                        {scopes: new Set(['popup', 'search'])}],
             ['playAudioFromSource',              {scopes: new Set(['popup', 'search']), argument: {template: 'hotkey-argument-audio-source', default: 'jpod101'}}],
             ['copyHostSelection',                {scopes: new Set(['popup'])}],

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -3878,7 +3878,7 @@
             <option value="addNoteKanji">Add kanji note</option>
             <option value="addNoteTermKanji">Add term note</option>
             <option value="addNoteTermKana">Add term note (reading)</option>
-            <option value="viewNote">View note</option>
+            <option value="viewNotes">View notes</option>
             <option value="playAudio">Play audio</option>
             <option value="playAudioFromSource">Play audio from source</option>
             <option value="copyHostSelection">Copy host window selection</option>

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -491,7 +491,7 @@ function createProfileOptionsUpdatedTestData1() {
                 {action: 'addNoteTermKanji',  argument: '',  key: 'KeyE',      modifiers: ['alt'],  scopes: ['popup', 'search'], enabled: true},
                 {action: 'addNoteTermKana',   argument: '',  key: 'KeyR',      modifiers: ['alt'],  scopes: ['popup', 'search'], enabled: true},
                 {action: 'playAudio',         argument: '',  key: 'KeyP',      modifiers: ['alt'],  scopes: ['popup', 'search'], enabled: true},
-                {action: 'viewNote',          argument: '',  key: 'KeyV',      modifiers: ['alt'],  scopes: ['popup', 'search'], enabled: true},
+                {action: 'viewNotes',         argument: '',  key: 'KeyV',      modifiers: ['alt'],  scopes: ['popup', 'search'], enabled: true},
                 {action: 'copyHostSelection', argument: '',  key: 'KeyC',      modifiers: ['ctrl'], scopes: ['popup'], enabled: true}
             ]
             /* eslint-enable @stylistic/no-multi-spaces */
@@ -604,7 +604,7 @@ function createOptionsUpdatedTestData1() {
             }
         ],
         profileCurrent: 0,
-        version: 24,
+        version: 25,
         global: {
             database: {
                 prefixWildcardsSupported: false

--- a/types/ext/api.d.ts
+++ b/types/ext/api.d.ts
@@ -193,14 +193,6 @@ type ApiSurface = {
             errors: Core.SerializedError[];
         };
     };
-    noteView: {
-        params: {
-            noteId: Anki.NoteId;
-            mode: Settings.AnkiNoteGuiMode;
-            allowFallback: boolean;
-        };
-        return: Settings.AnkiNoteGuiMode;
-    };
     viewNotes: {
         params: {
             noteIds: Anki.NoteId[];

--- a/types/ext/api.d.ts
+++ b/types/ext/api.d.ts
@@ -201,7 +201,7 @@ type ApiSurface = {
         };
         return: Settings.AnkiNoteGuiMode;
     };
-    notesView: {
+    viewNotes: {
         params: {
             noteIds: Anki.NoteId[];
             mode: Settings.AnkiNoteGuiMode;

--- a/types/ext/api.d.ts
+++ b/types/ext/api.d.ts
@@ -201,6 +201,14 @@ type ApiSurface = {
         };
         return: Settings.AnkiNoteGuiMode;
     };
+    notesView: {
+        params: {
+            noteIds: Anki.NoteId[];
+            mode: Settings.AnkiNoteGuiMode;
+            allowFallback: boolean;
+        };
+        return: Settings.AnkiNoteGuiMode;
+    };
     suspendAnkiCardsForNote: {
         params: {
             noteId: Anki.NoteId;


### PR DESCRIPTION
## Overview

This PR is to demonstrate a feature I had in mind in #610.

Now, when clicking the book icon in the pop-up, all duplicate Anki notes are shown (using 一括 as an example):

<img alt="all notes get shown in the Anki browser" src="https://github.com/themoeway/yomitan/assets/67062814/3011933d-714b-4370-926f-3006358449a5" width="500" />

## Areas of concern

The "view note(s)" button defaults to showing all notes[^1] in the browser, as opposed to only showing one card as it's done today.

Instead, the default behavior could be left unchanged, and we could add an option to "View all notes" inside the right-click context menu.

<img alt="right-click context menu" src="https://github.com/themoeway/yomitan/assets/67062814/986849de-4288-4577-a9fa-0c6fd54463ac" width="300" />

## Test Plan

Find a term with several duplicate notes in Anki

**Book icon**
- [ ] Click the book icon for that term
- [ ] All duplicate notes (within the selected scope) should be displayed in Anki

**Context menu**
- [ ] Right-click the book icon
- [ ] The IDs of all duplicate notes should appear
- [ ] Click any such ID
- [ ] Only the note corresponding to this ID should be displayed in Anki

**"View Notes" Hotkey (Alt + V)**
- [ ] Use the "View Notes" hotkey on the selected term
- [ ] All duplicate cards for this term should be displayed in Anki

**Regression**
- [ ] All the above tests should work for a term with only a single note in Anki

[^1]: This works fine even if there is only one note in the list.