### PR TITLE
Update @types/node to 20.11.5 and pin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "@types/events": "^3.0.3",
                 "@types/firefox-webext-browser": "^120.0.0",
                 "@types/jsdom": "^21.1.6",
-                "@types/node": "^20.10.6",
+                "@types/node": "20.11.5",
                 "@types/wanakana": "^4.0.6",
                 "@types/zip.js": "^2.0.32",
                 "@typescript-eslint/eslint-plugin": "^6.16.0",
@@ -1563,9 +1563,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.10.6",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
-            "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+            "version": "20.11.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+            "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -8008,9 +8008,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "20.10.6",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
-            "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+            "version": "20.11.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+            "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
             "dev": true,
             "requires": {
                 "undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@types/events": "^3.0.3",
         "@types/firefox-webext-browser": "^120.0.0",
         "@types/jsdom": "^21.1.6",
-        "@types/node": "^20.10.6",
+        "@types/node": "20.11.5",
         "@types/wanakana": "^4.0.6",
         "@types/zip.js": "^2.0.32",
         "@typescript-eslint/eslint-plugin": "^6.16.0",


### PR DESCRIPTION
Fixes the issue with #618 causing a typescript conflict. Pinning the version for now will make it so it won't break again.

https://github.com/vitejs/vite/issues/15714