### PR TITLE
Move initialization of offscreen proxy elements

### DIFF
--- a/ext/js/extension/web-extension.js
+++ b/ext/js/extension/web-extension.js
@@ -105,4 +105,12 @@ export class WebExtension extends EventDispatcher {
         this._unloaded = true;
         this.trigger('unloaded', {});
     }
+
+    /**
+     * @returns {boolean}
+     */
+    isOffscreenSupported() {
+        const {offscreen} = chrome;
+        return typeof offscreen === 'object' && offscreen !== null;
+    }
 }


### PR DESCRIPTION
This change is intending to move all of the proxy stuff out of `Backend` directly and makes the `main` function in charge of initialization. There are a few reasons behind this:

* I general, I think it's just better dependency management so Backend can remain agnostic to the details of whether or not something if a proxy.
* Backend really doesn't need to have knowledge of the Offscreen class itself, since all it does is prepare it, and the prepare can be handled externally.
* Additionally, the prepare function of Offscreen hooks `chrome.runtime.onMessage`, which should really be performed as soon as possible.


Historically, there is some weirdness involving how the chrome events used to be hooked on the service worker after the transition from removing the background page in MV3. At least one of these events needs to be hooked without being deferred, otherwise the service worker can terminate immediately and never wake back up. I'm trying to think about how to better address this as well, since I have run into some issues that are not easy to solve due to the way the API hooking is deferred. Notably, the issue of the _entire_ `API` not being able to be used until the service worker has been fully started, which can apparently take a non-trivial amount of time when large dictionaries have been installed.