### PR TITLE
`publish-chrome*`: update upload action to avoid error with `author`

### DIFF
--- a/.github/workflows/publish-chrome-development.yml
+++ b/.github/workflows/publish-chrome-development.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Upload to Google Web Store
         id: webStoreUpload
         continue-on-error: true
-        uses: cardinalby/webext-buildtools-chrome-webstore-upload-action@8db7a005529498d95d3e2e0166f6f4050d2b96a5 # pin@v1.0.10
+        uses: cardinalby/webext-buildtools-chrome-webstore-upload-action@3d829e042b559c35f7fb71676cbaf6031892a313 # v1.0.11
         with:
           zipFilePath: yomitan-chrome-dev.zip
           extensionId: ${{ secrets.G_DEVELOPMENT_EXTENSION_ID }}

--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Upload to Google Web Store
         id: webStoreUpload
         continue-on-error: true
-        uses: cardinalby/webext-buildtools-chrome-webstore-upload-action@8db7a005529498d95d3e2e0166f6f4050d2b96a5 # pin@v1.0.10
+        uses: cardinalby/webext-buildtools-chrome-webstore-upload-action@3d829e042b559c35f7fb71676cbaf6031892a313 # v1.0.11
         with:
           zipFilePath: yomitan-chrome.zip
           extensionId: ${{ secrets.G_STABLE_EXTENSION_ID }}


### PR DESCRIPTION
https://github.com/cardinalby/webext-buildtools-chrome-webstore-upload-action/issues/10