### PR TITLE
Update eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -74,8 +74,8 @@
         "no-implied-eval": "error",
         "no-new": "error",
         "no-new-native-nonconstructor": "error",
-        "no-octal": "off",
-        "no-octal-escape": "off",
+        "no-octal": "error",
+        "no-octal-escape": "error",
         "no-param-reassign": "off",
         "no-promise-executor-return": "error",
         "no-prototype-builtins": "error",
@@ -394,9 +394,9 @@
                 "plugin:@typescript-eslint/recommended-type-checked"
             ],
             "rules": {
-                "@typescript-eslint/no-floating-promises": "off",
+                "@typescript-eslint/no-floating-promises": ["error", {"ignoreIIFE": true}],
                 "@typescript-eslint/no-misused-promises": "off",
-                "@typescript-eslint/no-redundant-type-constituents": "off",
+                "@typescript-eslint/no-redundant-type-constituents": "error",
                 "@typescript-eslint/no-unsafe-argument": "off",
                 "@typescript-eslint/no-unsafe-assignment": "off",
                 "@typescript-eslint/no-unsafe-call": "off",

--- a/dev/bin/build-libs.js
+++ b/dev/bin/build-libs.js
@@ -18,4 +18,4 @@
 
 import {buildLibs} from '../build-libs.js';
 
-buildLibs();
+await buildLibs();

--- a/dev/bin/build.js
+++ b/dev/bin/build.js
@@ -280,4 +280,4 @@ export async function main(argv) {
     }
 }
 
-testMain(main, process.argv.slice(2));
+await testMain(main, process.argv.slice(2));

--- a/dev/bin/dictionary-validate.js
+++ b/dev/bin/dictionary-validate.js
@@ -39,4 +39,4 @@ async function main() {
     await testDictionaryFiles(mode, dictionaryFileNames);
 }
 
-main();
+await main();

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -256,14 +256,14 @@ export class Frontend {
      * @returns {void}
      */
     _onActionScanSelectedText() {
-        this._scanSelectedText(false);
+        void this._scanSelectedText(false);
     }
 
     /**
      * @returns {void}
      */
     _onActionScanTextAtCaret() {
-        this._scanSelectedText(true);
+        void this._scanSelectedText(true);
     }
 
     // API message handlers
@@ -320,7 +320,7 @@ export class Frontend {
      * @returns {void}
      */
     _onResize() {
-        this._updatePopupPosition();
+        void this._updatePopupPosition();
     }
 
     /** @type {import('extension').ChromeRuntimeOnMessageCallback<import('application').ApiMessageAny>} */
@@ -347,7 +347,7 @@ export class Frontend {
      * @returns {void}
      */
     _onVisualViewportScroll() {
-        this._updatePopupPosition();
+        void this._updatePopupPosition();
     }
 
     /**
@@ -423,8 +423,8 @@ export class Frontend {
     _clearSelection(passive) {
         this._stopClearSelectionDelayed();
         if (this._popup !== null) {
-            this._popup.clearAutoPlayTimer();
-            this._popup.hide(!passive);
+            void this._popup.clearAutoPlayTimer();
+            void this._popup.hide(!passive);
             this._isPointerOverPopup = false;
         }
         this._textScanner.clearSelection();
@@ -630,7 +630,7 @@ export class Frontend {
         });
         popup.on('offsetNotFound', () => {
             this._allowRootFramePopupProxy = false;
-            this._updatePopup();
+            void this._updatePopup();
         });
         return popup;
     }
@@ -679,7 +679,7 @@ export class Frontend {
      * @param {import('text-source').TextSource} textSource
      */
     _showExtensionUnloaded(textSource) {
-        this._showPopupContent(textSource, null, null);
+        void this._showPopupContent(textSource, null, null);
     }
 
     /**
@@ -726,7 +726,7 @@ export class Frontend {
             details.params.full = textSource.fullContent;
             details.params['full-visible'] = 'true';
         }
-        this._showPopupContent(textSource, optionsContext, details);
+        void this._showPopupContent(textSource, optionsContext, details);
     }
 
     /**
@@ -792,9 +792,9 @@ export class Frontend {
 
         this._contentScale = contentScale;
         if (this._popup !== null) {
-            this._popup.setContentScale(this._contentScale);
+            void this._popup.setContentScale(this._contentScale);
         }
-        this._updatePopupPosition();
+        void this._updatePopupPosition();
     }
 
     /**
@@ -807,7 +807,7 @@ export class Frontend {
             this._popup !== null &&
             await this._popup.isVisible()
         ) {
-            this._showPopupContent(textSource, null, null);
+            void this._showPopupContent(textSource, null, null);
         }
     }
 
@@ -818,9 +818,9 @@ export class Frontend {
         /** @type {import('application').ApiMessageNoFrameId<'frontendReady'>} */
         const message = {action: 'frontendReady', params: {frameId: this._application.frameId}};
         if (targetFrameId === null) {
-            this._application.api.broadcastTab(message);
+            void this._application.api.broadcastTab(message);
         } else {
-            this._application.api.sendMessageToFrame(targetFrameId, message);
+            void this._application.api.sendMessageToFrame(targetFrameId, message);
         }
     }
 
@@ -864,7 +864,7 @@ export class Frontend {
             }
 
             chrome.runtime.onMessage.addListener(onMessage);
-            this._application.api.broadcastTab({action: 'frontendRequestReadyBroadcast', params: {frameId: this._application.frameId}});
+            void this._application.api.broadcastTab({action: 'frontendRequestReadyBroadcast', params: {frameId: this._application.frameId}});
         });
     }
 
@@ -950,7 +950,7 @@ export class Frontend {
     _prepareSiteSpecific() {
         switch (location.hostname.toLowerCase()) {
             case 'docs.google.com':
-                this._prepareGoogleDocs();
+                void this._prepareGoogleDocs();
                 break;
         }
     }

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -304,7 +304,7 @@ export class Popup extends EventDispatcher {
         await this._show(sourceRects, writingMode);
 
         if (displayDetails !== null) {
-            this._invokeSafe('displaySetContent', {details: displayDetails});
+            void this._invokeSafe('displaySetContent', {details: displayDetails});
         }
     }
 
@@ -662,7 +662,7 @@ export class Popup extends EventDispatcher {
         if (this._visibleValue === value) { return; }
         this._visibleValue = value;
         this._frame.style.setProperty('visibility', value ? 'visible' : 'hidden', 'important');
-        this._invokeSafe('displayVisibilityChanged', {value});
+        void this._invokeSafe('displayVisibilityChanged', {value});
     }
 
     /**
@@ -1028,7 +1028,7 @@ export class Popup extends EventDispatcher {
         this._useSecureFrameUrl = general.useSecurePopupFrameUrl;
         this._useShadowDom = general.usePopupShadowDom;
         this._customOuterCss = general.customPopupOuterCss;
-        this.updateTheme();
+        void this.updateTheme();
     }
 
     /**

--- a/ext/js/application.js
+++ b/ext/js/application.js
@@ -172,7 +172,7 @@ export class Application extends EventDispatcher {
     ready() {
         if (this._isReady) { return; }
         this._isReady = true;
-        this._webExtension.sendMessagePromise({action: 'applicationReady'});
+        void this._webExtension.sendMessagePromise({action: 'applicationReady'});
     }
 
     /** */

--- a/ext/js/background/background-main.js
+++ b/ext/js/background/background-main.js
@@ -29,4 +29,4 @@ async function main() {
     await backend.prepare();
 }
 
-main();
+void main();

--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -259,7 +259,7 @@ export class ClipboardReaderProxy {
     set browser(value) {
         if (this._browser === value) { return; }
         this._browser = value;
-        this._offscreen.sendMessagePromise({action: 'clipboardSetBrowserOffscreen', params: {value}});
+        void this._offscreen.sendMessagePromise({action: 'clipboardSetBrowserOffscreen', params: {value}});
     }
 
     /**

--- a/ext/js/comm/clipboard-monitor.js
+++ b/ext/js/comm/clipboard-monitor.js
@@ -82,7 +82,7 @@ export class ClipboardMonitor extends EventDispatcher {
 
         this._timerToken = token;
 
-        intervalCallback();
+        void intervalCallback();
     }
 
     /**

--- a/ext/js/comm/frame-ancestry-handler.js
+++ b/ext/js/comm/frame-ancestry-handler.js
@@ -176,7 +176,7 @@ export class FrameAncestryHandler {
         const {params} = /** @type {import('core').SerializableObject} */ (data);
         if (typeof params !== 'object' || params === null) { return; }
 
-        this._onRequestFrameInfo(/** @type {import('core').SerializableObject} */ (params), source);
+        void this._onRequestFrameInfo(/** @type {import('core').SerializableObject} */ (params), source);
     }
 
     /**

--- a/ext/js/comm/frame-client.js
+++ b/ext/js/comm/frame-client.js
@@ -112,7 +112,7 @@ export class FrameClient {
 
             /** @type {import('extension').ChromeRuntimeOnMessageCallback<import('application').ApiMessageAny>} */
             const onMessage = (message) => {
-                onMessageInner(message);
+                void onMessageInner(message);
                 return false;
             };
 

--- a/ext/js/comm/frame-endpoint.js
+++ b/ext/js/comm/frame-endpoint.js
@@ -46,7 +46,7 @@ export class FrameEndpoint {
         }
         /** @type {import('frame-client').FrameEndpointReadyDetails} */
         const details = {secret: this._secret};
-        this._api.broadcastTab({action: 'frameEndpointReady', params: details});
+        void this._api.broadcastTab({action: 'frameEndpointReady', params: details});
     }
 
     /**
@@ -88,6 +88,6 @@ export class FrameEndpoint {
         this._eventListeners.removeAllEventListeners();
         /** @type {import('frame-client').FrameEndpointConnectedDetails} */
         const details = {secret, token};
-        this._api.sendMessageToFrame(hostFrameId, {action: 'frameEndpointConnected', params: details});
+        void this._api.sendMessageToFrame(hostFrameId, {action: 'frameEndpointConnected', params: details});
     }
 }

--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -286,7 +286,7 @@ export class AnkiNoteBuilder {
     _runBatchedRequestsDelayed() {
         if (this._batchedRequestsQueued) { return; }
         this._batchedRequestsQueued = true;
-        Promise.resolve().then(() => {
+        void Promise.resolve().then(() => {
             this._batchedRequestsQueued = false;
             this._runBatchedRequests();
         });
@@ -322,7 +322,7 @@ export class AnkiNoteBuilder {
 
         this._batchedRequests.length = 0;
 
-        this._resolveBatchedRequests(items, allRequests);
+        void this._resolveBatchedRequests(items, allRequests);
     }
 
     /**

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -1095,9 +1095,9 @@ export class OptionsUtil {
         }
 
         if (customTemplates && isObject(chrome.storage)) {
-            chrome.storage.session.set({needsCustomTemplatesWarning: true});
+            void chrome.storage.session.set({needsCustomTemplatesWarning: true});
             await this._createTab(chrome.runtime.getURL('/welcome.html'));
-            chrome.storage.session.set({openedWelcomePage: true});
+            void chrome.storage.session.set({openedWelcomePage: true});
         }
     }
 

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -187,7 +187,7 @@ export class DictionaryImporter {
             media: {total: media.length}
         };
         const summary = this._createSummary(dictionaryTitle, version, index, {prefixWildcardsSupported, counts});
-        dictionaryDatabase.bulkAdd('dictionaries', [summary], 0, 1);
+        await dictionaryDatabase.bulkAdd('dictionaries', [summary], 0, 1);
 
         // Add data
         /** @type {Error[]} */

--- a/ext/js/dictionary/dictionary-worker-handler.js
+++ b/ext/js/dictionary/dictionary-worker-handler.js
@@ -41,13 +41,13 @@ export class DictionaryWorkerHandler {
         const {action, params} = event.data;
         switch (action) {
             case 'importDictionary':
-                this._onMessageWithProgress(params, this._importDictionary.bind(this));
+                void this._onMessageWithProgress(params, this._importDictionary.bind(this));
                 break;
             case 'deleteDictionary':
-                this._onMessageWithProgress(params, this._deleteDictionary.bind(this));
+                void this._onMessageWithProgress(params, this._deleteDictionary.bind(this));
                 break;
             case 'getDictionaryCounts':
-                this._onMessageWithProgress(params, this._getDictionaryCounts.bind(this));
+                void this._onMessageWithProgress(params, this._getDictionaryCounts.bind(this));
                 break;
             case 'getImageDetails.response':
                 this._mediaLoader.handleMessage(params);
@@ -95,7 +95,7 @@ export class DictionaryWorkerHandler {
                 errors: errors.map((error) => ExtensionError.serialize(error))
             };
         } finally {
-            dictionaryDatabase.close();
+            void dictionaryDatabase.close();
         }
     }
 
@@ -109,7 +109,7 @@ export class DictionaryWorkerHandler {
         try {
             return await dictionaryDatabase.deleteDictionary(dictionaryTitle, 1000, onProgress);
         } finally {
-            dictionaryDatabase.close();
+            void dictionaryDatabase.close();
         }
     }
 
@@ -122,7 +122,7 @@ export class DictionaryWorkerHandler {
         try {
             return await dictionaryDatabase.getDictionaryCounts(dictionaryNames, getTotal);
         } finally {
-            dictionaryDatabase.close();
+            void dictionaryDatabase.close();
         }
     }
 

--- a/ext/js/dictionary/dictionary-worker.js
+++ b/ext/js/dictionary/dictionary-worker.js
@@ -126,7 +126,7 @@ export class DictionaryWorker {
                 {
                     const {worker} = details;
                     if (worker === null) { return; }
-                    this._onMessageGetImageDetails(params, worker);
+                    void this._onMessageGetImageDetails(params, worker);
                 }
                 break;
         }

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -223,7 +223,7 @@ export class DisplayAnki {
         this._modeOptions.set('term-kanji', terms);
         this._modeOptions.set('term-kana', terms);
 
-        this._updateAnkiFieldTemplates(options);
+        void this._updateAnkiFieldTemplates(options);
     }
 
     /** */
@@ -258,7 +258,7 @@ export class DisplayAnki {
 
     /** */
     _onContentUpdateComplete() {
-        this._updateDictionaryEntryDetails();
+        void this._updateDictionaryEntryDetails();
     }
 
     /**
@@ -277,7 +277,7 @@ export class DisplayAnki {
         const mode = this._getValidCreateMode(element.dataset.mode);
         if (mode === null) { return; }
         const index = this._display.getElementDictionaryEntryIndex(element);
-        this._addAnkiNote(index, mode);
+        void this._addAnkiNote(index, mode);
     }
 
     /**
@@ -444,7 +444,7 @@ export class DisplayAnki {
      */
     _tryAddAnkiNoteForSelectedEntry(mode) {
         const index = this._display.selectedIndex;
-        this._addAnkiNote(index, mode);
+        void this._addAnkiNote(index, mode);
     }
 
     /**
@@ -783,7 +783,7 @@ export class DisplayAnki {
         if (e.shiftKey) {
             this._showViewNotesMenu(element);
         } else {
-            this._viewNotes(element);
+            void this._viewNotes(element);
         }
     }
 
@@ -804,7 +804,7 @@ export class DisplayAnki {
         switch (action) {
             case 'viewNotes':
                 if (item !== null) {
-                    this._viewNotes(item);
+                    void this._viewNotes(item);
                 }
                 break;
         }
@@ -927,7 +927,7 @@ export class DisplayAnki {
         const index = this._display.selectedIndex;
         const button = this._getViewNoteButton(index);
         if (button !== null) {
-            this._viewNotes(button);
+            void this._viewNotes(button);
         }
     }
 

--- a/ext/js/display/display-audio.js
+++ b/ext/js/display/display-audio.js
@@ -225,7 +225,7 @@ export class DisplayAudio {
 
         const callback = () => {
             this._autoPlayAudioTimer = null;
-            this.playAudio(0, 0);
+            void this.playAudio(0, 0);
         };
 
         if (this._autoPlayAudioDelay > 0) {
@@ -248,7 +248,7 @@ export class DisplayAudio {
 
     /** */
     _onHotkeyActionPlayAudio() {
-        this.playAudio(this._display.selectedIndex, 0);
+        void this.playAudio(this._display.selectedIndex, 0);
     }
 
     /**
@@ -256,7 +256,7 @@ export class DisplayAudio {
      */
     _onHotkeyActionPlayAudioFromSource(source) {
         if (!(typeof source === 'string' || typeof source === 'undefined' || source === null)) { return; }
-        this.playAudio(this._display.selectedIndex, 0, source);
+        void this.playAudio(this._display.selectedIndex, 0, source);
     }
 
     /** @type {import('display').DirectApiHandler<'displayAudioClearAutoPlayTimer'>} */
@@ -317,7 +317,7 @@ export class DisplayAudio {
         if (e.shiftKey) {
             this._showAudioMenu(button, dictionaryEntryIndex, headwordIndex);
         } else {
-            this.playAudio(dictionaryEntryIndex, headwordIndex);
+            void this.playAudio(dictionaryEntryIndex, headwordIndex);
         }
     }
 
@@ -348,7 +348,7 @@ export class DisplayAudio {
                 if (shiftKey) {
                     e.preventDefault();
                 }
-                this._playAudioFromSource(dictionaryEntryIndex, headwordIndex, item);
+                void this._playAudioFromSource(dictionaryEntryIndex, headwordIndex, item);
                 break;
             case 'setPrimaryAudio':
                 e.preventDefault();

--- a/ext/js/display/display-content-manager.js
+++ b/ext/js/display/display-content-manager.js
@@ -49,7 +49,7 @@ export class DisplayContentManager {
      * @param {import('display-content-manager').OnUnloadCallback} onUnload The callback that is executed when the media should be unloaded.
      */
     loadMedia(path, dictionary, onLoad, onUnload) {
-        this._loadMedia(path, dictionary, onLoad, onUnload);
+        void this._loadMedia(path, dictionary, onLoad, onUnload);
     }
 
     /**
@@ -65,7 +65,7 @@ export class DisplayContentManager {
 
         for (const map of this._mediaCache.values()) {
             for (const result of map.values()) {
-                this._revokeUrl(result);
+                void this._revokeUrl(result);
             }
         }
         this._mediaCache.clear();

--- a/ext/js/display/display-profile-selection.js
+++ b/ext/js/display/display-profile-selection.js
@@ -63,7 +63,7 @@ export class DisplayProfileSelection {
         if (source === this._source) { return; }
         this._profileListNeedsUpdate = true;
         if (this._profilePanel.isVisible()) {
-            this._updateProfileList();
+            void this._updateProfileList();
         }
     }
 
@@ -84,7 +84,7 @@ export class DisplayProfileSelection {
         this._profileButton.classList.toggle('sidebar-button-highlight', visible);
         document.documentElement.dataset.profilePanelVisible = `${visible}`;
         if (visible && this._profileListNeedsUpdate) {
-            this._updateProfileList();
+            void this._updateProfileList();
         }
     }
 
@@ -121,7 +121,7 @@ export class DisplayProfileSelection {
     _onProfileRadioChange(index, e) {
         const element = /** @type {HTMLInputElement} */ (e.currentTarget);
         if (element.checked) {
-            this._setProfileCurrent(index);
+            void this._setProfileCurrent(index);
         }
     }
 

--- a/ext/js/display/display-resizer.js
+++ b/ext/js/display/display-resizer.js
@@ -87,7 +87,7 @@ export class DisplayResizer {
         } else {
             if (this._startSize === null) { return; }
             const {clientX: x, clientY: y} = e;
-            this._updateFrameSize(x, y);
+            void this._updateFrameSize(x, y);
         }
     }
 
@@ -115,7 +115,7 @@ export class DisplayResizer {
         const primaryTouch = this._getTouch(e.changedTouches, this._touchIdentifier);
         if (primaryTouch === null) { return; }
         const {clientX: x, clientY: y} = primaryTouch;
-        this._updateFrameSize(x, y);
+        void this._updateFrameSize(x, y);
     }
 
     /**
@@ -138,7 +138,7 @@ export class DisplayResizer {
             documentElement.dataset.isResizing = 'true';
         }
 
-        this._initializeFrameResize(token);
+        void this._initializeFrameResize(token);
     }
 
     /**
@@ -163,7 +163,7 @@ export class DisplayResizer {
             documentElement.dataset.isResizing = 'true';
         }
 
-        this._initializeFrameResize(token);
+        void this._initializeFrameResize(token);
     }
 
     /**

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -364,7 +364,7 @@ export class Display extends EventDispatcher {
 
     /** */
     initializeState() {
-        this._onStateChanged();
+        void this._onStateChanged();
         if (this._frameEndpoint !== null) {
             this._frameEndpoint.signal();
         }
@@ -448,7 +448,7 @@ export class Display extends EventDispatcher {
             }
         });
 
-        this._updateNestedFrontend(options);
+        void this._updateNestedFrontend(options);
         this._updateContentTextScanner(options);
 
         this.trigger('optionsUpdated', {options});
@@ -523,10 +523,10 @@ export class Display extends EventDispatcher {
     close() {
         switch (this._pageType) {
             case 'popup':
-                this.invokeContentOrigin('frontendClosePopup', void 0);
+                void this.invokeContentOrigin('frontendClosePopup', void 0);
                 break;
             case 'search':
-                this._closeTab();
+                void this._closeTab();
                 break;
         }
     }
@@ -964,7 +964,7 @@ export class Display extends EventDispatcher {
     _onDebugLogClick(e) {
         const link = /** @type {HTMLElement} */ (e.currentTarget);
         const index = this.getElementDictionaryEntryIndex(link);
-        this._logDictionaryEntryData(index);
+        void this._logDictionaryEntryData(index);
     }
 
     /**
@@ -1064,7 +1064,7 @@ export class Display extends EventDispatcher {
         const {action} = e.detail;
         switch (action) {
             case 'log-debug-info':
-                this._logDictionaryEntryData(this.getElementDictionaryEntryIndex(node));
+                void this._logDictionaryEntryData(this.getElementDictionaryEntryIndex(node));
                 break;
         }
     }
@@ -1345,7 +1345,7 @@ export class Display extends EventDispatcher {
         const visible = this._isQueryParserVisible();
         this._queryParserContainer.hidden = !visible || text.length === 0;
         if (visible && this._queryParser.text !== text) {
-            this._setQueryParserText(text);
+            void this._setQueryParserText(text);
         }
     }
 
@@ -1738,7 +1738,7 @@ export class Display extends EventDispatcher {
         if (typeof this._contentOriginFrameId !== 'number') { return false; }
         const selection = window.getSelection();
         if (selection !== null && selection.toString().length > 0) { return false; }
-        this._copyHostSelectionSafe();
+        void this._copyHostSelectionSafe();
         return true;
     }
 

--- a/ext/js/display/option-toggle-hotkey-handler.js
+++ b/ext/js/display/option-toggle-hotkey-handler.js
@@ -60,7 +60,7 @@ export class OptionToggleHotkeyHandler {
      */
     _onHotkeyActionToggleOption(argument) {
         if (typeof argument !== 'string') { return; }
-        this._toggleOption(argument);
+        void this._toggleOption(argument);
     }
 
     /**

--- a/ext/js/display/popup-main.js
+++ b/ext/js/display/popup-main.js
@@ -42,7 +42,7 @@ await Application.main(true, async (application) => {
     displayAnki.prepare();
 
     const displayProfileSelection = new DisplayProfileSelection(display);
-    displayProfileSelection.prepare();
+    void displayProfileSelection.prepare();
 
     const displayResizer = new DisplayResizer(display);
     displayResizer.prepare();

--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -207,7 +207,7 @@ export class QueryParser extends EventDispatcher {
             scope: 'profile',
             optionsContext
         };
-        this._api.modifySettings([modification], 'search');
+        void this._api.modifySettings([modification], 'search');
     }
 
     /**
@@ -410,6 +410,6 @@ export class QueryParser extends EventDispatcher {
     _loadJapaneseWanakanaModule() {
         if (this._japaneseWanakanaModuleImport !== null) { return; }
         this._japaneseWanakanaModuleImport = import('../language/ja/japanese-wanakana.js');
-        this._japaneseWanakanaModuleImport.then((value) => { this._japaneseWanakanaModule = value; });
+        void this._japaneseWanakanaModuleImport.then((value) => { this._japaneseWanakanaModule = value; });
     }
 }

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -298,7 +298,7 @@ export class SearchDisplayController {
             scope: 'profile',
             optionsContext: this._display.getOptionsContext()
         };
-        this._display.application.api.modifySettings([modification], 'search');
+        void this._display.application.api.modifySettings([modification], 'search');
     }
 
     /**
@@ -307,7 +307,7 @@ export class SearchDisplayController {
     _onClipboardMonitorEnableChange(e) {
         const element = /** @type {HTMLInputElement} */ (e.target);
         const enabled = element.checked;
-        this._setClipboardMonitorEnabled(enabled);
+        void this._setClipboardMonitorEnabled(enabled);
     }
 
     /** */
@@ -323,7 +323,7 @@ export class SearchDisplayController {
         const value = Number.parseInt(node.value, 10);
         const optionsFull = await this._display.application.api.optionsGetFull();
         if (typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= optionsFull.profiles.length) {
-            this._setPrimaryProfileIndex(value);
+            await this._setPrimaryProfileIndex(value);
         }
     }
 

--- a/ext/js/dom/dom-data-binder.js
+++ b/ext/js/dom/dom-data-binder.js
@@ -133,7 +133,7 @@ export class DOMDataBinder {
         const value = this._getElementValue(observer.element);
         observer.value = value;
         observer.hasValue = true;
-        this._assignTasks.enqueue(observer, {value});
+        void this._assignTasks.enqueue(observer, {value});
     }
 
     /**
@@ -182,7 +182,7 @@ export class DOMDataBinder {
 
         element.addEventListener('change', observer.onChange, false);
 
-        this._updateTasks.enqueue(observer, {all: false});
+        void this._updateTasks.enqueue(observer, {all: false});
 
         return observer;
     }

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -542,7 +542,7 @@ export class TextScanner extends EventDispatcher {
         const inputInfo = this._getMatchingInputGroupFromEvent('mouse', 'mouseMove', e);
         if (inputInfo === null) { return; }
 
-        this._searchAtFromMouseMove(e.clientX, e.clientY, inputInfo);
+        void this._searchAtFromMouseMove(e.clientX, e.clientY, inputInfo);
     }
 
     /**
@@ -612,7 +612,7 @@ export class TextScanner extends EventDispatcher {
         const modifiers = getActiveModifiersAndButtons(e);
         const modifierKeys = getActiveModifiers(e);
         const inputInfo = this._createInputInfo(null, 'mouse', 'click', false, modifiers, modifierKeys);
-        this._searchAt(e.clientX, e.clientY, inputInfo);
+        void this._searchAt(e.clientX, e.clientY, inputInfo);
     }
 
     /** */
@@ -669,7 +669,7 @@ export class TextScanner extends EventDispatcher {
         const inputInfo = this._getMatchingInputGroupFromEvent('touch', 'touchStart', e);
         if (inputInfo === null || !(inputInfo.input !== null && inputInfo.input.scanOnTouchPress)) { return; }
 
-        this._searchAtFromTouchStart(x, y, inputInfo);
+        void this._searchAtFromTouchStart(x, y, inputInfo);
     }
 
     /**
@@ -703,7 +703,7 @@ export class TextScanner extends EventDispatcher {
         const inputInfo = this._getMatchingInputGroupFromEvent('touch', 'touchEnd', e);
         if (inputInfo === null || !(inputInfo.input !== null && inputInfo.input.scanOnTouchRelease)) { return; }
 
-        this._searchAtFromTouchEnd(x, y, inputInfo);
+        void this._searchAtFromTouchEnd(x, y, inputInfo);
     }
 
     /**
@@ -739,7 +739,7 @@ export class TextScanner extends EventDispatcher {
 
         const {input} = inputInfo;
         if (input !== null && input.scanOnTouchMove) {
-            this._searchAt(primaryTouch.clientX, primaryTouch.clientY, inputInfo);
+            void this._searchAt(primaryTouch.clientX, primaryTouch.clientY, inputInfo);
         }
 
         e.preventDefault(); // Disable scroll
@@ -899,7 +899,7 @@ export class TextScanner extends EventDispatcher {
         const inputInfo = this._getMatchingInputGroupFromEvent('touch', 'touchMove', e);
         if (inputInfo === null || !(inputInfo.input !== null && inputInfo.input.scanOnTouchMove)) { return; }
 
-        this._searchAt(e.clientX, e.clientY, inputInfo);
+        void this._searchAt(e.clientX, e.clientY, inputInfo);
     }
 
     /**
@@ -942,7 +942,7 @@ export class TextScanner extends EventDispatcher {
      */
     _onPenPointerOver(e) {
         this._penPointerState = 1;
-        this._searchAtFromPen(e, 'pointerOver', false);
+        void this._searchAtFromPen(e, 'pointerOver', false);
     }
 
     /**
@@ -950,7 +950,7 @@ export class TextScanner extends EventDispatcher {
      */
     _onPenPointerDown(e) {
         this._penPointerState = 2;
-        this._searchAtFromPen(e, 'pointerDown', true);
+        void this._searchAtFromPen(e, 'pointerDown', true);
     }
 
     /**
@@ -958,7 +958,7 @@ export class TextScanner extends EventDispatcher {
      */
     _onPenPointerMove(e) {
         if (this._penPointerState === 2 && (!this._preventScroll || !e.cancelable)) { return; }
-        this._searchAtFromPen(e, 'pointerMove', true);
+        void this._searchAtFromPen(e, 'pointerMove', true);
     }
 
     /**
@@ -967,7 +967,7 @@ export class TextScanner extends EventDispatcher {
     _onPenPointerUp(e) {
         this._penPointerState = 3;
         this._preventScroll = false;
-        this._searchAtFromPen(e, 'pointerUp', false);
+        void this._searchAtFromPen(e, 'pointerUp', false);
     }
 
     /** */

--- a/ext/js/pages/action-popup-main.js
+++ b/ext/js/pages/action-popup-main.js
@@ -37,14 +37,14 @@ class DisplayController {
         const manifest = chrome.runtime.getManifest();
 
         this._showExtensionInfo(manifest);
-        this._setupEnvironment();
+        void this._setupEnvironment();
         this._setupButtonEvents('.action-open-search', 'openSearchPage', chrome.runtime.getURL('/search.html'), this._onSearchClick.bind(this));
         this._setupButtonEvents('.action-open-info', 'openInfoPage', chrome.runtime.getURL('/info.html'));
 
         const optionsFull = await this._api.optionsGetFull();
         this._optionsFull = optionsFull;
 
-        this._setupHotkeys();
+        void this._setupHotkeys();
 
         const optionsPageUrl = (
             typeof manifest.options_ui === 'object' &&
@@ -114,7 +114,7 @@ class DisplayController {
                         const result = customHandler(e);
                         if (typeof result !== 'undefined') { return; }
                     }
-                    this._api.commandExec(command, {mode: e.ctrlKey ? 'newTab' : 'existingOrNewTab'});
+                    void this._api.commandExec(command, {mode: e.ctrlKey ? 'newTab' : 'existingOrNewTab'});
                     e.preventDefault();
                 };
                 /**
@@ -122,7 +122,7 @@ class DisplayController {
                  */
                 const onAuxClick = (e) => {
                     if (e.button !== 1) { return; }
-                    this._api.commandExec(command, {mode: 'newTab'});
+                    void this._api.commandExec(command, {mode: 'newTab'});
                     e.preventDefault();
                 };
                 node.addEventListener('click', onClick, false);
@@ -191,8 +191,8 @@ class DisplayController {
             toggle.checked = extensionEnabled;
             toggle.addEventListener('change', onToggleChanged, false);
         }
-        this._updateDictionariesEnabledWarnings(options);
-        this._updatePermissionsWarnings(options);
+        void this._updateDictionariesEnabledWarnings(options);
+        void this._updatePermissionsWarnings(options);
     }
 
     /** */
@@ -240,7 +240,7 @@ class DisplayController {
         const node = /** @type {HTMLInputElement} */ (event.currentTarget);
         const value = Number.parseInt(node.value, 10);
         if (typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= /** @type {import('settings').Options} */ (this._optionsFull).profiles.length) {
-            this._setPrimaryProfileIndex(value);
+            void this._setPrimaryProfileIndex(value);
         }
     }
 
@@ -307,8 +307,8 @@ class DisplayController {
 }
 
 await Application.main(true, async (application) => {
-    application.api.logIndicatorClear();
+    void application.api.logIndicatorClear();
 
     const displayController = new DisplayController(application.api);
-    displayController.prepare();
+    await displayController.prepare();
 });

--- a/ext/js/pages/common/extension-content-controller.js
+++ b/ext/js/pages/common/extension-content-controller.js
@@ -23,7 +23,7 @@ export class ExtensionContentController {
     prepare() {
         this._prepareSpecialUrls();
         this._prepareExtensionIdExamples();
-        this._prepareEnvironmentInfo();
+        void this._prepareEnvironmentInfo();
     }
 
     // Private
@@ -93,7 +93,7 @@ export class ExtensionContentController {
                     const {specialUrl} = element.dataset;
                     if (typeof specialUrl !== 'string') { return; }
                     e.preventDefault();
-                    this._createTab(specialUrl, true);
+                    void this._createTab(specialUrl, true);
                 }
                 break;
         }

--- a/ext/js/pages/info-main.js
+++ b/ext/js/pages/info-main.js
@@ -148,8 +148,8 @@ await Application.main(true, async (application) => {
     languageElement.textContent = `${language}`;
     userAgentElement.textContent = userAgent;
 
-    showAnkiConnectInfo(application.api);
-    showDictionaryInfo(application.api);
+    void showAnkiConnectInfo(application.api);
+    void showDictionaryInfo(application.api);
 
     const settingsController = new SettingsController(application);
     await settingsController.prepare();

--- a/ext/js/pages/permissions-main.js
+++ b/ext/js/pages/permissions-main.js
@@ -95,7 +95,7 @@ await Application.main(true, async (application) => {
 
     setupPermissionsToggles();
 
-    setupEnvironmentInfo(application.api);
+    void setupEnvironmentInfo(application.api);
 
     /** @type {HTMLInputElement} */
     const permissionCheckbox1 = querySelectorNotNull(document, '#permission-checkbox-allow-in-private-windows');
@@ -122,13 +122,13 @@ await Application.main(true, async (application) => {
     await settingsController.prepare();
 
     const permissionsToggleController = new PermissionsToggleController(settingsController);
-    permissionsToggleController.prepare();
+    void permissionsToggleController.prepare();
 
     const permissionsOriginController = new PermissionsOriginController(settingsController);
-    permissionsOriginController.prepare();
+    void permissionsOriginController.prepare();
 
     const persistentStorageController = new PersistentStorageController(application);
-    persistentStorageController.prepare();
+    void persistentStorageController.prepare();
 
     await promiseTimeout(100);
 

--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -110,7 +110,7 @@ export class AnkiController {
         ankiApiKeyInput.addEventListener('focus', this._onApiKeyInputFocus.bind(this));
         ankiApiKeyInput.addEventListener('blur', this._onApiKeyInputBlur.bind(this));
 
-        const onAnkiSettingChanged = () => { this._updateOptions(); };
+        const onAnkiSettingChanged = () => { void this._updateOptions(); };
         const nodes = [ankiApiKeyInput, ...document.querySelectorAll('[data-setting="anki.enable"]')];
         for (const node of nodes) {
             node.addEventListener('settingChanged', onAnkiSettingChanged);
@@ -128,7 +128,7 @@ export class AnkiController {
         if (promise === null) {
             promise = this._getAnkiData();
             this._getAnkiDataPromise = promise;
-            promise.finally(() => { this._getAnkiDataPromise = null; });
+            void promise.finally(() => { this._getAnkiDataPromise = null; });
         }
         return promise;
     }
@@ -161,7 +161,7 @@ export class AnkiController {
     /**
      * @param {import('settings-controller').EventArgument<'optionsChanged'>} details
      */
-    async _onOptionsChanged({options: {anki}}) {
+    _onOptionsChanged({options: {anki}}) {
         /** @type {?string} */
         let apiKey = anki.apiKey;
         if (apiKey === '') { apiKey = null; }
@@ -187,7 +187,7 @@ export class AnkiController {
         this._ankiConnect.enabled = typeof value === 'boolean' && value;
 
         for (const cardController of this._selectorObserver.datas()) {
-            cardController.updateAnkiState();
+            void cardController.updateAnkiState();
         }
     }
 
@@ -219,7 +219,7 @@ export class AnkiController {
 
         const normalizedMode = this._normalizeAnkiNoteGuiMode(mode);
         if (normalizedMode === null) { return; }
-        this._testAnkiNoteViewerSafe(normalizedMode);
+        void this._testAnkiNoteViewerSafe(normalizedMode);
     }
 
     /**
@@ -258,7 +258,7 @@ export class AnkiController {
      */
     _createCardController(node) {
         const cardController = new AnkiCardController(this._settingsController, this, /** @type {HTMLElement} */ (node));
-        cardController.prepare();
+        void cardController.prepare();
         return cardController;
     }
 
@@ -588,7 +588,7 @@ class AnkiCardController {
      */
     _onCardDeckChange(e) {
         const node = /** @type {HTMLSelectElement} */ (e.currentTarget);
-        this._setDeck(node.value);
+        void this._setDeck(node.value);
     }
 
     /**
@@ -596,7 +596,7 @@ class AnkiCardController {
      */
     _onCardModelChange(e) {
         const node = /** @type {HTMLSelectElement} */ (e.currentTarget);
-        this._setModel(node.value);
+        void this._setModel(node.value);
     }
 
     /**
@@ -605,7 +605,7 @@ class AnkiCardController {
      */
     _onFieldChange(index, e) {
         const node = /** @type {HTMLInputElement} */ (e.currentTarget);
-        this._validateFieldPermissions(node, index, true);
+        void this._validateFieldPermissions(node, index, true);
         this._validateField(node, index);
     }
 
@@ -624,7 +624,7 @@ class AnkiCardController {
      */
     _onFieldSettingChanged(index, e) {
         const node = /** @type {HTMLInputElement} */ (e.currentTarget);
-        this._validateFieldPermissions(node, index, false);
+        void this._validateFieldPermissions(node, index, false);
     }
 
     /**
@@ -731,7 +731,7 @@ class AnkiCardController {
             const inputField = querySelectorNotNull(content, '.anki-card-field-value');
             inputField.value = fieldValue;
             inputField.dataset.setting = ObjectPropertyAccessor.getPathString(['anki', this._optionsType, 'fields', fieldName]);
-            this._validateFieldPermissions(inputField, index, false);
+            void this._validateFieldPermissions(inputField, index, false);
 
             this._fieldEventListeners.addEventListener(inputField, 'change', this._onFieldChange.bind(this, index), false);
             this._fieldEventListeners.addEventListener(inputField, 'input', this._onFieldInput.bind(this, index), false);
@@ -769,7 +769,7 @@ class AnkiCardController {
             container.appendChild(totalFragment);
         }
 
-        this._validateFields();
+        void this._validateFields();
     }
 
     /** */

--- a/ext/js/pages/settings/anki-templates-controller.js
+++ b/ext/js/pages/settings/anki-templates-controller.js
@@ -156,7 +156,7 @@ export class AnkiTemplatesController {
     /** */
     _onValidateCompile() {
         if (this._compileResultInfo === null) { return; }
-        this._validate(this._compileResultInfo, '{expression}', 'term-kanji', false, true);
+        void this._validate(this._compileResultInfo, '{expression}', 'term-kanji', false, true);
     }
 
     /**
@@ -169,7 +169,7 @@ export class AnkiTemplatesController {
         const infoNode = /** @type {HTMLElement} */ (this._renderResult);
         infoNode.hidden = true;
         this._cachedDictionaryEntryText = null;
-        this._validate(infoNode, field, 'term-kanji', true, false);
+        void this._validate(infoNode, field, 'term-kanji', true, false);
     }
 
     /**

--- a/ext/js/pages/settings/audio-controller.js
+++ b/ext/js/pages/settings/audio-controller.js
@@ -134,7 +134,7 @@ export class AudioController extends EventDispatcher {
 
     /** */
     _onAddAudioSource() {
-        this._addAudioSource();
+        void this._addAudioSource();
     }
 
     /** */
@@ -145,7 +145,7 @@ export class AudioController extends EventDispatcher {
             const voiceUri = input.dataset.voice;
             const audio = this._audioSystem.createTextToSpeechAudio(text, typeof voiceUri === 'string' ? voiceUri : '');
             audio.volume = 1;
-            audio.play();
+            void audio.play();
         } catch (e) {
             // NOP
         }
@@ -352,7 +352,7 @@ class AudioSourceEntry {
         const element = /** @type {HTMLSelectElement} */ (e.currentTarget);
         const value = this._normalizeAudioSourceType(element.value);
         if (value === null) { return; }
-        this._setType(value);
+        void this._setType(value);
     }
 
     /**
@@ -360,7 +360,7 @@ class AudioSourceEntry {
      */
     _onUrlInputChange(e) {
         const element = /** @type {HTMLInputElement} */ (e.currentTarget);
-        this._setUrl(element.value);
+        void this._setUrl(element.value);
     }
 
     /**
@@ -368,7 +368,7 @@ class AudioSourceEntry {
      */
     _onVoiceSelectChange(e) {
         const element = /** @type {HTMLSelectElement} */ (e.currentTarget);
-        this._setVoice(element.value);
+        void this._setVoice(element.value);
     }
 
     /**
@@ -403,7 +403,7 @@ class AudioSourceEntry {
                 this._showHelp(this._type);
                 break;
             case 'remove':
-                this._parent.removeSource(this);
+                void this._parent.removeSource(this);
                 break;
         }
     }

--- a/ext/js/pages/settings/backup-controller.js
+++ b/ext/js/pages/settings/backup-controller.js
@@ -642,7 +642,7 @@ export class BackupController {
         await Dexie.import(file, {
             progressCallback: this._databaseImportProgressCallback.bind(this)
         });
-        this._settingsController.application.api.triggerDatabaseUpdated('dictionary', 'import');
+        void this._settingsController.application.api.triggerDatabaseUpdated('dictionary', 'import');
         this._settingsController.application.triggerStorageChanged();
     }
 

--- a/ext/js/pages/settings/collapsible-dictionary-controller.js
+++ b/ext/js/pages/settings/collapsible-dictionary-controller.js
@@ -99,7 +99,7 @@ export class CollapsibleDictionaryController {
 
     /** */
     _onDefinitionsCollapsibleChange() {
-        this._updateAllSelectFresh();
+        void this._updateAllSelectFresh();
     }
 
     /**
@@ -109,7 +109,7 @@ export class CollapsibleDictionaryController {
         const {value} = /** @type {HTMLSelectElement} */ (e.currentTarget);
         const value2 = this._normalizeDictionaryDefinitionsCollapsible(value);
         if (value2 === null) { return; }
-        this._setDefinitionsCollapsibleAll(value2);
+        void this._setDefinitionsCollapsibleAll(value2);
     }
 
     /** */

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -149,7 +149,7 @@ class DictionaryEntry {
     _onEnabledChanged(e) {
         const {detail: {value}} = e;
         this._titleContainer.dataset.enabled = `${value}`;
-        this._dictionaryController.updateDictionariesEnabled();
+        void this._dictionaryController.updateDictionariesEnabled();
     }
 
     /** */
@@ -255,7 +255,7 @@ class DictionaryEntry {
      * @param {number} offset
      */
     _move(offset) {
-        this._dictionaryController.moveDictionaryOptions(this._index, this._index + offset);
+        void this._dictionaryController.moveDictionaryOptions(this._index, this._index + offset);
     }
 
     /**
@@ -598,7 +598,7 @@ export class DictionaryController {
     _onOptionsChanged({options}) {
         this._updateDictionariesEnabledWarnings(options);
         if (this._dictionaries !== null) {
-            this._updateEntries();
+            void this._updateEntries();
         }
     }
 
@@ -620,7 +620,7 @@ export class DictionaryController {
         const allCheckbox = /** @type {HTMLInputElement} */ (this._allCheckbox);
         const value = allCheckbox.checked;
         allCheckbox.checked = !value;
-        this._setAllDictionariesEnabled(value);
+        void this._setAllDictionariesEnabled(value);
     }
 
     /** */
@@ -718,7 +718,7 @@ export class DictionaryController {
         if (typeof title !== 'string') { return; }
         delete modal.node.dataset.dictionaryTitle;
 
-        this._deleteDictionary(title);
+        void this._deleteDictionary(title);
     }
 
     /**
@@ -726,7 +726,7 @@ export class DictionaryController {
      */
     _onCheckIntegrityButtonClick(e) {
         e.preventDefault();
-        this._checkIntegrity();
+        void this._checkIntegrity();
     }
 
     /** */
@@ -743,7 +743,7 @@ export class DictionaryController {
 
         if (!Number.isFinite(target) || !Number.isFinite(indexNumber) || indexNumber === target) { return; }
 
-        this.moveDictionaryOptions(indexNumber, target);
+        void this.moveDictionaryOptions(indexNumber, target);
     }
 
     /**
@@ -916,7 +916,7 @@ export class DictionaryController {
      */
     async _deleteDictionaryInternal(dictionaryTitle, onProgress) {
         await new DictionaryWorker().deleteDictionary(dictionaryTitle, onProgress);
-        this._settingsController.application.api.triggerDatabaseUpdated('dictionary', 'delete');
+        void this._settingsController.application.api.triggerDatabaseUpdated('dictionary', 'delete');
     }
 
     /**

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -64,7 +64,7 @@ export class DictionaryImportController {
     }
 
     /** */
-    async prepare() {
+    prepare() {
         this._purgeConfirmModal = this._modalController.getModal('dictionary-confirm-delete-all');
 
         this._purgeButton.addEventListener('click', this._onPurgeButtonClick.bind(this), false);
@@ -94,7 +94,7 @@ export class DictionaryImportController {
     _onPurgeConfirmButtonClick(e) {
         e.preventDefault();
         /** @type {import('./modal.js').Modal} */ (this._purgeConfirmModal).setVisible(false);
-        this._purgeDatabase();
+        void this._purgeDatabase();
     }
 
     /**
@@ -106,7 +106,7 @@ export class DictionaryImportController {
         if (files === null) { return; }
         const files2 = [...files];
         node.value = '';
-        this._importDictionaries(files2);
+        void this._importDictionaries(files2);
     }
 
     /** */
@@ -235,7 +235,7 @@ export class DictionaryImportController {
     async _importDictionary(file, importDetails, onProgress) {
         const archiveContent = await this._readFile(file);
         const {result, errors} = await new DictionaryWorker().importDictionary(archiveContent, importDetails, onProgress);
-        this._settingsController.application.api.triggerDatabaseUpdated('dictionary', 'import');
+        void this._settingsController.application.api.triggerDatabaseUpdated('dictionary', 'import');
         const errors2 = await this._addDictionarySettings(result.sequenced, result.title);
 
         if (errors.length > 0) {

--- a/ext/js/pages/settings/extension-keyboard-shortcuts-controller.js
+++ b/ext/js/pages/settings/extension-keyboard-shortcuts-controller.js
@@ -133,7 +133,7 @@ export class ExtensionKeyboardShortcutController {
      */
     _onResetClick(e) {
         e.preventDefault();
-        this._resetAllCommands();
+        void this._resetAllCommands();
     }
 
     /**
@@ -141,7 +141,7 @@ export class ExtensionKeyboardShortcutController {
      */
     _onClearClick(e) {
         e.preventDefault();
-        this._clearAllCommands();
+        void this._clearAllCommands();
     }
 
     /**
@@ -317,7 +317,7 @@ class ExtensionKeyboardShortcutHotkeyEntry {
      */
     _onInputFieldChange(e) {
         const {key, modifiers} = e;
-        this._tryUpdateInput(key, modifiers, false);
+        void this._tryUpdateInput(key, modifiers, false);
     }
 
     /** */
@@ -331,10 +331,10 @@ class ExtensionKeyboardShortcutHotkeyEntry {
     _onMenuClose(e) {
         switch (e.detail.action) {
             case 'clearInput':
-                this._tryUpdateInput(null, [], true);
+                void this._tryUpdateInput(null, [], true);
                 break;
             case 'resetInput':
-                this._resetInput();
+                void this._resetInput();
                 break;
         }
     }

--- a/ext/js/pages/settings/generic-setting-controller.js
+++ b/ext/js/pages/settings/generic-setting-controller.js
@@ -66,7 +66,7 @@ export class GenericSettingController {
 
     /** */
     _onOptionsChanged() {
-        this._dataBinder.refresh();
+        void this._dataBinder.refresh();
     }
 
     /**

--- a/ext/js/pages/settings/keyboard-shortcuts-controller.js
+++ b/ext/js/pages/settings/keyboard-shortcuts-controller.js
@@ -191,7 +191,7 @@ export class KeyboardShortcutController {
      */
     _onAddClick(e) {
         e.preventDefault();
-        this._addNewEntry();
+        void this._addNewEntry();
     }
 
     /**
@@ -199,7 +199,7 @@ export class KeyboardShortcutController {
      */
     _onResetClick(e) {
         e.preventDefault();
-        this._reset();
+        void this._reset();
     }
 
     /** */
@@ -350,16 +350,16 @@ class KeyboardShortcutHotkeyEntry {
     _onMenuClose(e) {
         switch (e.detail.action) {
             case 'delete':
-                this._delete();
+                void this._delete();
                 break;
             case 'clearInputs':
                 /** @type {KeyboardMouseInputField} */ (this._inputField).clearInputs();
                 break;
             case 'resetInput':
-                this._resetInput();
+                void this._resetInput();
                 break;
             case 'resetArgument':
-                this._resetArgument();
+                void this._resetArgument();
                 break;
         }
     }
@@ -404,7 +404,7 @@ class KeyboardShortcutHotkeyEntry {
             if (modifier2 === null) { continue; }
             modifiers2.push(modifier2);
         }
-        this._setKeyAndModifiers(key, modifiers2);
+        void this._setKeyAndModifiers(key, modifiers2);
     }
 
     /**
@@ -414,7 +414,7 @@ class KeyboardShortcutHotkeyEntry {
         const node = /** @type {HTMLInputElement} */ (e.currentTarget);
         const scope = this._normalizeScope(node.dataset.scope);
         if (scope === null) { return; }
-        this._setScopeEnabled(scope, node.checked);
+        void this._setScopeEnabled(scope, node.checked);
     }
 
     /**
@@ -423,7 +423,7 @@ class KeyboardShortcutHotkeyEntry {
     _onActionSelectChange(e) {
         const node = /** @type {HTMLSelectElement} */ (e.currentTarget);
         const value = node.value;
-        this._setAction(value);
+        void this._setAction(value);
     }
 
     /**
@@ -438,12 +438,12 @@ class KeyboardShortcutHotkeyEntry {
                 value = `${convertElementValueToNumber(value, node)}`;
                 break;
         }
-        this._setArgument(value);
+        void this._setArgument(value);
     }
 
     /** */
     async _delete() {
-        this._parent.deleteEntry(this._index);
+        void this._parent.deleteEntry(this._index);
     }
 
     /**
@@ -607,7 +607,7 @@ class KeyboardShortcutHotkeyEntry {
             this._setArgumentInputValue(node, value);
         }
 
-        this._updateArgumentInputValidity();
+        void this._updateArgumentInputValidity();
 
         await this._modifyProfileSettings([{
             action: 'set',
@@ -702,7 +702,7 @@ class KeyboardShortcutHotkeyEntry {
             if (inputNode !== null) {
                 this._setArgumentInputValue(inputNode, argument);
                 this._argumentInput = inputNode;
-                this._updateArgumentInputValidity();
+                void this._updateArgumentInputValidity();
                 this._argumentEventListeners.addEventListener(inputNode, 'change', this._onArgumentValueChange.bind(this, template), false);
             }
             if (this._argumentContainer !== null) {

--- a/ext/js/pages/settings/mecab-controller.js
+++ b/ext/js/pages/settings/mecab-controller.js
@@ -46,7 +46,7 @@ export class MecabController {
      */
     _onTestButtonClick(e) {
         e.preventDefault();
-        this._testMecab();
+        void this._testMecab();
     }
 
     /** */

--- a/ext/js/pages/settings/nested-popups-controller.js
+++ b/ext/js/pages/settings/nested-popups-controller.js
@@ -63,7 +63,7 @@ export class NestedPopupsController {
         const node = /** @type {HTMLInputElement} */ (e.currentTarget);
         const value = node.checked;
         if (value && this._popupNestingMaxDepth > 0) { return; }
-        this._setPopupNestingMaxDepth(value ? 1 : 0);
+        void this._setPopupNestingMaxDepth(value ? 1 : 0);
     }
 
     /**
@@ -72,7 +72,7 @@ export class NestedPopupsController {
     _onNestedPopupsCountChange(e) {
         const node = /** @type {HTMLInputElement} */ (e.currentTarget);
         const value = Math.max(1, convertElementValueToNumber(node.value, node));
-        this._setPopupNestingMaxDepth(value);
+        void this._setPopupNestingMaxDepth(value);
     }
 
     /**

--- a/ext/js/pages/settings/permissions-origin-controller.js
+++ b/ext/js/pages/settings/permissions-origin-controller.js
@@ -114,19 +114,19 @@ export class PermissionsOriginController {
 
         const {origin} = node.dataset;
         if (typeof origin !== 'string') { return; }
-        this._setOriginPermissionEnabled(origin, value);
+        void this._setOriginPermissionEnabled(origin, value);
     }
 
     /**
      * @param {string} origin
      */
     _onOriginMenuClose(origin) {
-        this._setOriginPermissionEnabled(origin, false);
+        void this._setOriginPermissionEnabled(origin, false);
     }
 
     /** */
     _onAddButtonClick() {
-        this._addOrigin();
+        void this._addOrigin();
     }
 
     /** */

--- a/ext/js/pages/settings/permissions-toggle-controller.js
+++ b/ext/js/pages/settings/permissions-toggle-controller.js
@@ -69,7 +69,7 @@ export class PermissionsToggleController {
             }
             toggle.checked = !!value;
         }
-        this._updateValidity();
+        void this._updateValidity();
     }
 
     /**

--- a/ext/js/pages/settings/persistent-storage-controller.js
+++ b/ext/js/pages/settings/persistent-storage-controller.js
@@ -70,7 +70,7 @@ export class PersistentStorageController {
         const node = /** @type {HTMLInputElement} */ (e.currentTarget);
         if (node.checked) {
             node.checked = false;
-            this._attemptPersistStorage();
+            void this._attemptPersistStorage();
         } else {
             node.checked = true;
         }

--- a/ext/js/pages/settings/popup-preview-controller.js
+++ b/ext/js/pages/settings/popup-preview-controller.js
@@ -38,7 +38,7 @@ export class PopupPreviewController {
     }
 
     /** */
-    async prepare() {
+    prepare() {
         if (new URLSearchParams(location.search).get('popup-preview') === 'false') { return; }
 
         this._customCss.addEventListener('input', this._onCustomCssChange.bind(this), false);

--- a/ext/js/pages/settings/popup-preview-frame.js
+++ b/ext/js/pages/settings/popup-preview-frame.js
@@ -89,7 +89,7 @@ export class PopupPreviewFrame {
 
         this._languageSummaries = await this._application.api.getLanguageSummaries();
         const options = await this._application.api.optionsGet({current: true});
-        this._onOptionsChanged({options, optionsContext: {current: true}});
+        void this._onOptionsChanged({options, optionsContext: {current: true}});
 
         // Overwrite frontend
         this._frontend = new Frontend({
@@ -115,7 +115,7 @@ export class PopupPreviewFrame {
         }
 
         // Update search
-        this._updateSearch();
+        void this._updateSearch();
     }
 
     // Private
@@ -181,7 +181,7 @@ export class PopupPreviewFrame {
             this._themeChangeTimeout = null;
             const popup = /** @type {Frontend} */ (this._frontend).popup;
             if (popup === null) { return; }
-            popup.updateTheme();
+            void popup.updateTheme();
         }, 300);
     }
 
@@ -229,7 +229,7 @@ export class PopupPreviewFrame {
 
         this._exampleText.textContent = text;
         if (this._frontend === null) { return; }
-        this._updateSearch();
+        void this._updateSearch();
     }
 
     /**
@@ -249,7 +249,7 @@ export class PopupPreviewFrame {
         if (this._frontend === null) { return; }
         const popup = this._frontend.popup;
         if (popup === null) { return; }
-        popup.setCustomCss(css);
+        void popup.setCustomCss(css);
     }
 
     /**
@@ -259,7 +259,7 @@ export class PopupPreviewFrame {
         if (this._frontend === null) { return; }
         const popup = this._frontend.popup;
         if (popup === null) { return; }
-        popup.setCustomOuterCss(css, false);
+        void popup.setCustomOuterCss(css, false);
     }
 
     /**

--- a/ext/js/pages/settings/popup-window-controller.js
+++ b/ext/js/pages/settings/popup-window-controller.js
@@ -41,7 +41,7 @@ export class PopupWindowController {
      */
     _onTestWindowOpenLinkClick(e) {
         e.preventDefault();
-        this._testWindowOpen();
+        void this._testWindowOpen();
     }
 
     /** */

--- a/ext/js/pages/settings/profile-conditions-ui.js
+++ b/ext/js/pages/settings/profile-conditions-ui.js
@@ -266,7 +266,7 @@ export class ProfileConditionsUI extends EventDispatcher {
             this._children[i].index = i;
         }
 
-        this.settingsController.modifyGlobalSettings([{
+        void this.settingsController.modifyGlobalSettings([{
             action: 'splice',
             path: this.getPath('conditionGroups'),
             start: index,
@@ -333,7 +333,7 @@ export class ProfileConditionsUI extends EventDispatcher {
 
         this._addConditionGroup(conditionGroup, index);
 
-        this.settingsController.modifyGlobalSettings([{
+        void this.settingsController.modifyGlobalSettings([{
             action: 'splice',
             path: this.getPath('conditionGroups'),
             start: index,
@@ -543,7 +543,7 @@ class ProfileConditionGroupUI {
             this._children[i].index = i;
         }
 
-        this.settingsController.modifyGlobalSettings([{
+        void this.settingsController.modifyGlobalSettings([{
             action: 'splice',
             path: this.getPath('conditions'),
             start: index,
@@ -581,7 +581,7 @@ class ProfileConditionGroupUI {
 
         this._addCondition(condition, index);
 
-        this.settingsController.modifyGlobalSettings([{
+        void this.settingsController.modifyGlobalSettings([{
             action: 'splice',
             path: this.getPath('conditions'),
             start: index,
@@ -714,7 +714,7 @@ class ProfileConditionUI {
         const element = /** @type {HTMLSelectElement} */ (e.currentTarget);
         const type = ProfileConditionsUI.normalizeProfileConditionType(element.value);
         if (type === null) { return; }
-        this._setType(type);
+        void this._setType(type);
     }
 
     /**
@@ -725,7 +725,7 @@ class ProfileConditionUI {
         const type = ProfileConditionsUI.normalizeProfileConditionType(this._typeInput.value);
         if (type === null) { return; }
         const operator = element.value;
-        this._setOperator(type, operator);
+        void this._setOperator(type, operator);
     }
 
     /**
@@ -740,7 +740,7 @@ class ProfileConditionUI {
         if (okay) {
             const normalizedValue = this._normalizeValue(value, normalize);
             node.value = normalizedValue;
-            this.settingsController.setGlobalSetting(this.getPath('value'), normalizedValue);
+            void this.settingsController.setGlobalSetting(this.getPath('value'), normalizedValue);
         }
     }
 
@@ -754,7 +754,7 @@ class ProfileConditionUI {
         this._value = modifiers;
         if (okay) {
             const normalizedValue = this._normalizeValue(modifiers, normalize);
-            this.settingsController.setGlobalSetting(this.getPath('value'), normalizedValue);
+            void this.settingsController.setGlobalSetting(this.getPath('value'), normalizedValue);
         }
     }
 
@@ -782,7 +782,7 @@ class ProfileConditionUI {
                 this._parent.removeSelf();
                 break;
             case 'resetValue':
-                this._resetValue();
+                void this._resetValue();
                 break;
         }
     }

--- a/ext/js/pages/settings/profile-controller.js
+++ b/ext/js/pages/settings/profile-controller.js
@@ -98,7 +98,7 @@ export class ProfileController {
 
         this._profileConditionsUI.on('conditionGroupCountChanged', this._onConditionGroupCountChanged.bind(this));
         this._settingsController.on('optionsChanged', this._onOptionsChanged.bind(this));
-        this._onOptionsChanged();
+        void this._onOptionsChanged();
     }
 
     /**
@@ -376,7 +376,7 @@ export class ProfileController {
 
         this._profileConditionsUI.cleanup();
         this._profileConditionsIndex = profileIndex;
-        this._profileConditionsUI.prepare(profileIndex);
+        void this._profileConditionsUI.prepare(profileIndex);
         if (this._profileConditionsProfileName !== null) {
             this._profileConditionsProfileName.textContent = profile.name;
         }
@@ -403,7 +403,7 @@ export class ProfileController {
         this._profileConditionsUI.cleanup();
         const conditionsProfile = this._getProfile(this._profileConditionsIndex !== null ? this._profileConditionsIndex : settingsProfileIndex);
         if (conditionsProfile !== null) {
-            this._profileConditionsUI.prepare(settingsProfileIndex);
+            void this._profileConditionsUI.prepare(settingsProfileIndex);
         }
 
         // Udpate profile entries
@@ -425,7 +425,7 @@ export class ProfileController {
         const element = /** @type {HTMLSelectElement} */ (e.currentTarget);
         const value = this._tryGetValidProfileIndex(element.value);
         if (value === null) { return; }
-        this.setDefaultProfile(value);
+        void this.setDefaultProfile(value);
     }
 
     /**
@@ -440,7 +440,7 @@ export class ProfileController {
 
     /** */
     _onAdd() {
-        this.duplicateProfile(this._settingsController.profileIndex);
+        void this.duplicateProfile(this._settingsController.profileIndex);
     }
 
     /** */
@@ -454,7 +454,7 @@ export class ProfileController {
         const validProfileIndex = this._tryGetValidProfileIndex(profileIndex);
         if (validProfileIndex === null) { return; }
 
-        this.deleteProfile(validProfileIndex);
+        void this.deleteProfile(validProfileIndex);
     }
 
     /** */
@@ -471,7 +471,7 @@ export class ProfileController {
         const sourceProfileIndex = this._tryGetValidProfileIndex(/** @type {HTMLSelectElement} */ (this._profileCopySourceSelect).value);
         if (sourceProfileIndex === null) { return; }
 
-        this.copyProfile(sourceProfileIndex, validDestinationProfileIndex);
+        void this.copyProfile(sourceProfileIndex, validDestinationProfileIndex);
     }
 
     /**
@@ -738,7 +738,7 @@ class ProfileEntry {
     _onIsDefaultRadioChange(e) {
         const element = /** @type {HTMLInputElement} */ (e.currentTarget);
         if (!element.checked) { return; }
-        this._profileController.setDefaultProfile(this._index);
+        void this._profileController.setDefaultProfile(this._index);
     }
 
     /**
@@ -747,7 +747,7 @@ class ProfileEntry {
     _onNameInputInput(e) {
         const element = /** @type {HTMLInputElement} */ (e.currentTarget);
         const name = element.value;
-        this._profileController.setProfileName(this._index, name);
+        void this._profileController.setProfileName(this._index, name);
     }
 
     /** */
@@ -773,10 +773,10 @@ class ProfileEntry {
     _onMenuClose(e) {
         switch (e.detail.action) {
             case 'moveUp':
-                this._profileController.moveProfile(this._index, -1);
+                void this._profileController.moveProfile(this._index, -1);
                 break;
             case 'moveDown':
-                this._profileController.moveProfile(this._index, 1);
+                void this._profileController.moveProfile(this._index, 1);
                 break;
             case 'copyFrom':
                 this._profileController.openCopyProfileModal(this._index);
@@ -785,7 +785,7 @@ class ProfileEntry {
                 this._profileController.openProfileConditionsModal(this._index);
                 break;
             case 'duplicate':
-                this._profileController.duplicateProfile(this._index);
+                void this._profileController.duplicateProfile(this._index);
                 break;
             case 'delete':
                 this._profileController.openDeleteProfileModal(this._index);

--- a/ext/js/pages/settings/recommended-permissions-controller.js
+++ b/ext/js/pages/settings/recommended-permissions-controller.js
@@ -73,7 +73,7 @@ export class RecommendedPermissionsController {
 
         const {origin} = node.dataset;
         if (typeof origin !== 'string') { return; }
-        this._setOriginPermissionEnabled(origin, value);
+        void this._setOriginPermissionEnabled(origin, value);
     }
 
     /** */

--- a/ext/js/pages/settings/scan-inputs-controller.js
+++ b/ext/js/pages/settings/scan-inputs-controller.js
@@ -51,7 +51,7 @@ export class ScanInputsController {
         this._settingsController.on('scanInputsChanged', this._onScanInputsChanged.bind(this));
         this._settingsController.on('optionsChanged', this._onOptionsChanged.bind(this));
 
-        this.refresh();
+        await this.refresh();
     }
 
     /**
@@ -67,7 +67,7 @@ export class ScanInputsController {
             this._entries[i].index = i;
         }
         this._updateCounts();
-        this._modifyProfileSettings([{
+        void this._modifyProfileSettings([{
             action: 'splice',
             path: 'scanning.inputs',
             start: index,
@@ -113,7 +113,7 @@ export class ScanInputsController {
      */
     _onScanInputsChanged({source}) {
         if (source === this) { return; }
-        this.refresh();
+        void this.refresh();
     }
 
     /**
@@ -144,7 +144,7 @@ export class ScanInputsController {
         const scanningInput = ScanInputsController.createDefaultMouseInput('', '');
         this._addOption(index, scanningInput);
         this._updateCounts();
-        this._modifyProfileSettings([{
+        void this._modifyProfileSettings([{
             action: 'splice',
             path: 'scanning.inputs',
             start: index,
@@ -315,7 +315,7 @@ class ScanInputField {
      */
     _onIncludeValueChange({modifiers}) {
         const modifiers2 = this._joinModifiers(modifiers);
-        this._parent.setProperty(this._index, 'include', modifiers2, true);
+        void this._parent.setProperty(this._index, 'include', modifiers2, true);
     }
 
     /**
@@ -323,7 +323,7 @@ class ScanInputField {
      */
     _onExcludeValueChange({modifiers}) {
         const modifiers2 = this._joinModifiers(modifiers);
-        this._parent.setProperty(this._index, 'exclude', modifiers2, true);
+        void this._parent.setProperty(this._index, 'exclude', modifiers2, true);
     }
 
     /**
@@ -406,7 +406,7 @@ class ScanInputField {
         if (this._node !== null) {
             this._node.dataset.showAdvanced = `${showAdvanced}`;
         }
-        this._parent.setProperty(this._index, 'options.showAdvanced', showAdvanced, false);
+        void this._parent.setProperty(this._index, 'options.showAdvanced', showAdvanced, false);
     }
 
     /**

--- a/ext/js/pages/settings/scan-inputs-simple-controller.js
+++ b/ext/js/pages/settings/scan-inputs-simple-controller.js
@@ -70,7 +70,7 @@ export class ScanInputsSimpleController {
      */
     _onScanInputsChanged({source}) {
         if (source === this) { return; }
-        this.refresh();
+        void this.refresh();
     }
 
     /**
@@ -112,7 +112,7 @@ export class ScanInputsSimpleController {
     onMiddleMouseButtonScanChange(e) {
         const element = /** @type {HTMLInputElement} */ (e.currentTarget);
         const middleMouseSupported = element.checked;
-        this._setMiddleMouseSuppported(middleMouseSupported);
+        void this._setMiddleMouseSuppported(middleMouseSupported);
     }
 
     /**
@@ -123,7 +123,7 @@ export class ScanInputsSimpleController {
         const mainScanKey = element.value;
         if (mainScanKey === 'other') { return; }
         const mainScanInputs = (mainScanKey === 'none' ? [] : [mainScanKey]);
-        this._setMainScanInputs(mainScanInputs);
+        void this._setMainScanInputs(mainScanInputs);
     }
 
     /**

--- a/ext/js/pages/settings/sentence-termination-characters-controller.js
+++ b/ext/js/pages/settings/sentence-termination-characters-controller.js
@@ -135,7 +135,7 @@ export class SentenceTerminationCharactersController {
      */
     _onAddClick(e) {
         e.preventDefault();
-        this._addNewEntry();
+        void this._addNewEntry();
     }
 
     /**
@@ -143,7 +143,7 @@ export class SentenceTerminationCharactersController {
      */
     _onResetClick(e) {
         e.preventDefault();
-        this._reset();
+        void this._reset();
     }
 
     /** */
@@ -258,7 +258,7 @@ class SentenceTerminationCharacterEntry {
      */
     _onTypeSelectChange(e) {
         const element = /** @type {HTMLSelectElement} */ (e.currentTarget);
-        this._setHasCharacter2(element.value === 'quote');
+        void this._setHasCharacter2(element.value === 'quote');
     }
 
     /**
@@ -272,7 +272,7 @@ class SentenceTerminationCharacterEntry {
         }
 
         const value = node.value.substring(0, 1);
-        this._setCharacterValue(node, characterNumber, value);
+        void this._setCharacterValue(node, characterNumber, value);
     }
 
     /**
@@ -281,14 +281,14 @@ class SentenceTerminationCharacterEntry {
     _onMenuClose(e) {
         switch (e.detail.action) {
             case 'delete':
-                this._delete();
+                void this._delete();
                 break;
         }
     }
 
     /** */
     async _delete() {
-        this._parent.deleteEntry(this._index);
+        void this._parent.deleteEntry(this._index);
     }
 
     /**

--- a/ext/js/pages/settings/settings-controller.js
+++ b/ext/js/pages/settings/settings-controller.js
@@ -239,7 +239,7 @@ export class SettingsController extends EventDispatcher {
     _setProfileIndex(value, canUpdateProfileIndex) {
         this._profileIndex = value;
         this.trigger('optionsContextChanged', {});
-        this._onOptionsUpdatedInternal(canUpdateProfileIndex);
+        void this._onOptionsUpdatedInternal(canUpdateProfileIndex);
     }
 
     /**
@@ -247,7 +247,7 @@ export class SettingsController extends EventDispatcher {
      */
     _onOptionsUpdated({source}) {
         if (source === this._source) { return; }
-        this._onOptionsUpdatedInternal(true);
+        void this._onOptionsUpdatedInternal(true);
     }
 
     /**
@@ -332,7 +332,7 @@ export class SettingsController extends EventDispatcher {
 
     /** */
     _onPermissionsChanged() {
-        this._triggerPermissionsChanged();
+        void this._triggerPermissionsChanged();
     }
 
     /** */

--- a/ext/js/pages/settings/settings-main.js
+++ b/ext/js/pages/settings/settings-main.js
@@ -91,13 +91,13 @@ await Application.main(true, async (application) => {
     await settingsController.prepare();
 
     const persistentStorageController = new PersistentStorageController(application);
-    persistentStorageController.prepare();
+    preparePromises.push(persistentStorageController.prepare());
 
     const storageController = new StorageController(persistentStorageController);
     storageController.prepare();
 
     const dictionaryController = new DictionaryController(settingsController, modalController, statusFooter);
-    dictionaryController.prepare();
+    preparePromises.push(dictionaryController.prepare());
 
     const dictionaryImportController = new DictionaryImportController(settingsController, modalController, statusFooter);
     dictionaryImportController.prepare();
@@ -106,52 +106,52 @@ await Application.main(true, async (application) => {
     preparePromises.push(setupGenericSettingController(genericSettingController));
 
     const audioController = new AudioController(settingsController, modalController);
-    audioController.prepare();
+    preparePromises.push(audioController.prepare());
 
     const profileController = new ProfileController(settingsController, modalController);
-    profileController.prepare();
+    preparePromises.push(profileController.prepare());
 
     const settingsBackup = new BackupController(settingsController, modalController);
-    settingsBackup.prepare();
+    preparePromises.push(settingsBackup.prepare());
 
     const ankiController = new AnkiController(settingsController);
-    ankiController.prepare();
+    preparePromises.push(ankiController.prepare());
 
     const ankiTemplatesController = new AnkiTemplatesController(settingsController, modalController, ankiController);
-    ankiTemplatesController.prepare();
+    preparePromises.push(ankiTemplatesController.prepare());
 
     const popupPreviewController = new PopupPreviewController(settingsController);
     popupPreviewController.prepare();
 
     const scanInputsController = new ScanInputsController(settingsController);
-    scanInputsController.prepare();
+    preparePromises.push(scanInputsController.prepare());
 
     const simpleScanningInputController = new ScanInputsSimpleController(settingsController);
-    simpleScanningInputController.prepare();
+    preparePromises.push(simpleScanningInputController.prepare());
 
     const nestedPopupsController = new NestedPopupsController(settingsController);
-    nestedPopupsController.prepare();
+    preparePromises.push(nestedPopupsController.prepare());
 
     const permissionsToggleController = new PermissionsToggleController(settingsController);
-    permissionsToggleController.prepare();
+    preparePromises.push(permissionsToggleController.prepare());
 
     const secondarySearchDictionaryController = new SecondarySearchDictionaryController(settingsController);
-    secondarySearchDictionaryController.prepare();
+    preparePromises.push(secondarySearchDictionaryController.prepare());
 
     const languagesController = new LanguagesController(settingsController);
-    languagesController.prepare();
+    preparePromises.push(languagesController.prepare());
 
     const translationTextReplacementsController = new TranslationTextReplacementsController(settingsController);
-    translationTextReplacementsController.prepare();
+    preparePromises.push(translationTextReplacementsController.prepare());
 
     const sentenceTerminationCharactersController = new SentenceTerminationCharactersController(settingsController);
-    sentenceTerminationCharactersController.prepare();
+    preparePromises.push(sentenceTerminationCharactersController.prepare());
 
     const keyboardShortcutController = new KeyboardShortcutController(settingsController);
-    keyboardShortcutController.prepare();
+    preparePromises.push(keyboardShortcutController.prepare());
 
     const extensionKeyboardShortcutController = new ExtensionKeyboardShortcutController(settingsController);
-    extensionKeyboardShortcutController.prepare();
+    preparePromises.push(extensionKeyboardShortcutController.prepare());
 
     const popupWindowController = new PopupWindowController(application.api);
     popupWindowController.prepare();
@@ -160,10 +160,10 @@ await Application.main(true, async (application) => {
     mecabController.prepare();
 
     const collapsibleDictionaryController = new CollapsibleDictionaryController(settingsController);
-    collapsibleDictionaryController.prepare();
+    preparePromises.push(collapsibleDictionaryController.prepare());
 
     const sortFrequencyDictionaryController = new SortFrequencyDictionaryController(settingsController);
-    sortFrequencyDictionaryController.prepare();
+    preparePromises.push(sortFrequencyDictionaryController.prepare());
 
     await Promise.all(preparePromises);
 

--- a/ext/js/pages/settings/sort-frequency-dictionary-controller.js
+++ b/ext/js/pages/settings/sort-frequency-dictionary-controller.js
@@ -79,7 +79,7 @@ export class SortFrequencyDictionaryController {
     /** */
     _onSortFrequencyDictionarySelectChange() {
         const {value} = /** @type {HTMLSelectElement} */ (this._sortFrequencyDictionarySelect);
-        this._setSortFrequencyDictionaryValue(value !== '' ? value : null);
+        void this._setSortFrequencyDictionaryValue(value !== '' ? value : null);
     }
 
     /** */
@@ -87,14 +87,14 @@ export class SortFrequencyDictionaryController {
         const {value} = /** @type {HTMLSelectElement} */ (this._sortFrequencyDictionaryOrderSelect);
         const value2 = this._normalizeSortFrequencyDictionaryOrder(value);
         if (value2 === null) { return; }
-        this._setSortFrequencyDictionaryOrderValue(value2);
+        void this._setSortFrequencyDictionaryOrderValue(value2);
     }
 
     /** */
     _onSortFrequencyDictionaryOrderAutoButtonClick() {
         const {value} = /** @type {HTMLSelectElement} */ (this._sortFrequencyDictionarySelect);
         if (value === '') { return; }
-        this._autoUpdateOrder(value);
+        void this._autoUpdateOrder(value);
     }
 
     /**

--- a/ext/js/pages/settings/storage-controller.js
+++ b/ext/js/pages/settings/storage-controller.js
@@ -62,19 +62,19 @@ export class StorageController {
         storageRefreshButton.addEventListener('click', this._onStorageRefreshButtonClick.bind(this), false);
         this._persistentStorageController.application.on('storageChanged', this._onStorageChanged.bind(this));
 
-        this._updateStats();
+        void this._updateStats();
     }
 
     // Private
 
     /** */
     _onStorageRefreshButtonClick() {
-        this._updateStats();
+        void this._updateStats();
     }
 
     /** */
     _onStorageChanged() {
-        this._updateStats();
+        void this._updateStats();
     }
 
     /** */

--- a/ext/js/pages/settings/translation-text-replacements-controller.js
+++ b/ext/js/pages/settings/translation-text-replacements-controller.js
@@ -133,7 +133,7 @@ export class TranslationTextReplacementsController {
 
     /** */
     _onAdd() {
-        this.addGroup();
+        void this.addGroup();
     }
 
     /** */
@@ -242,7 +242,7 @@ class TranslationTextReplacementsEntry {
     _onMenuClose(e) {
         switch (e.detail.action) {
             case 'remove':
-                this._parent.deleteGroup(this._index);
+                void this._parent.deleteGroup(this._index);
                 break;
             case 'showTest':
                 this._setTestVisible(true);

--- a/ext/js/pages/welcome-main.js
+++ b/ext/js/pages/welcome-main.js
@@ -49,6 +49,15 @@ async function setupGenericSettingsController(genericSettingController) {
     await genericSettingController.refresh();
 }
 
+/** */
+async function checkNeedsCustomTemplatesWarning() {
+    const key = 'needsCustomTemplatesWarning';
+    const result = await chrome.storage.session.get({[key]: false});
+    if (!result[key]) { return; }
+    document.documentElement.dataset.warnCustomTemplates = 'true';
+    await chrome.storage.session.remove([key]);
+}
+
 await Application.main(true, async (application) => {
     const documentFocusController = new DocumentFocusController();
     documentFocusController.prepare();
@@ -61,14 +70,8 @@ await Application.main(true, async (application) => {
     const statusFooter = new StatusFooter(statusFooterElement);
     statusFooter.prepare();
 
-    setupEnvironmentInfo(application.api);
-
-    chrome.storage.session.get({needsCustomTemplatesWarning: false}).then((result) => {
-        if (result.needsCustomTemplatesWarning) {
-            document.documentElement.dataset.warnCustomTemplates = 'true';
-            chrome.storage.session.remove(['needsCustomTemplatesWarning']);
-        }
-    });
+    void setupEnvironmentInfo(application.api);
+    void checkNeedsCustomTemplatesWarning();
 
     const preparePromises = [];
 
@@ -79,19 +82,19 @@ await Application.main(true, async (application) => {
     await settingsController.prepare();
 
     const dictionaryController = new DictionaryController(settingsController, modalController, statusFooter);
-    dictionaryController.prepare();
+    preparePromises.push(dictionaryController.prepare());
 
     const dictionaryImportController = new DictionaryImportController(settingsController, modalController, statusFooter);
-    dictionaryImportController.prepare();
+    preparePromises.push(dictionaryImportController.prepare());
 
     const genericSettingController = new GenericSettingController(settingsController);
     preparePromises.push(setupGenericSettingsController(genericSettingController));
 
     const simpleScanningInputController = new ScanInputsSimpleController(settingsController);
-    simpleScanningInputController.prepare();
+    preparePromises.push(simpleScanningInputController.prepare());
 
     const recommendedPermissionsController = new RecommendedPermissionsController(settingsController);
-    recommendedPermissionsController.prepare();
+    preparePromises.push(recommendedPermissionsController.prepare());
 
     await Promise.all(preparePromises);
 

--- a/test/data/html/js/html-test-utilities.js
+++ b/test/data/html/js/html-test-utilities.js
@@ -26,38 +26,38 @@ class HtmlTestUtilities {
      */
     static requestFullscreen(element) {
         if (element.requestFullscreen) {
-            element.requestFullscreen();
+            void element.requestFullscreen();
             // @ts-expect-error - Browser compatibility
         } else if (element.mozRequestFullScreen) {
             // @ts-expect-error - Browser compatibility
-            element.mozRequestFullScreen();
+            void element.mozRequestFullScreen();
             // @ts-expect-error - Browser compatibility
         } else if (element.webkitRequestFullscreen) {
             // @ts-expect-error - Browser compatibility
-            element.webkitRequestFullscreen();
+            void element.webkitRequestFullscreen();
             // @ts-expect-error - Browser compatibility
         } else if (element.msRequestFullscreen) {
             // @ts-expect-error - Browser compatibility
-            element.msRequestFullscreen();
+            void element.msRequestFullscreen();
         }
     }
 
     /** */
     static exitFullscreen() {
         if (document.exitFullscreen) {
-            document.exitFullscreen();
+            void document.exitFullscreen();
             // @ts-expect-error - Browser compatibility
         } else if (document.mozCancelFullScreen) {
             // @ts-expect-error - Browser compatibility
-            document.mozCancelFullScreen();
+            void document.mozCancelFullScreen();
             // @ts-expect-error - Browser compatibility
         } else if (document.webkitExitFullscreen) {
             // @ts-expect-error - Browser compatibility
-            document.webkitExitFullscreen();
+            void document.webkitExitFullscreen();
             // @ts-expect-error - Browser compatibility
         } else if (document.msExitFullscreen) {
             // @ts-expect-error - Browser compatibility
-            document.msExitFullscreen();
+            void document.msExitFullscreen();
         }
     }
 

--- a/test/fixtures/dom-test.js
+++ b/test/fixtures/dom-test.js
@@ -69,7 +69,7 @@ export function createDomTest(htmlFilePath) {
             try {
                 await use(window);
             } finally {
-                environment.teardown(global);
+                await environment.teardown(global);
             }
         }
     });

--- a/test/playwright/integration.spec.js
+++ b/test/playwright/integration.spec.js
@@ -51,7 +51,7 @@ test('anki add', async ({context, page, extensionId}) => {
         resolve = res;
     });
     await context.route(/127.0.0.1:8765\/*/, (route) => {
-        mockAnkiRouteHandler(route);
+        void mockAnkiRouteHandler(route);
         const req = route.request();
         if (req.url().includes('127.0.0.1:8765') && req.postDataJSON().action === 'addNote') {
             /** @type {(value: unknown) => void} */ (resolve)(req.postDataJSON());

--- a/test/playwright/playwright-util.js
+++ b/test/playwright/playwright-util.js
@@ -68,16 +68,16 @@ export const mockModelFieldsToAnkiValues = {
 
 /**
  * @param {import('playwright').Route} route
- * @returns {Promise<void>|undefined}
+ * @returns {Promise<void>}
  */
-export const mockAnkiRouteHandler = (route) => {
+export async function mockAnkiRouteHandler(route) {
     const reqBody = route.request().postDataJSON();
     const respBody = ankiRouteResponses[reqBody.action];
     if (!respBody) {
         return route.abort();
     }
-    route.fulfill(respBody);
-};
+    await route.fulfill(respBody);
+}
 
 /**
  * @param {import('playwright').Page} page

--- a/test/playwright/visual.spec.js
+++ b/test/playwright/visual.spec.js
@@ -22,7 +22,7 @@ import {expect, root, test} from './playwright-util.js';
 test.beforeEach(async ({context}) => {
     // Wait for the on-install welcome.html tab to load, which becomes the foreground tab
     const welcome = await context.waitForEvent('page');
-    welcome.close(); // Close the welcome tab so our main tab becomes the foreground tab -- otherwise, the screenshot can hang
+    await welcome.close(); // Close the welcome tab so our main tab becomes the foreground tab -- otherwise, the screenshot can hang
 });
 
 test('visual', async ({page, extensionId}) => {

--- a/types/ext/settings-modifications.d.ts
+++ b/types/ext/settings-modifications.d.ts
@@ -97,7 +97,10 @@ export type ModificationSpliceResult = unknown[];
 
 export type ModificationPushResult = number;
 
+// There is some redundancy with this type currently due to the `unknown`s used in it.
+// For now, this is fine, but the types could be improved in the future.
 export type ModificationResult = (
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
     ModificationSetResult |
     ModificationDeleteResult |
     // eslint-disable-next-line @typescript-eslint/no-duplicate-type-constituents


### PR DESCRIPTION
This change turns on a few rules:

* `no-octal` - this was inadvertently set to off, no changes were required.
* `no-octal-escape` - this was inadvertently set to off, no changes were required.
* `@typescript-eslint/no-redundant-type-constituents` - enabled this, only had one issue to resolve in a type file.
* `@typescript-eslint/no-floating-promises` - this is the big one, requires either `await` or `void` for `async` functions. This should help prevent issues where sync functions are subsequently changed to async, or just situations where someone might forget. It makes the intent required to be more explicit. Unfortunately, there were about 300 places in the code that needed this to be addressed. Most of which were turned to `void`, which is the existing behaviour, and only a few were changed to `await`.