### PR TITLE
Application data refactor

### DIFF
--- a/ext/js/app/content-script-main.js
+++ b/ext/js/app/content-script-main.js
@@ -25,7 +25,7 @@ await Application.main(async (application) => {
     const hotkeyHandler = new HotkeyHandler();
     hotkeyHandler.prepare(application.crossFrame);
 
-    const popupFactory = new PopupFactory(application, frameId);
+    const popupFactory = new PopupFactory(application);
     popupFactory.prepare();
 
     const frontend = new Frontend({

--- a/ext/js/app/content-script-main.js
+++ b/ext/js/app/content-script-main.js
@@ -22,11 +22,6 @@ import {Frontend} from './frontend.js';
 import {PopupFactory} from './popup-factory.js';
 
 await Application.main(async (application) => {
-    const {tabId, frameId} = await application.api.frameInformationGet();
-    if (typeof frameId !== 'number') {
-        throw new Error('Failed to get frameId');
-    }
-
     const hotkeyHandler = new HotkeyHandler();
     hotkeyHandler.prepare(application.crossFrame);
 

--- a/ext/js/app/content-script-main.js
+++ b/ext/js/app/content-script-main.js
@@ -30,8 +30,6 @@ await Application.main(async (application) => {
 
     const frontend = new Frontend({
         application,
-        tabId,
-        frameId,
         popupFactory,
         depth: 0,
         parentPopupId: null,

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -705,10 +705,7 @@ export class Frontend {
         const {tabId, frameId} = this._application;
         /** @type {import('display').HistoryContent} */
         const detailsContent = {
-            contentOrigin: {
-                tabId: tabId !== null ? tabId : void 0,
-                frameId: frameId !== null ? frameId : void 0
-            }
+            contentOrigin: {tabId, frameId}
         };
         if (dictionaryEntries !== null) {
             detailsContent.dictionaryEntries = dictionaryEntries;

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -39,8 +39,6 @@ export class Frontend {
         pageType,
         popupFactory,
         depth,
-        tabId,
-        frameId,
         parentPopupId,
         parentFrameId,
         useProxyPopup,
@@ -57,10 +55,6 @@ export class Frontend {
         this._popupFactory = popupFactory;
         /** @type {number} */
         this._depth = depth;
-        /** @type {number|undefined} */
-        this._tabId = tabId;
-        /** @type {number} */
-        this._frameId = frameId;
         /** @type {?string} */
         this._parentPopupId = parentPopupId;
         /** @type {?number} */
@@ -588,8 +582,13 @@ export class Frontend {
             return null;
         }
 
+        const {frameId} = this._application;
+        if (frameId === null) {
+            return null;
+        }
+
         return await this._popupFactory.getOrCreatePopup({
-            frameId: this._frameId,
+            frameId,
             depth: this._depth,
             childrenSupported: this._childrenSupported
         });
@@ -703,11 +702,12 @@ export class Frontend {
         };
         if (sentence !== null) { detailsState.sentence = sentence; }
         if (documentTitle !== null) { detailsState.documentTitle = documentTitle; }
+        const {tabId, frameId} = this._application;
         /** @type {import('display').HistoryContent} */
         const detailsContent = {
             contentOrigin: {
-                tabId: this._tabId,
-                frameId: this._frameId
+                tabId: tabId !== null ? tabId : void 0,
+                frameId: frameId !== null ? frameId : void 0
             }
         };
         if (dictionaryEntries !== null) {
@@ -819,7 +819,7 @@ export class Frontend {
      */
     _signalFrontendReady(targetFrameId) {
         /** @type {import('application').ApiMessageNoFrameId<'frontendReady'>} */
-        const message = {action: 'frontendReady', params: {frameId: this._frameId}};
+        const message = {action: 'frontendReady', params: {frameId: this._application.frameId}};
         if (targetFrameId === null) {
             this._application.api.broadcastTab(message);
         } else {
@@ -867,7 +867,7 @@ export class Frontend {
             }
 
             chrome.runtime.onMessage.addListener(onMessage);
-            this._application.api.broadcastTab({action: 'frontendRequestReadyBroadcast', params: {frameId: this._frameId}});
+            this._application.api.broadcastTab({action: 'frontendRequestReadyBroadcast', params: {frameId: this._application.frameId}});
         });
     }
 

--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -29,13 +29,10 @@ export class PopupFactory {
     /**
      * Creates a new instance.
      * @param {import('../application.js').Application} application
-     * @param {number} frameId The frame ID of the host frame.
      */
-    constructor(application, frameId) {
+    constructor(application) {
         /** @type {import('../application.js').Application} */
         this._application = application;
-        /** @type {number} */
-        this._frameId = frameId;
         /** @type {FrameOffsetForwarder} */
         this._frameOffsetForwarder = new FrameOffsetForwarder(application.crossFrame);
         /** @type {Map<string, import('popup').PopupAny>} */
@@ -115,6 +112,9 @@ export class PopupFactory {
             depth = 0;
         }
 
+        const currentFrameId = this._application.frameId;
+        if (currentFrameId === null) { throw new Error('Cannot create popup: no frameId'); }
+
         if (popupWindow) {
             // New unique id
             if (id === null) {
@@ -124,11 +124,11 @@ export class PopupFactory {
                 application: this._application,
                 id,
                 depth,
-                frameId: this._frameId
+                frameId: currentFrameId
             });
             this._popups.set(id, popup);
             return popup;
-        } else if (frameId === this._frameId) {
+        } else if (frameId === currentFrameId) {
             // New unique id
             if (id === null) {
                 id = generateId(16);
@@ -137,7 +137,7 @@ export class PopupFactory {
                 application: this._application,
                 id,
                 depth,
-                frameId: this._frameId,
+                frameId: currentFrameId,
                 childrenSupported
             });
             if (parent !== null) {

--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -37,7 +37,7 @@ export class PopupFactory {
         /** @type {number} */
         this._frameId = frameId;
         /** @type {FrameOffsetForwarder} */
-        this._frameOffsetForwarder = new FrameOffsetForwarder(application.crossFrame, frameId);
+        this._frameOffsetForwarder = new FrameOffsetForwarder(application.crossFrame);
         /** @type {Map<string, import('popup').PopupAny>} */
         this._popups = new Map();
         /** @type {Map<string, {popup: import('popup').PopupAny, token: string}[]>} */

--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -155,13 +155,12 @@ export class PopupFactory {
                 throw new Error('Invalid frameId');
             }
             const useFrameOffsetForwarder = (parentPopupId === null);
-            /** @type {{id: string, depth: number, frameId: number}} */
-            const info = await this._application.crossFrame.invoke(frameId, 'popupFactoryGetOrCreatePopup', /** @type {import('popup-factory').GetOrCreatePopupDetails} */ ({
+            const info = await this._application.crossFrame.invoke(frameId, 'popupFactoryGetOrCreatePopup', {
                 id,
                 parentPopupId,
                 frameId,
                 childrenSupported
-            }));
+            });
             id = info.id;
             const popup = new PopupProxy({
                 application: this._application,

--- a/ext/js/application.js
+++ b/ext/js/application.js
@@ -60,10 +60,8 @@ export class Application extends EventDispatcher {
      * Creates a new instance. The instance should not be used until it has been fully prepare()'d.
      * @param {API} api
      * @param {CrossFrameAPI} crossFrameApi
-     * @param {?number} tabId
-     * @param {?number} frameId
      */
-    constructor(api, crossFrameApi, tabId, frameId) {
+    constructor(api, crossFrameApi) {
         super();
 
         /** @type {WebExtension} */
@@ -86,10 +84,6 @@ export class Application extends EventDispatcher {
         this._crossFrame = crossFrameApi;
         /** @type {boolean} */
         this._isReady = false;
-        /** @type {?number} */
-        this._tabId = tabId;
-        /** @type {?number} */
-        this._frameId = frameId;
 
         /* eslint-disable @stylistic/no-multi-spaces */
         /** @type {import('application').ApiMap} */
@@ -130,14 +124,14 @@ export class Application extends EventDispatcher {
      * @type {?number}
      */
     get tabId() {
-        return this._tabId;
+        return this._crossFrame.tabId;
     }
 
     /**
      * @type {?number}
      */
     get frameId() {
-        return this._frameId;
+        return this._crossFrame.frameId;
     }
 
     /**
@@ -178,7 +172,7 @@ export class Application extends EventDispatcher {
         const {tabId = null, frameId = null} = await api.frameInformationGet();
         const crossFrameApi = new CrossFrameAPI(api, tabId, frameId);
         crossFrameApi.prepare();
-        const application = new Application(api, crossFrameApi, tabId, frameId);
+        const application = new Application(api, crossFrameApi);
         application.prepare();
         try {
             await mainFunction(application);

--- a/ext/js/application.js
+++ b/ext/js/application.js
@@ -60,8 +60,10 @@ export class Application extends EventDispatcher {
      * Creates a new instance. The instance should not be used until it has been fully prepare()'d.
      * @param {API} api
      * @param {CrossFrameAPI} crossFrameApi
+     * @param {?number} tabId
+     * @param {?number} frameId
      */
-    constructor(api, crossFrameApi) {
+    constructor(api, crossFrameApi, tabId, frameId) {
         super();
 
         /** @type {WebExtension} */
@@ -84,6 +86,10 @@ export class Application extends EventDispatcher {
         this._crossFrame = crossFrameApi;
         /** @type {boolean} */
         this._isReady = false;
+        /** @type {?number} */
+        this._tabId = tabId;
+        /** @type {?number} */
+        this._frameId = frameId;
 
         /* eslint-disable @stylistic/no-multi-spaces */
         /** @type {import('application').ApiMap} */
@@ -108,7 +114,6 @@ export class Application extends EventDispatcher {
      * @type {API}
      */
     get api() {
-        if (this._api === null) { throw new Error('Not prepared'); }
         return this._api;
     }
 
@@ -118,8 +123,21 @@ export class Application extends EventDispatcher {
      * @type {CrossFrameAPI}
      */
     get crossFrame() {
-        if (this._crossFrame === null) { throw new Error('Not prepared'); }
         return this._crossFrame;
+    }
+
+    /**
+     * @type {?number}
+     */
+    get tabId() {
+        return this._tabId;
+    }
+
+    /**
+     * @type {?number}
+     */
+    get frameId() {
+        return this._frameId;
     }
 
     /**
@@ -160,7 +178,7 @@ export class Application extends EventDispatcher {
         const {tabId = null, frameId = null} = await api.frameInformationGet();
         const crossFrameApi = new CrossFrameAPI(api, tabId, frameId);
         crossFrameApi.prepare();
-        const application = new Application(api, crossFrameApi);
+        const application = new Application(api, crossFrameApi, tabId, frameId);
         application.prepare();
         try {
             await mainFunction(application);

--- a/ext/js/application.js
+++ b/ext/js/application.js
@@ -169,7 +169,7 @@ export class Application extends EventDispatcher {
         const webExtension = new WebExtension();
         const api = new API(webExtension);
         await this.waitForBackendReady(webExtension);
-        const {tabId = null, frameId = null} = await api.frameInformationGet();
+        const {tabId, frameId} = await api.frameInformationGet();
         const crossFrameApi = new CrossFrameAPI(api, tabId, frameId);
         crossFrameApi.prepare();
         const application = new Application(api, crossFrameApi);

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -654,7 +654,10 @@ export class Backend {
         const tab = sender.tab;
         const tabId = tab ? tab.id : void 0;
         const frameId = sender.frameId;
-        return Promise.resolve({tabId, frameId});
+        return {
+            tabId: typeof tabId === 'number' ? tabId : null,
+            frameId: typeof frameId === 'number' ? frameId : null
+        };
     }
 
     /** @type {import('api').ApiHandler<'injectStylesheet'>} */

--- a/ext/js/comm/cross-frame-api.js
+++ b/ext/js/comm/cross-frame-api.js
@@ -313,6 +313,20 @@ export class CrossFrameAPI {
         this._frameId = frameId;
     }
 
+    /**
+     * @type {?number}
+     */
+    get tabId() {
+        return this._tabId;
+    }
+
+    /**
+     * @type {?number}
+     */
+    get frameId() {
+        return this._frameId;
+    }
+
     /** */
     prepare() {
         chrome.runtime.onConnect.addListener(this._onConnect.bind(this));

--- a/ext/js/comm/frame-ancestry-handler.js
+++ b/ext/js/comm/frame-ancestry-handler.js
@@ -48,14 +48,6 @@ export class FrameAncestryHandler {
     }
 
     /**
-     * Gets the frame ID that the instance is instantiated in.
-     * @type {number}
-     */
-    get frameId() {
-        return this._frameId;
-    }
-
-    /**
      * Initializes event event listening.
      */
     prepare() {

--- a/ext/js/comm/frame-offset-forwarder.js
+++ b/ext/js/comm/frame-offset-forwarder.js
@@ -29,7 +29,7 @@ export class FrameOffsetForwarder {
         /** @type {number} */
         this._frameId = frameId;
         /** @type {FrameAncestryHandler} */
-        this._frameAncestryHandler = new FrameAncestryHandler(crossFrameApi, frameId);
+        this._frameAncestryHandler = new FrameAncestryHandler(crossFrameApi);
     }
 
     /**

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1720,7 +1720,7 @@ export class Display extends EventDispatcher {
             import('../app/frontend.js')
         ]);
 
-        const popupFactory = new PopupFactory(this._application, this._frameId);
+        const popupFactory = new PopupFactory(this._application);
         popupFactory.prepare();
 
         /** @type {import('frontend').ConstructorDetails} */
@@ -1730,8 +1730,6 @@ export class Display extends EventDispatcher {
             parentPopupId,
             parentFrameId,
             depth: this._depth + 1,
-            tabId: this._tabId,
-            frameId: this._frameId,
             popupFactory,
             pageType: this._pageType,
             allowRootFramePopupProxy: true,

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -46,20 +46,14 @@ import {QueryParser} from './query-parser.js';
 export class Display extends EventDispatcher {
     /**
      * @param {import('../application.js').Application} application
-     * @param {number|undefined} tabId
-     * @param {number|undefined} frameId
      * @param {import('display').DisplayPageType} pageType
      * @param {import('../dom/document-focus-controller.js').DocumentFocusController} documentFocusController
      * @param {import('../input/hotkey-handler.js').HotkeyHandler} hotkeyHandler
      */
-    constructor(application, tabId, frameId, pageType, documentFocusController, hotkeyHandler) {
+    constructor(application, pageType, documentFocusController, hotkeyHandler) {
         super();
         /** @type {import('../application.js').Application} */
         this._application = application;
-        /** @type {number|undefined} */
-        this._tabId = tabId;
-        /** @type {number|undefined} */
-        this._frameId = frameId;
         /** @type {import('display').DisplayPageType} */
         this._pageType = pageType;
         /** @type {import('../dom/document-focus-controller.js').DocumentFocusController} */
@@ -159,10 +153,10 @@ export class Display extends EventDispatcher {
         this._parentPopupId = null;
         /** @type {?number} */
         this._parentFrameId = null;
-        /** @type {number|undefined} */
-        this._contentOriginTabId = tabId;
-        /** @type {number|undefined} */
-        this._contentOriginFrameId = frameId;
+        /** @type {?number} */
+        this._contentOriginTabId = application.tabId;
+        /** @type {?number} */
+        this._contentOriginFrameId = application.frameId;
         /** @type {boolean} */
         this._childrenSupported = true;
         /** @type {?FrameEndpoint} */
@@ -588,10 +582,10 @@ export class Display extends EventDispatcher {
      * @returns {Promise<import('cross-frame-api').ApiReturn<TName>>}
      */
     async invokeContentOrigin(action, params) {
-        if (this._contentOriginTabId === this._tabId && this._contentOriginFrameId === this._frameId) {
+        if (this._contentOriginTabId === this._application.tabId && this._contentOriginFrameId === this._application.frameId) {
             throw new Error('Content origin is same page');
         }
-        if (typeof this._contentOriginTabId !== 'number' || typeof this._contentOriginFrameId !== 'number') {
+        if (this._contentOriginTabId === null || this._contentOriginFrameId === null) {
             throw new Error('No content origin is assigned');
         }
         return await this._application.crossFrame.invokeTab(this._contentOriginTabId, this._contentOriginFrameId, action, params);
@@ -604,7 +598,8 @@ export class Display extends EventDispatcher {
      * @returns {Promise<import('cross-frame-api').ApiReturn<TName>>}
      */
     async invokeParentFrame(action, params) {
-        if (this._parentFrameId === null || this._parentFrameId === this._frameId) {
+        const {frameId} = this._application;
+        if (frameId === null || this._parentFrameId === null || this._parentFrameId === frameId) {
             throw new Error('Invalid parent frame');
         }
         return await this._application.crossFrame.invoke(this._parentFrameId, action, params);
@@ -832,6 +827,7 @@ export class Display extends EventDispatcher {
     _onExtensionUnloaded() {
         const type = 'unloaded';
         if (this._contentType === type) { return; }
+        const {tabId, frameId} = this._application;
         /** @type {import('display').ContentDetails} */
         const details = {
             focus: false,
@@ -839,10 +835,7 @@ export class Display extends EventDispatcher {
             params: {type},
             state: {},
             content: {
-                contentOrigin: {
-                    tabId: this._tabId,
-                    frameId: this._frameId
-                }
+                contentOrigin: {tabId, frameId}
             }
         };
         this.setContent(details);
@@ -1222,11 +1215,9 @@ export class Display extends EventDispatcher {
         const {contentOrigin} = content;
         if (typeof contentOrigin === 'object' && contentOrigin !== null) {
             const {tabId, frameId} = contentOrigin;
-            if (typeof tabId === 'number' && typeof frameId === 'number') {
-                this._contentOriginTabId = tabId;
-                this._contentOriginFrameId = frameId;
-                contentOriginValid = true;
-            }
+            this._contentOriginTabId = tabId;
+            this._contentOriginFrameId = frameId;
+            contentOriginValid = true;
         }
         if (!contentOriginValid) {
             content.contentOrigin = this.getContentOrigin();
@@ -1673,12 +1664,12 @@ export class Display extends EventDispatcher {
      * @param {import('settings').ProfileOptions} options
      */
     async _updateNestedFrontend(options) {
-        if (typeof this._frameId !== 'number') { return; }
+        const {tabId, frameId} = this._application;
+        if (tabId === null || frameId === null) { return; }
 
         const isSearchPage = (this._pageType === 'search');
         const isEnabled = (
             this._childrenSupported &&
-            typeof this._tabId === 'number' &&
             (
                 (isSearchPage) ?
                 (options.scanning.enableOnSearchPage) :
@@ -1707,10 +1698,6 @@ export class Display extends EventDispatcher {
 
     /** */
     async _setupNestedFrontend() {
-        if (typeof this._frameId !== 'number') {
-            throw new Error('No frameId assigned');
-        }
-
         const useProxyPopup = this._parentFrameId !== null;
         const parentPopupId = this._parentPopupId;
         const parentFrameId = this._parentFrameId;

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1215,9 +1215,11 @@ export class Display extends EventDispatcher {
         const {contentOrigin} = content;
         if (typeof contentOrigin === 'object' && contentOrigin !== null) {
             const {tabId, frameId} = contentOrigin;
-            this._contentOriginTabId = tabId;
-            this._contentOriginFrameId = frameId;
-            contentOriginValid = true;
+            if (tabId !== null && frameId !== null) {
+                this._contentOriginTabId = tabId;
+                this._contentOriginFrameId = frameId;
+                contentOriginValid = true;
+            }
         }
         if (!contentOriginValid) {
             content.contentOrigin = this.getContentOrigin();

--- a/ext/js/display/popup-main.js
+++ b/ext/js/display/popup-main.js
@@ -29,8 +29,6 @@ await Application.main(async (application) => {
     const documentFocusController = new DocumentFocusController();
     documentFocusController.prepare();
 
-    const {tabId, frameId} = await application.api.frameInformationGet();
-
     const hotkeyHandler = new HotkeyHandler();
     hotkeyHandler.prepare(application.crossFrame);
 

--- a/ext/js/display/popup-main.js
+++ b/ext/js/display/popup-main.js
@@ -32,7 +32,7 @@ await Application.main(async (application) => {
     const hotkeyHandler = new HotkeyHandler();
     hotkeyHandler.prepare(application.crossFrame);
 
-    const display = new Display(application, tabId, frameId, 'popup', documentFocusController, hotkeyHandler);
+    const display = new Display(application, 'popup', documentFocusController, hotkeyHandler);
     await display.prepare();
 
     const displayAudio = new DisplayAudio(display);

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -24,17 +24,11 @@ import {querySelectorNotNull} from '../dom/query-selector.js';
 
 export class SearchDisplayController {
     /**
-     * @param {number|undefined} tabId
-     * @param {number|undefined} frameId
      * @param {import('./display.js').Display} display
      * @param {import('./display-audio.js').DisplayAudio} displayAudio
      * @param {import('./search-persistent-state-controller.js').SearchPersistentStateController} searchPersistentStateController
      */
-    constructor(tabId, frameId, display, displayAudio, searchPersistentStateController) {
-        /** @type {number|undefined} */
-        this._tabId = tabId;
-        /** @type {number|undefined} */
-        this._frameId = frameId;
+    constructor(display, displayAudio, searchPersistentStateController) {
         /** @type {import('./display.js').Display} */
         this._display = display;
         /** @type {import('./display-audio.js').DisplayAudio} */
@@ -519,6 +513,7 @@ export class SearchDisplayController {
         if (flags !== null) {
             optionsContext.flags = flags;
         }
+        const {tabId, frameId} = this._display.application;
         /** @type {import('display').ContentDetails} */
         const details = {
             focus: false,
@@ -536,10 +531,7 @@ export class SearchDisplayController {
             content: {
                 dictionaryEntries: void 0,
                 animate,
-                contentOrigin: {
-                    tabId: this._tabId,
-                    frameId: this._frameId
-                }
+                contentOrigin: {tabId, frameId}
             }
         };
         if (!lookup) { details.params.lookup = 'false'; }

--- a/ext/js/display/search-main.js
+++ b/ext/js/display/search-main.js
@@ -36,8 +36,6 @@ await Application.main(async (application) => {
     const searchActionPopupController = new SearchActionPopupController(searchPersistentStateController);
     searchActionPopupController.prepare();
 
-    const {tabId, frameId} = await application.api.frameInformationGet();
-
     const hotkeyHandler = new HotkeyHandler();
     hotkeyHandler.prepare(application.crossFrame);
 

--- a/ext/js/display/search-main.js
+++ b/ext/js/display/search-main.js
@@ -48,7 +48,7 @@ await Application.main(async (application) => {
     const displayAnki = new DisplayAnki(display, displayAudio);
     displayAnki.prepare();
 
-    const searchDisplayController = new SearchDisplayController(tabId, frameId, display, displayAudio, searchPersistentStateController);
+    const searchDisplayController = new SearchDisplayController(display, displayAudio, searchPersistentStateController);
     await searchDisplayController.prepare();
 
     display.initializeState();

--- a/ext/js/display/search-main.js
+++ b/ext/js/display/search-main.js
@@ -39,7 +39,7 @@ await Application.main(async (application) => {
     const hotkeyHandler = new HotkeyHandler();
     hotkeyHandler.prepare(application.crossFrame);
 
-    const display = new Display(application, tabId, frameId, 'search', documentFocusController, hotkeyHandler);
+    const display = new Display(application, 'search', documentFocusController, hotkeyHandler);
     await display.prepare();
 
     const displayAudio = new DisplayAudio(display);

--- a/ext/js/pages/settings/popup-preview-frame-main.js
+++ b/ext/js/pages/settings/popup-preview-frame-main.js
@@ -22,14 +22,6 @@ import {HotkeyHandler} from '../../input/hotkey-handler.js';
 import {PopupPreviewFrame} from './popup-preview-frame.js';
 
 await Application.main(async (application) => {
-    const {tabId, frameId} = await application.api.frameInformationGet();
-    if (typeof tabId === 'undefined') {
-        throw new Error('Failed to get tabId');
-    }
-    if (typeof frameId === 'undefined') {
-        throw new Error('Failed to get frameId');
-    }
-
     const hotkeyHandler = new HotkeyHandler();
     hotkeyHandler.prepare(application.crossFrame);
 

--- a/ext/js/pages/settings/popup-preview-frame-main.js
+++ b/ext/js/pages/settings/popup-preview-frame-main.js
@@ -25,7 +25,7 @@ await Application.main(async (application) => {
     const hotkeyHandler = new HotkeyHandler();
     hotkeyHandler.prepare(application.crossFrame);
 
-    const popupFactory = new PopupFactory(application, frameId);
+    const popupFactory = new PopupFactory(application);
     popupFactory.prepare();
 
     const preview = new PopupPreviewFrame(application, tabId, frameId, popupFactory, hotkeyHandler);

--- a/ext/js/pages/settings/popup-preview-frame-main.js
+++ b/ext/js/pages/settings/popup-preview-frame-main.js
@@ -28,7 +28,7 @@ await Application.main(async (application) => {
     const popupFactory = new PopupFactory(application);
     popupFactory.prepare();
 
-    const preview = new PopupPreviewFrame(application, tabId, frameId, popupFactory, hotkeyHandler);
+    const preview = new PopupPreviewFrame(application, popupFactory, hotkeyHandler);
     await preview.prepare();
 
     document.documentElement.dataset.loaded = 'true';

--- a/ext/js/pages/settings/popup-preview-frame.js
+++ b/ext/js/pages/settings/popup-preview-frame.js
@@ -94,8 +94,6 @@ export class PopupPreviewFrame {
         // Overwrite frontend
         this._frontend = new Frontend({
             application: this._application,
-            tabId: this._tabId,
-            frameId: this._frameId,
             popupFactory: this._popupFactory,
             depth: 0,
             parentPopupId: null,

--- a/ext/js/pages/settings/popup-preview-frame.js
+++ b/ext/js/pages/settings/popup-preview-frame.js
@@ -24,18 +24,12 @@ import {TextSourceRange} from '../../dom/text-source-range.js';
 export class PopupPreviewFrame {
     /**
      * @param {import('../../application.js').Application} application
-     * @param {number} tabId
-     * @param {number} frameId
      * @param {import('../../app/popup-factory.js').PopupFactory} popupFactory
      * @param {import('../../input/hotkey-handler.js').HotkeyHandler} hotkeyHandler
      */
-    constructor(application, tabId, frameId, popupFactory, hotkeyHandler) {
+    constructor(application, popupFactory, hotkeyHandler) {
         /** @type {import('../../application.js').Application} */
         this._application = application;
-        /** @type {number} */
-        this._tabId = tabId;
-        /** @type {number} */
-        this._frameId = frameId;
         /** @type {import('../../app/popup-factory.js').PopupFactory} */
         this._popupFactory = popupFactory;
         /** @type {import('../../input/hotkey-handler.js').HotkeyHandler} */

--- a/types/ext/application.d.ts
+++ b/types/ext/application.d.ts
@@ -81,7 +81,7 @@ export type ApiSurface = {
     };
     frontendRequestReadyBroadcast: {
         params: {
-            frameId: number;
+            frameId: number | null;
         };
         return: void;
     };
@@ -101,7 +101,7 @@ export type ApiSurface = {
     };
     frontendReady: {
         params: {
-            frameId: number;
+            frameId: number | null;
         };
         return: void;
     };

--- a/types/ext/extension.d.ts
+++ b/types/ext/extension.d.ts
@@ -18,8 +18,8 @@
 export type HtmlElementWithContentWindow = HTMLIFrameElement | HTMLFrameElement | HTMLObjectElement;
 
 export type ContentOrigin = {
-    tabId?: number;
-    frameId?: number;
+    tabId: number | null;
+    frameId: number | null;
 };
 
 export type ChromeRuntimeOnMessageCallback<TMessage = unknown> = (

--- a/types/ext/frontend.d.ts
+++ b/types/ext/frontend.d.ts
@@ -29,10 +29,6 @@ export type ConstructorDetails = {
     popupFactory: PopupFactory;
     /** The nesting depth value of the popup. */
     depth: number;
-    /** The tab ID of the host tab. */
-    tabId: number | undefined;
-    /** The frame ID of the host frame. */
-    frameId: number;
     /** The popup ID of the parent popup if one exists, otherwise null. */
     parentPopupId: string | null;
     /** The frame ID of the parent popup if one exists, otherwise null. */


### PR DESCRIPTION
This change removes a lot of the redundancy involving tabId/frameId on non-background scripts. Application already computes this during initialization, so there is no reason to recompute it. The only tricky bit here is primarily that there are bunch of places that `null` needs to be checked, and the `undefined` value was changed to `null` on the `ContentOrigin` type.