### PR TITLE
Dependency version pinning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # These dependencies should be updated manually:
+      - dependency-name: "vitest"
+        # Benchmarking is an experimental feature in vitest:
+        # https://github.com/themoeway/yomitan/pull/583#issuecomment-1925047371
+      - dependency-name: "@vitest/coverage-v8"
+        # Pinned to stay on the same version as vitest
+      - dependency-name: "@types/node"
+        # Version 20.11.6 introduces an incompatibility with vite:
+        # https://github.com/vitejs/vite/issues/15714

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
                 "stylelint": "^16.1.0",
                 "stylelint-config-recommended": "^14.0.0",
                 "ts-json-schema-generator": "^1.5.0",
-                "typescript": "5.3.3",
+                "typescript": "^5.3.3",
                 "vitest": "1.2.2"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -88,16 +88,16 @@
         "stylelint": "^16.1.0",
         "stylelint-config-recommended": "^14.0.0",
         "ts-json-schema-generator": "^1.5.0",
-        "typescript": "5.3.3",
+        "typescript": "^5.3.3",
         "vitest": "1.2.2"
     },
     "dependencies": {
         "@zip.js/zip.js": "^2.7.31",
         "dexie": "^3.2.4",
         "dexie-export-import": "^4.0.7",
-        "yomitan-handlebars": "git+https://github.com/themoeway/yomitan-handlebars.git#12aff5e3550954d7d3a98a5917ff7d579f3cce25",
         "parse5": "^7.1.2",
-        "wanakana": "^5.3.1"
+        "wanakana": "^5.3.1",
+        "yomitan-handlebars": "git+https://github.com/themoeway/yomitan-handlebars.git#12aff5e3550954d7d3a98a5917ff7d579f3cce25"
     },
     "lint-staged": {
         "*.md": "prettier --write"


### PR DESCRIPTION
_Hopefully_ this fixes dependabot's nagging once and for all.

I don't remember exactly why I pinned typescript in 19f359af78c052c7d3083fc353d37c606444f179, but I think it's no longer a problem.