### PR TITLE
Update to zip.js for tests

### DIFF
--- a/dev/dictionary-archive-util.js
+++ b/dev/dictionary-archive-util.js
@@ -29,7 +29,8 @@ import {parseJson} from './json.js';
 export async function createDictionaryArchiveData(dictionaryDirectory, dictionaryName) {
     const fileNames = readdirSync(dictionaryDirectory);
     const zipFileWriter = new BlobWriter();
-    // Curiously, any level other than 0 here will cause DictionaryImporter.importDictionary to fail.
+    // Level 0 compression used since decompression in the node environment is not supported.
+    // See dev/lib/zip.js for more details.
     const zipWriter = new ZipWriter(zipFileWriter, {
         level: 0
     });

--- a/dev/dictionary-archive-util.js
+++ b/dev/dictionary-archive-util.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2024  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {BlobWriter, TextReader, TextWriter, Uint8ArrayReader, ZipReader, ZipWriter} from '@zip.js/zip.js';
+import {readFileSync, readdirSync} from 'fs';
+import {join} from 'path';
+import {parseJson} from './json.js';
+
+/**
+ * Creates a zip archive from the given dictionary directory.
+ * @param {string} dictionaryDirectory
+ * @param {string} [dictionaryName]
+ * @returns {Promise<ArrayBuffer>}
+ */
+export async function createDictionaryArchiveData(dictionaryDirectory, dictionaryName) {
+    const fileNames = readdirSync(dictionaryDirectory);
+    const zipFileWriter = new BlobWriter();
+    const zipWriter = new ZipWriter(zipFileWriter);
+    for (const fileName of fileNames) {
+        if (/\.json$/.test(fileName)) {
+            const content = readFileSync(join(dictionaryDirectory, fileName), {encoding: 'utf8'});
+            /** @type {import('dictionary-data').Index} */
+            const json = parseJson(content);
+            if (fileName === 'index.json' && typeof dictionaryName === 'string') {
+                json.title = dictionaryName;
+            }
+            await zipWriter.add(fileName, new TextReader(JSON.stringify(json, null, 0)));
+        } else {
+            const content = readFileSync(join(dictionaryDirectory, fileName), {encoding: null});
+            await zipWriter.add(fileName, new Blob([content]).stream());
+        }
+    }
+    const blob = await zipWriter.close();
+    return await blob.arrayBuffer();
+}
+
+/**
+ * @param {import('@zip.js/zip.js').Entry} entry
+ * @returns {Promise<string>}
+ */
+export async function readArchiveEntryDataString(entry) {
+    if (typeof entry.getData === 'undefined') { throw new Error('Cannot get index data'); }
+    return await entry.getData(new TextWriter());
+}
+
+/**
+ * @template [T=unknown]
+ * @param {import('@zip.js/zip.js').Entry} entry
+ * @returns {Promise<T>}
+ */
+export async function readArchiveEntryDataJson(entry) {
+    const indexContent = await readArchiveEntryDataString(entry);
+    return parseJson(indexContent);
+}
+
+/**
+ * @param {ArrayBuffer} data
+ * @returns {Promise<import('@zip.js/zip.js').Entry[]>}
+ */
+export async function getDictionaryArchiveEntries(data) {
+    const zipFileReader = new Uint8ArrayReader(new Uint8Array(data));
+    const zipReader = new ZipReader(zipFileReader);
+    return await zipReader.getEntries();
+}
+
+/**
+ * @template T
+ * @param {import('@zip.js/zip.js').Entry[]} entries
+ * @param {string} fileName
+ * @returns {Promise<T>}
+ */
+export async function getDictionaryArchiveJson(entries, fileName) {
+    const entry = entries.find((item) => item.filename === fileName);
+    if (typeof entry === 'undefined') { throw new Error(`File not found: ${fileName}`); }
+    return await readArchiveEntryDataJson(entry);
+}
+
+/**
+ * @returns {string}
+ */
+export function getIndexFileName() {
+    return 'index.json';
+}
+
+/**
+ * @param {ArrayBuffer} data
+ * @returns {Promise<import('dictionary-data').Index>}
+ */
+export async function getDictionaryArchiveIndex(data) {
+    const entries = await getDictionaryArchiveEntries(data);
+    return await getDictionaryArchiveJson(entries, getIndexFileName());
+}

--- a/dev/dictionary-archive-util.js
+++ b/dev/dictionary-archive-util.js
@@ -29,7 +29,10 @@ import {parseJson} from './json.js';
 export async function createDictionaryArchiveData(dictionaryDirectory, dictionaryName) {
     const fileNames = readdirSync(dictionaryDirectory);
     const zipFileWriter = new BlobWriter();
-    const zipWriter = new ZipWriter(zipFileWriter);
+    // Curiously, any level other than 0 here will cause DictionaryImporter.importDictionary to fail.
+    const zipWriter = new ZipWriter(zipFileWriter, {
+        level: 0
+    });
     for (const fileName of fileNames) {
         if (/\.json$/.test(fileName)) {
             const content = readFileSync(join(dictionaryDirectory, fileName), {encoding: 'utf8'});

--- a/dev/lib/zip.js
+++ b/dev/lib/zip.js
@@ -15,4 +15,18 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/**
+ * This script is importing a file within the '@zip.js/zip.js' dependency rather than
+ * simply importing '@zip.js/zip.js'.
+ *
+ * This is done in order to only import the subset of functionality that the extension needs.
+ *
+ * In this case, this subset only includes the components to support decompression using web workers.
+ *
+ * Therefore, if this file or the built library file is imported in a development, testing, or
+ * benchmark script, it will not be able to properly decompress the data of compressed zip files.
+ *
+ * As a workaround, testing zip data can be generated using {level: 0} compression.
+ */
+
 export * from '@zip.js/zip.js/lib/zip.js';

--- a/dev/util.js
+++ b/dev/util.js
@@ -17,9 +17,7 @@
  */
 
 import fs from 'fs';
-import JSZip from 'jszip';
 import path from 'path';
-import {parseJson} from './json.js';
 
 /**
  * @param {string} baseDirectory
@@ -46,49 +44,4 @@ export function getAllFiles(baseDirectory, predicate = null) {
         }
     }
     return results;
-}
-
-/**
- * Creates a zip archive from the given dictionary directory.
- * @param {string} dictionaryDirectory
- * @param {string} [dictionaryName]
- * @returns {import('jszip')}
- */
-export function createDictionaryArchive(dictionaryDirectory, dictionaryName) {
-    const fileNames = fs.readdirSync(dictionaryDirectory);
-
-    // Const zipFileWriter = new BlobWriter();
-    // const zipWriter = new ZipWriter(zipFileWriter);
-    const archive = new JSZip();
-
-    for (const fileName of fileNames) {
-        if (/\.json$/.test(fileName)) {
-            const content = fs.readFileSync(path.join(dictionaryDirectory, fileName), {encoding: 'utf8'});
-            const json = parseJson(content);
-            if (fileName === 'index.json' && typeof dictionaryName === 'string') {
-                /** @type {import('dictionary-data').Index} */ (json).title = dictionaryName;
-            }
-            archive.file(fileName, JSON.stringify(json, null, 0));
-
-            // Await zipWriter.add(fileName, new TextReader(JSON.stringify(json, null, 0)));
-        } else {
-            const content = fs.readFileSync(path.join(dictionaryDirectory, fileName), {encoding: null});
-            archive.file(fileName, content);
-
-            // console.log('adding');
-            // const r = new TextReader(content);
-            // console.log(r.readUint8Array(0, 10));
-            // console.log('reader done');
-            // await zipWriter.add(fileName, r);
-            // console.log('??');
-        }
-    }
-    // Await zipWriter.close();
-
-    // Retrieves the Blob object containing the zip content into `zipFileBlob`. It
-    // is also returned by zipWriter.close() for more convenience.
-    // const zipFileBlob = await zipFileWriter.getData();
-    return archive;
-
-    // Return zipFileBlob;
 }

--- a/test/fixtures/translator-test.js
+++ b/test/fixtures/translator-test.js
@@ -21,8 +21,8 @@ import {readFileSync} from 'fs';
 import {fileURLToPath} from 'node:url';
 import {dirname, join} from 'path';
 import {expect, vi} from 'vitest';
+import {createDictionaryArchiveData} from '../../dev/dictionary-archive-util.js';
 import {parseJson} from '../../dev/json.js';
-import {createDictionaryArchive} from '../../dev/util.js';
 import {DictionaryDatabase} from '../../ext/js/dictionary/dictionary-database.js';
 import {DictionaryImporter} from '../../ext/js/dictionary/dictionary-importer.js';
 import {Translator} from '../../ext/js/language/translator.js';
@@ -45,8 +45,7 @@ vi.stubGlobal('chrome', chrome);
  */
 export async function createTranslatorContext(dictionaryDirectory, dictionaryName) {
     // Dictionary
-    const testDictionary = createDictionaryArchive(dictionaryDirectory, dictionaryName);
-    const testDictionaryContent = await testDictionary.generateAsync({type: 'arraybuffer'});
+    const testDictionaryData = await createDictionaryArchiveData(dictionaryDirectory, dictionaryName);
 
     // Setup database
     const dictionaryImporterMediaLoader = new DictionaryImporterMediaLoader();
@@ -56,7 +55,7 @@ export async function createTranslatorContext(dictionaryDirectory, dictionaryNam
 
     const {errors} = await dictionaryImporter.importDictionary(
         dictionaryDatabase,
-        testDictionaryContent,
+        testDictionaryData,
         {prefixWildcardsSupported: true}
     );
 

--- a/test/playwright/integration.spec.js
+++ b/test/playwright/integration.spec.js
@@ -16,7 +16,7 @@
  */
 
 import path from 'path';
-import {createDictionaryArchive} from '../../dev/util.js';
+import {createDictionaryArchiveData} from '../../dev/dictionary-archive-util.js';
 import {deferPromise} from '../../ext/js/core/utilities.js';
 import {
     expect,
@@ -67,12 +67,11 @@ test('anki add', async ({context, page, extensionId}) => {
     await page.goto(`chrome-extension://${extensionId}/settings.html`);
 
     // Load in test dictionary
-    const dictionary = createDictionaryArchive(path.join(root, 'test/data/dictionaries/valid-dictionary1'), 'valid-dictionary1');
-    const testDictionarySource = await dictionary.generateAsync({type: 'arraybuffer'});
+    const dictionary = await createDictionaryArchiveData(path.join(root, 'test/data/dictionaries/valid-dictionary1'), 'valid-dictionary1');
     await page.locator('input[id="dictionary-import-file-input"]').setInputFiles({
         name: 'valid-dictionary1.zip',
         mimeType: 'application/x-zip',
-        buffer: Buffer.from(testDictionarySource)
+        buffer: Buffer.from(dictionary)
     });
     await expect(page.locator('id=dictionaries')).toHaveText('Dictionaries (1 installed, 1 enabled)', {timeout: 5 * 60 * 1000});
 


### PR DESCRIPTION
This change updates the test code to use zip.js instead of jszip.

I ran into one curiosity while doing this: allowing `createDictionaryArchiveData` to generate compressed data fails for some reason, and I call this out here:

https://github.com/themoeway/yomitan/blob/e3e3b9a912a895b6cde0702e87280e8a3475d8f4/dev/dictionary-archive-util.js#L32-L35

This seems to stem from the test scripts importing directly from `'@zip.js/zip.js'`, whereas the build application uses `'@zip.js/zip.js/lib/zip.js'`. If I change either of them to match the other, the tests work as expected. This change stems from #307.

@djahandarie Is there a reason why `'@zip.js/zip.js/lib/zip.js'` is used here vs just `'@zip.js/zip.js'`? Comparing the generated files after running build-libs, it does add a lot of additional code, but I haven't completely looked into what's causing the difference.

https://github.com/themoeway/yomitan/blob/4aaa9f15d97668203741c1731f15e710ae8b8294/dev/lib/zip.js#L18

For example of what happens when level is not 0, which seems to appear like the data isn't being decompressed:

<details>
    <summary>Expand/collapse log</summary>

    >npx vitest run test/database.test.js          

    RUN  v1.2.2 yomitan

    ❯ test/database.test.js (10) 434ms
    ❯ Database (10) 433ms
        × Database invalid usage
        ❯ Invalid dictionaries (6)
        ❯ Invalid dictionary: 'invalid-dictionary1' (1)
            × Has invalid data
        ❯ Invalid dictionary: 'invalid-dictionary2' (1)
            × Has invalid data
        ❯ Invalid dictionary: 'invalid-dictionary3' (1)
            × Has invalid data
        ❯ Invalid dictionary: 'invalid-dictionary4' (1)
            × Has invalid data
        ❯ Invalid dictionary: 'invalid-dictionary5' (1)
            × Has invalid data
        ❯ Invalid dictionary: 'invalid-dictionary6' (1)
            × Has invalid data
        ❯ Database valid usage (1)
        × Import data and test
        ❯ Database cleanup (2)
        ❯ Testing cleanup method 'purge' (1)
            × Import data and test
        ❯ Testing cleanup method 'delete' (1)
            × Import data and test

    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 10 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
    FAIL  test/database.test.js > Database > Database invalid usage
    SyntaxError: Unexpected token '�', "�V*�,�IU�R"... is not valid JSON
    ❯ Module.parseJson ext/js/core/json.js:29:17
        27| export function parseJson(value) {
        28|     // eslint-disable-next-line no-restricted-syntax
        29|     return JSON.parse(value);
        |                 ^
        30| }
        31| 
    ❯ DictionaryImporter.importDictionary ext/js/dictionary/dictionary-importer.js:94:71
    ❯ test/database.test.js:145:9

    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/10]⎯
    FAIL  test/database.test.js > Database > Invalid dictionaries > Invalid dictionary: 'invalid-dictionary1' > Has invalid data
    AssertionError: expected [Function] to throw error including 'Dictionary has invalid data' but got 'Unexpected token \'M\', "M\ufffd1\n\u…'

    - Expected
    + Received

    - Dictionary has invalid data
    + Unexpected token 'M', "M�1
    + �0►Dѫ�"... is not valid JSON

    ❯ test/database.test.js:170:17


    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/10]⎯
    FAIL  test/database.test.js > Database > Invalid dictionaries > Invalid dictionary: 'invalid-dictionary2' > Has invalid data
    AssertionError: expected [Function] to throw error including 'Dictionary has invalid data' but got 'Unexpected token \'\u0015\', "\u0015\…'

    - Expected
    + Received

    - Dictionary has invalid data
    + Unexpected token '§', "§�1♫�0♀F�X"... is not valid JSON

    ❯ test/database.test.js:170:17


    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/10]⎯
    FAIL  test/database.test.js > Database > Invalid dictionaries > Invalid dictionary: 'invalid-dictionary3' > Has invalid data
    FAIL  test/database.test.js > Database > Invalid dictionaries > Invalid dictionary: 'invalid-dictionary4' > Has invalid data
    FAIL  test/database.test.js > Database > Invalid dictionaries > Invalid dictionary: 'invalid-dictionary5' > Has invalid data
    FAIL  test/database.test.js > Database > Invalid dictionaries > Invalid dictionary: 'invalid-dictionary6' > Has invalid data
    AssertionError: expected [Function] to throw error including 'Dictionary has invalid data' but got 'Unexpected token \'M\', "M\ufffd1\u00…'

    - Expected
    + Received

    - Dictionary has invalid data
    + Unexpected token 'M', "M�1♫�0♀F�X"... is not valid JSON

    ❯ test/database.test.js:170:17


    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/10]⎯
    FAIL  test/database.test.js > Database > Database valid usage > Import data and test
    SyntaxError: Unexpected token '�', "�V*�,�IU�R"... is not valid JSON
    ❯ Module.parseJson ext/js/core/json.js:29:17
        27| export function parseJson(value) {
        28|     // eslint-disable-next-line no-restricted-syntax
        29|     return JSON.parse(value);
        |                 ^
        30| }
        31| 
    ❯ DictionaryImporter.importDictionary ext/js/dictionary/dictionary-importer.js:94:71
    ❯ test/database.test.js:198:86

    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/10]⎯
    FAIL  test/database.test.js > Database > Database cleanup > Testing cleanup method 'purge' > Import data and test
    FAIL  test/database.test.js > Database > Database cleanup > Testing cleanup method 'delete' > Import data and test
    SyntaxError: Unexpected token '�', "�V*�,�IU�R"... is not valid JSON
    ❯ Module.parseJson ext/js/core/json.js:29:17
        27| export function parseJson(value) {
        28|     // eslint-disable-next-line no-restricted-syntax
        29|     return JSON.parse(value);
        |                 ^
        30| }
        31|
    ❯ DictionaryImporter.importDictionary ext/js/dictionary/dictionary-importer.js:94:71
    ❯ test/database.test.js:322:17

    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/10]⎯
    Test Files  1 failed (1)
        Tests  10 failed (10)
    Start at  11:27:25
    Duration  1.23s (transform 369ms, setup 0ms, collect 498ms, tests 434ms, environment 0ms, prepare 90ms)
</details>