### PR TITLE
Application main updates

### DIFF
--- a/ext/action-popup.html
+++ b/ext/action-popup.html
@@ -12,6 +12,7 @@
     <link rel="icon" type="image/png" href="/images/icon64.png" sizes="64x64">
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
     <link rel="stylesheet" type="text/css" href="/css/action-popup.css">
+    <script src="/js/pages/action-popup-main.js" type="module"></script>
 </head>
 <body>
 
@@ -80,9 +81,6 @@
         <span class="link-group-icon" data-icon="chevron"></span><span class="link-group-label">Information</span>
     </a>
 </div>
-
-<!-- Scripts -->
-<script src="/js/pages/action-popup-main.js" type="module"></script>
 
 </body>
 </html>

--- a/ext/background.html
+++ b/ext/background.html
@@ -12,13 +12,11 @@
     <link rel="icon" type="image/png" href="/images/icon64.png" sizes="64x64">
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
     <link rel="stylesheet" type="text/css" href="/css/background.css">
+    <script src="/js/background/background-main.js" type="module"></script>
 </head>
 <body>
 
 <textarea id="clipboard-paste-target"></textarea>
-
-<!-- Scripts -->
-<script src="/js/background/background-main.js" type="module"></script>
 
 <!--
     Due to a Firefox bug, this next element is purposefully terminated incorrectly.

--- a/ext/info.html
+++ b/ext/info.html
@@ -13,6 +13,7 @@
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
     <link rel="stylesheet" type="text/css" href="/css/material.css">
     <link rel="stylesheet" type="text/css" href="/css/settings.css">
+    <script src="/js/pages/info-main.js" type="module"></script>
 </head>
 <body>
 
@@ -58,9 +59,6 @@
 </div>
 <div class="content-right"></div>
 </div></div>
-
-<!-- Scripts -->
-<script src="/js/pages/info-main.js" type="module"></script>
 
 </body>
 </html>

--- a/ext/issues.html
+++ b/ext/issues.html
@@ -13,6 +13,7 @@
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
     <link rel="stylesheet" type="text/css" href="/css/material.css">
     <link rel="stylesheet" type="text/css" href="/css/settings.css">
+    <script src="/js/pages/generic-page-main.js" type="module"></script>
 </head>
 <body>
 
@@ -74,9 +75,6 @@
 </div>
 <div class="content-right"></div>
 </div></div>
-
-<!-- Scripts -->
-<script src="/js/pages/generic-page-main.js" type="module"></script>
 
 </body>
 </html>

--- a/ext/js/app/content-script-main.js
+++ b/ext/js/app/content-script-main.js
@@ -21,7 +21,7 @@ import {HotkeyHandler} from '../input/hotkey-handler.js';
 import {Frontend} from './frontend.js';
 import {PopupFactory} from './popup-factory.js';
 
-await Application.main(async (application) => {
+await Application.main(false, async (application) => {
     const hotkeyHandler = new HotkeyHandler();
     hotkeyHandler.prepare(application.crossFrame);
 

--- a/ext/js/display/popup-main.js
+++ b/ext/js/display/popup-main.js
@@ -25,7 +25,7 @@ import {DisplayProfileSelection} from './display-profile-selection.js';
 import {DisplayResizer} from './display-resizer.js';
 import {Display} from './display.js';
 
-await Application.main(async (application) => {
+await Application.main(true, async (application) => {
     const documentFocusController = new DocumentFocusController();
     documentFocusController.prepare();
 

--- a/ext/js/display/search-main.js
+++ b/ext/js/display/search-main.js
@@ -26,7 +26,7 @@ import {SearchActionPopupController} from './search-action-popup-controller.js';
 import {SearchDisplayController} from './search-display-controller.js';
 import {SearchPersistentStateController} from './search-persistent-state-controller.js';
 
-await Application.main(async (application) => {
+await Application.main(true, async (application) => {
     const documentFocusController = new DocumentFocusController('#search-textbox');
     documentFocusController.prepare();
 

--- a/ext/js/pages/action-popup-main.js
+++ b/ext/js/pages/action-popup-main.js
@@ -306,7 +306,7 @@ class DisplayController {
     }
 }
 
-await Application.main(async (application) => {
+await Application.main(true, async (application) => {
     application.api.logIndicatorClear();
 
     const displayController = new DisplayController(application.api);

--- a/ext/js/pages/info-main.js
+++ b/ext/js/pages/info-main.js
@@ -115,7 +115,7 @@ async function showDictionaryInfo(api) {
     container.appendChild(fragment);
 }
 
-await Application.main(async (application) => {
+await Application.main(true, async (application) => {
     const documentFocusController = new DocumentFocusController();
     documentFocusController.prepare();
 

--- a/ext/js/pages/permissions-main.js
+++ b/ext/js/pages/permissions-main.js
@@ -86,7 +86,7 @@ function setupPermissionsToggles() {
     }
 }
 
-await Application.main(async (application) => {
+await Application.main(true, async (application) => {
     const documentFocusController = new DocumentFocusController();
     documentFocusController.prepare();
 

--- a/ext/js/pages/settings/popup-preview-frame-main.js
+++ b/ext/js/pages/settings/popup-preview-frame-main.js
@@ -21,7 +21,7 @@ import {Application} from '../../application.js';
 import {HotkeyHandler} from '../../input/hotkey-handler.js';
 import {PopupPreviewFrame} from './popup-preview-frame.js';
 
-await Application.main(async (application) => {
+await Application.main(true, async (application) => {
     const hotkeyHandler = new HotkeyHandler();
     hotkeyHandler.prepare(application.crossFrame);
 

--- a/ext/js/pages/settings/settings-main.js
+++ b/ext/js/pages/settings/settings-main.js
@@ -58,7 +58,7 @@ async function setupGenericSettingController(genericSettingController) {
     await genericSettingController.refresh();
 }
 
-await Application.main(async (application) => {
+await Application.main(true, async (application) => {
     const documentFocusController = new DocumentFocusController();
     documentFocusController.prepare();
 

--- a/ext/js/pages/welcome-main.js
+++ b/ext/js/pages/welcome-main.js
@@ -49,7 +49,7 @@ async function setupGenericSettingsController(genericSettingController) {
     await genericSettingController.refresh();
 }
 
-await Application.main(async (application) => {
+await Application.main(true, async (application) => {
     const documentFocusController = new DocumentFocusController();
     documentFocusController.prepare();
 

--- a/ext/legal.html
+++ b/ext/legal.html
@@ -14,6 +14,7 @@
    <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
    <link rel="stylesheet" type="text/css" href="/css/material.css">
    <link rel="stylesheet" type="text/css" href="/css/settings.css">
+   <script src="/js/pages/generic-page-main.js" type="module"></script>
 </head>
 
 <body>
@@ -89,9 +90,6 @@ and are used in conformance with the Group's <a href="https://www.edrdg.org/edrd
          <div class="content-right"></div>
       </div>
    </div>
-
-   <!-- Scripts -->
-   <script src="/js/pages/generic-page-main.js" type="module"></script>
 
 </body>
 

--- a/ext/offscreen.html
+++ b/ext/offscreen.html
@@ -12,13 +12,11 @@
     <link rel="icon" type="image/png" href="/images/icon64.png" sizes="64x64">
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
     <link rel="stylesheet" type="text/css" href="/css/background.css">
+    <script src="/js/background/offscreen-main.js" type="module"></script>
 </head>
 <body>
 
 <textarea id="clipboard-paste-target"></textarea>
-
-<!-- Scripts -->
-<script src="/js/background/offscreen-main.js" type="module"></script>
 
 <!--
     Due to a Firefox bug, this next element is purposefully terminated incorrectly.

--- a/ext/permissions.html
+++ b/ext/permissions.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" type="text/css" href="/css/material.css">
     <link rel="stylesheet" type="text/css" href="/css/settings.css">
     <link rel="stylesheet" type="text/css" href="/css/permissions.css">
+    <script src="/js/pages/permissions-main.js" type="module"></script>
 </head>
 <body>
 
@@ -226,10 +227,6 @@
         <button type="button" class="low-emphasis" data-modal-action="hide">Close</button>
     </div>
 </div></div>
-
-
-<!-- Scripts -->
-<script src="/js/pages/permissions-main.js" type="module"></script>
 
 </body>
 </html>

--- a/ext/popup-preview.html
+++ b/ext/popup-preview.html
@@ -13,6 +13,7 @@
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
     <link rel="stylesheet" type="text/css" href="/css/popup-preview.css">
     <link rel="stylesheet" type="text/css" href="/css/popup-outer.css" id="popup-outer-css">
+    <script src="/js/pages/settings/popup-preview-frame-main.js" type="module"></script>
 </head>
 <body>
 
@@ -33,9 +34,6 @@
         If you see this message, make sure you have a dictionary installed.
     </div></div>
 </div></div>
-
-<!-- Scripts -->
-<script src="/js/pages/settings/popup-preview-frame-main.js" type="module"></script>
 
 </body>
 </html>

--- a/ext/popup.html
+++ b/ext/popup.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" type="text/css" href="/css/display.css">
     <link rel="stylesheet" type="text/css" href="/css/display-pronunciation.css">
     <link rel="stylesheet" type="text/css" href="/css/structured-content.css">
+    <script src="/js/display/popup-main.js" type="module"></script>
 </head>
 <body>
 
@@ -91,9 +92,6 @@
 </div>
 
 <div id="popup-menus"></div>
-
-<!-- Scripts -->
-<script src="/js/display/popup-main.js" type="module"></script>
 
 </body>
 </html>

--- a/ext/search.html
+++ b/ext/search.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" type="text/css" href="/css/display-pronunciation.css">
     <link rel="stylesheet" type="text/css" href="/css/structured-content.css">
     <link rel="stylesheet" type="text/css" href="/css/search.css">
+    <script src="/js/display/search-main.js" type="module"></script>
 </head>
 <body>
 
@@ -81,9 +82,6 @@
 </div>
 
 <div id="popup-menus"></div>
-
-<!-- Scripts -->
-<script src="/js/display/search-main.js" type="module"></script>
 
 </body>
 </html>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" type="text/css" href="/css/material.css">
     <link rel="stylesheet" type="text/css" href="/css/settings.css">
     <link rel="stylesheet" type="text/css" href="/css/display-pronunciation.css">
+    <script src="/js/pages/settings/settings-main.js" type="module"></script>
 </head>
 <body>
 
@@ -3430,10 +3431,6 @@
         <button type="button" class="danger" id="hotkey-list-reset" data-modal-action="hide">Reset All</button>
     </div>
 </div></div>
-
-
-<!-- Scripts -->
-<script src="/js/pages/settings/settings-main.js" type="module"></script>
 
 </body>
 </html>

--- a/ext/template-renderer.html
+++ b/ext/template-renderer.html
@@ -11,11 +11,9 @@
     <link rel="icon" type="image/png" href="/images/icon48.png" sizes="48x48">
     <link rel="icon" type="image/png" href="/images/icon64.png" sizes="64x64">
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
+    <script src="/js/templates/sandbox/template-renderer-frame-main.js" type="module"></script>
 </head>
 <body>
-
-<!-- Scripts -->
-<script src="/js/templates/sandbox/template-renderer-frame-main.js" type="module"></script>
 
 </body>
 </html>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -13,6 +13,7 @@
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
     <link rel="stylesheet" type="text/css" href="/css/material.css">
     <link rel="stylesheet" type="text/css" href="/css/settings.css">
+    <script src="/js/pages/welcome-main.js" type="module"></script>
 </head>
 <body>
 
@@ -424,9 +425,6 @@
         <button type="button" data-modal-action="hide" id="dictionary-move-button">Move</button>
     </div>
 </div></div>
-
-<!-- Scripts -->
-<script src="/js/pages/welcome-main.js" type="module"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Since there's only one script now, it makes more sense to have it start loading in the `<head>` tag rather than at the end of the `<body>`. This may only really make a potentially-noticeable speed difference on the settings page since it's a _massive_ document.

For context about this change and #706, I'm trying to look into some cleanup of the settings pages code and see if I can make it cleaner to design content for it, and these were the first cleanup steps in the process.