### PR TITLE
Add and fix tests with options upgrades

### DIFF
--- a/ext/data/templates/anki-field-templates-upgrade-v24.handlebars
+++ b/ext/data/templates/anki-field-templates-upgrade-v24.handlebars
@@ -21,6 +21,15 @@
 
 {{<<<<<<<}}
 {{#*inline "conjugation"}}
+    {{~#if definition.reasons~}}
+        {{~#each definition.reasons~}}
+            {{~#if (op ">" @index 0)}} « {{/if~}}
+            {{.}}
+        {{~/each~}}
+    {{~/if~}}
+{{/inline}}
+{{=======}}
+{{#*inline "conjugation"}}
     {{~#if (op ">" definition.inflectionRuleChainCandidates.length 0)~}}
         {{~set "multiple" false~}}
         {{~#if (op ">" definition.inflectionRuleChainCandidates.length 1)~}}
@@ -38,15 +47,6 @@
                 {{~/if~}}
             {{~/each~}}
         {{~#if (get "multiple")~}}</ul>{{/if~}}
-    {{~/if~}}
-{{/inline}}
-{{=======}}
-{{#*inline "conjugation"}}
-    {{~#if definition.reasons~}}
-        {{~#each definition.reasons~}}
-            {{~#if (op ">" @index 0)}} « {{/if~}}
-            {{.}}
-        {{~/each~}}
     {{~/if~}}
 {{/inline}}
 {{>>>>>>>}}

--- a/ext/data/templates/anki-field-templates-upgrade-v24.handlebars
+++ b/ext/data/templates/anki-field-templates-upgrade-v24.handlebars
@@ -86,3 +86,7 @@
         {{definition.frequencyAverage}}
     {{~/if~}}
 {{/inline}}
+
+{{~#*inline "pitch-accent-categories"~}}
+    {{~#each (pitchCategories @root)~}}{{~.~}}{{~#unless @last~}},{{~/unless~}}{{~/each~}}
+{{~/inline~}}

--- a/ext/data/templates/anki-field-templates-upgrade-v24.handlebars
+++ b/ext/data/templates/anki-field-templates-upgrade-v24.handlebars
@@ -1,3 +1,7 @@
+{{#*inline "cloze-body-kana"}}
+    {{~#if definition.cloze}}{{definition.cloze.bodyKana}}{{/if~}}
+{{/inline}}
+
 {{#*inline "phonetic-transcriptions"}}
     {{~#if (op ">" definition.phoneticTranscriptions.length 0)~}}
         <ul>
@@ -50,3 +54,35 @@
     {{~/if~}}
 {{/inline}}
 {{>>>>>>>}}
+
+{{#*inline "frequency-harmonic-rank"}}
+    {{~#if (op "===" definition.frequencyHarmonic -1) ~}}
+        9999999
+    {{~else ~}}
+        {{definition.frequencyHarmonic}}
+    {{~/if~}}
+{{/inline}}
+
+{{#*inline "frequency-harmonic-occurrence"}}
+    {{~#if (op "===" definition.frequencyHarmonic -1) ~}}
+        0
+    {{~else ~}}
+        {{definition.frequencyHarmonic}}
+    {{~/if~}}
+{{/inline}}
+
+{{#*inline "frequency-average-rank"}}
+    {{~#if (op "===" definition.frequencyAverage -1) ~}}
+        9999999
+    {{~else ~}}
+        {{definition.frequencyAverage}}
+    {{~/if~}}
+{{/inline}}
+
+{{#*inline "frequency-average-occurrence"}}
+    {{~#if (op "===" definition.frequencyAverage -1) ~}}
+        0
+    {{~else ~}}
+        {{definition.frequencyAverage}}
+    {{~/if~}}
+{{/inline}}

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -1115,7 +1115,7 @@ export class OptionsUtil {
      */
     _updateVersion23(options) {
         for (const {options: profileOptions} of options.profiles) {
-            if (profileOptions.dictionaries.length > 0) {
+            if (Array.isArray(profileOptions.dictionaries)) {
                 for (const dictionary of profileOptions.dictionaries) {
                     dictionary.partsOfSpeechFilter = true;
                 }
@@ -1131,7 +1131,7 @@ export class OptionsUtil {
         await this._applyAnkiFieldTemplatesPatch(options, '/data/templates/anki-field-templates-upgrade-v24.handlebars');
 
         for (const {options: profileOptions} of options.profiles) {
-            if (profileOptions.dictionaries.length > 0) {
+            if (Array.isArray(profileOptions.dictionaries)) {
                 for (const dictionary of profileOptions.dictionaries) {
                     dictionary.useDeinflections = true;
                 }

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -1115,8 +1115,10 @@ export class OptionsUtil {
      */
     _updateVersion23(options) {
         for (const {options: profileOptions} of options.profiles) {
-            for (const dictionary of profileOptions.dictionaries) {
-                dictionary.partsOfSpeechFilter = true;
+            if (profileOptions.dictionaries.length > 0) {
+                for (const dictionary of profileOptions.dictionaries) {
+                    dictionary.partsOfSpeechFilter = true;
+                }
             }
         }
     }
@@ -1129,8 +1131,10 @@ export class OptionsUtil {
         await this._applyAnkiFieldTemplatesPatch(options, '/data/templates/anki-field-templates-upgrade-v24.handlebars');
 
         for (const {options: profileOptions} of options.profiles) {
-            for (const dictionary of profileOptions.dictionaries) {
-                dictionary.useDeinflections = true;
+            if (profileOptions.dictionaries.length > 0) {
+                for (const dictionary of profileOptions.dictionaries) {
+                    dictionary.useDeinflections = true;
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "test-ts-test": "npx tsc --noEmit --project test/jsconfig.json",
         "test-code": "vitest run",
         "test-code-write": "vitest run --config test/data/vitest.write.config.json",
+        "test-options-update": "vitest run --config test/data/vitest.options.config.json",
         "test-build": "node ./dev/bin/build.js --dryRun --all",
         "license-report": "license-report --output=html --only=prod --fields=name --fields=installedVersion --fields=licenseType --fields=link --html.cssFile=dev/data/legal-npm.css > ext/legal-npm.html",
         "license-report-markdown": "license-report --output=markdown --only=prod --fields=name --fields=installedVersion --fields=licenseType --fields=link",

--- a/test/data/json.json
+++ b/test/data/json.json
@@ -23,6 +23,7 @@
         {"path": "test/data/dictionaries/invalid-dictionary6/index.json", "ignore": true},
         {"path": "test/jsconfig.json", "ignore": true},
         {"path": "test/data/vitest.write.config.json", "ignore": true},
+        {"path": "test/data/vitest.options.config.json", "ignore": true},
         {"path": "benches/jsconfig.json", "ignore": true},
 
         {

--- a/test/data/vitest.options.config.json
+++ b/test/data/vitest.options.config.json
@@ -1,0 +1,7 @@
+{
+    "test": {
+        "include": [
+            "../**/options-util.test.js"
+        ]
+    }
+}

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -667,7 +667,7 @@ async function testFieldTemplatesUpdate() {
             return templatePatcher.parsePatch(content).addition;
         };
 
-        /** @type {{version: number, changes: string}[]} */
+        /** @type {import('options-util').TemplateFieldUpdate[]} */
         const updates = [];
         const fileNameRegex = /^anki-field-templates-upgrade-v(\d+)\.handlebars$/;
         const templatesDirPath = path.join(dirname, '..', 'ext', 'data', 'templates');

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -1659,7 +1659,11 @@ async function testFieldTemplatesUpdate() {
     {{~else ~}}
         {{definition.frequencyAverage}}
     {{~/if~}}
-{{/inline}}`.trimStart()
+{{/inline}}
+
+{{~#*inline "pitch-accent-categories"~}}
+    {{~#each (pitchCategories @root)~}}{{~.~}}{{~#unless @last~}},{{~/unless~}}{{~/each~}}
+{{~/inline~}}`.trimStart()
             }
         ];
 

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -1628,7 +1628,7 @@ async function testFieldTemplatesUpdate() {
     {{~/if~}}
 {{/inline}}
 `.trimStart()
-            },
+            }
         ];
 
         const updatesPattern = /<<<UPDATE-ADDITIONS>>>/g;

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -1582,8 +1582,7 @@ async function testFieldTemplatesUpdate() {
             {{.}}
         {{~/each~}}
     {{~/if~}}
-{{/inline}}
-`.trimStart(),
+{{/inline}}`.trimStart(),
 
                 expected: `
 {{#*inline "conjugation"}}
@@ -1606,6 +1605,9 @@ async function testFieldTemplatesUpdate() {
         {{~#if (get "multiple")~}}</ul>{{/if~}}
     {{~/if~}}
 {{/inline}}
+{{#*inline "cloze-body-kana"}}
+    {{~#if definition.cloze}}{{definition.cloze.bodyKana}}{{/if~}}
+{{/inline}}
 
 {{#*inline "phonetic-transcriptions"}}
     {{~#if (op ">" definition.phoneticTranscriptions.length 0)~}}
@@ -1627,7 +1629,37 @@ async function testFieldTemplatesUpdate() {
         </ul>
     {{~/if~}}
 {{/inline}}
-`.trimStart()
+{{#*inline "frequency-harmonic-rank"}}
+    {{~#if (op "===" definition.frequencyHarmonic -1) ~}}
+        9999999
+    {{~else ~}}
+        {{definition.frequencyHarmonic}}
+    {{~/if~}}
+{{/inline}}
+
+{{#*inline "frequency-harmonic-occurrence"}}
+    {{~#if (op "===" definition.frequencyHarmonic -1) ~}}
+        0
+    {{~else ~}}
+        {{definition.frequencyHarmonic}}
+    {{~/if~}}
+{{/inline}}
+
+{{#*inline "frequency-average-rank"}}
+    {{~#if (op "===" definition.frequencyAverage -1) ~}}
+        9999999
+    {{~else ~}}
+        {{definition.frequencyAverage}}
+    {{~/if~}}
+{{/inline}}
+
+{{#*inline "frequency-average-occurrence"}}
+    {{~#if (op "===" definition.frequencyAverage -1) ~}}
+        0
+    {{~else ~}}
+        {{definition.frequencyAverage}}
+    {{~/if~}}
+{{/inline}}`.trimStart()
             }
         ];
 

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -674,7 +674,8 @@ async function testFieldTemplatesUpdate() {
             {version: 10, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v10.handlebars')},
             {version: 12, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v12.handlebars')},
             {version: 13, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v13.handlebars')},
-            {version: 21, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v21.handlebars')}
+            {version: 21, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v21.handlebars')},
+            {version: 24, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v24.handlebars')}
         ];
         /**
          * @param {number} startVersion
@@ -1569,7 +1570,65 @@ async function testFieldTemplatesUpdate() {
 {{/inline}}
 
 {{~> (lookup . "marker") ~}}`.trimStart()
-            }
+            },
+            {
+                oldVersion: 21,
+                newVersion: 24,
+                old: `
+{{#*inline "conjugation"}}
+    {{~#if (op ">" definition.inflectionRuleChainCandidates.length 0)~}}
+        {{~set "multiple" false~}}
+        {{~#if (op ">" definition.inflectionRuleChainCandidates.length 1)~}}
+            {{~set "multiple" true~}}
+        {{~/if~}}
+        {{~#if (get "multiple")~}}<ul>{{/if~}}
+            {{~#each definition.inflectionRuleChainCandidates~}}
+                {{~#if (op ">" inflectionRules.length 0)~}}
+                    {{~#if (get "multiple")~}}<li>{{/if~}}
+                    {{~#each inflectionRules~}}
+                        {{~#if (op ">" @index 0)}} « {{/if~}}
+                        {{.}}
+                    {{~/each~}}
+                    {{~#if (get "multiple")~}}</li>{{/if~}}
+                {{~/if~}}
+            {{~/each~}}
+        {{~#if (get "multiple")~}}</ul>{{/if~}}
+    {{~/if~}}
+{{/inline}}
+`.trimStart(),
+
+                expected: `
+{{#*inline "conjugation"}}
+    {{~#if definition.reasons~}}
+        {{~#each definition.reasons~}}
+            {{~#if (op ">" @index 0)}} « {{/if~}}
+            {{.}}
+        {{~/each~}}
+    {{~/if~}}
+{{/inline}}
+
+{{#*inline "phonetic-transcriptions"}}
+    {{~#if (op ">" definition.phoneticTranscriptions.length 0)~}}
+        <ul>
+            {{~#each definition.phoneticTranscriptions~}}
+                {{~#each phoneticTranscriptions~}}
+                    <li>
+                        {{~set "any" false~}}
+                        {{~#each tags~}}
+                            {{~#if (get "any")}}, {{else}}<i>({{/if~}}
+                            {{name}}
+                            {{~set "any" true~}}
+                        {{~/each~}}
+                        {{~#if (get "any")}})</i> {{/if~}}
+                        {{ipa~}}
+                    </li>
+                {{~/each~}}
+            {{~/each~}}
+        </ul>
+    {{~/if~}}
+{{/inline}}
+`.trimStart()
+            },
         ];
 
         const updatesPattern = /<<<UPDATE-ADDITIONS>>>/g;

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -663,20 +663,25 @@ async function testFieldTemplatesUpdate() {
          * @returns {string}
          */
         const loadDataFile = (fileName) => {
-            const content = fs.readFileSync(path.join(dirname, '..', 'ext', fileName), {encoding: 'utf8'});
+            const content = fs.readFileSync(fileName, {encoding: 'utf8'});
             return templatePatcher.parsePatch(content).addition;
         };
-        const updates = [
-            {version: 2, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v2.handlebars')},
-            {version: 4, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v4.handlebars')},
-            {version: 6, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v6.handlebars')},
-            {version: 8, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v8.handlebars')},
-            {version: 10, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v10.handlebars')},
-            {version: 12, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v12.handlebars')},
-            {version: 13, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v13.handlebars')},
-            {version: 21, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v21.handlebars')},
-            {version: 24, changes: loadDataFile('data/templates/anki-field-templates-upgrade-v24.handlebars')}
-        ];
+
+        /** @type {{version: number, changes: string}[]} */
+        const updates = [];
+        const fileNameRegex = /^anki-field-templates-upgrade-v(\d+)\.handlebars$/;
+        const templatesDirPath = path.join(dirname, '..', 'ext', 'data', 'templates');
+        const templatesDir = fs.readdirSync(templatesDirPath, {encoding: 'utf8'});
+        for (const fileName of templatesDir) {
+            const match = fileNameRegex.exec(fileName);
+            if (match !== null) {
+                updates.push({
+                    version: Number.parseInt(match[1]),
+                    changes: loadDataFile(path.join(templatesDirPath, match[0]))
+                });
+            }
+        }
+        updates.sort((a, b) => a.version - b.version);
         /**
          * @param {number} startVersion
          * @param {number} targetVersion

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -1576,6 +1576,17 @@ async function testFieldTemplatesUpdate() {
                 newVersion: 24,
                 old: `
 {{#*inline "conjugation"}}
+    {{~#if definition.reasons~}}
+        {{~#each definition.reasons~}}
+            {{~#if (op ">" @index 0)}} « {{/if~}}
+            {{.}}
+        {{~/each~}}
+    {{~/if~}}
+{{/inline}}
+`.trimStart(),
+
+                expected: `
+{{#*inline "conjugation"}}
     {{~#if (op ">" definition.inflectionRuleChainCandidates.length 0)~}}
         {{~set "multiple" false~}}
         {{~#if (op ">" definition.inflectionRuleChainCandidates.length 1)~}}
@@ -1593,17 +1604,6 @@ async function testFieldTemplatesUpdate() {
                 {{~/if~}}
             {{~/each~}}
         {{~#if (get "multiple")~}}</ul>{{/if~}}
-    {{~/if~}}
-{{/inline}}
-`.trimStart(),
-
-                expected: `
-{{#*inline "conjugation"}}
-    {{~#if definition.reasons~}}
-        {{~#each definition.reasons~}}
-            {{~#if (op ">" @index 0)}} « {{/if~}}
-            {{.}}
-        {{~/each~}}
     {{~/if~}}
 {{/inline}}
 

--- a/types/ext/options-util.d.ts
+++ b/types/ext/options-util.d.ts
@@ -24,3 +24,8 @@ export type IntermediateOptions = Core.SafeAny;
 export type LegacyUpdateFunction = (options: LegacyOptions) => void;
 
 export type UpdateFunction = (options: IntermediateOptions) => void | Promise<void>;
+
+export type TemplateFieldUpdate = {
+    version: number;
+    changes: string;
+};


### PR DESCRIPTION
Adds `test-options-update` test. And changes to actually test the latest handlebars update changes. The test definitions here are quite static but having these tests be updated before merging updateVersion things would be a good idea. Hopefully to prevent #670 from happening again.

I had to add `if (profileOptions.dictionaries.length > 0) {` to the dict updates here due to the tests trying to run through some (maybe old?) dict that isn't in an array. Not sure if that's the best way to do that. 

Not the most knowledgeable on tests so not sure if I've done everything else right either.