### PR TITLE
Fix hotkey helper not properly returning attributesArray

### DIFF
--- a/ext/js/input/hotkey-help-controller.js
+++ b/ext/js/input/hotkey-help-controller.js
@@ -151,7 +151,7 @@ export class HotkeyHelpController {
         if (typeof hotkey !== 'string') { return null; }
         const data = /** @type {unknown} */ (parseJson(hotkey));
         if (!Array.isArray(data)) { return null; }
-        const [action, attributes, values] = data;
+        const [action, attributes, values] = /** @type {unknown[]} */ (data);
         if (typeof action !== 'string') { return null; }
         /** @type {string[]} */
         const attributesArray = [];
@@ -169,7 +169,7 @@ export class HotkeyHelpController {
         return {
             action: global ? action.substring(globalPrexix.length) : action,
             global,
-            attributes,
+            attributes: attributesArray,
             values,
             defaultAttributeValues
         };


### PR DESCRIPTION
Fixes a bug which occurred due to an implicit `any` type.