### PR TITLE
Constructor simplification

### DIFF
--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -120,12 +120,12 @@ export class PopupFactory {
             if (id === null) {
                 id = generateId(16);
             }
-            const popup = new PopupWindow({
-                application: this._application,
+            const popup = new PopupWindow(
+                this._application,
                 id,
                 depth,
-                frameId: currentFrameId
-            });
+                currentFrameId
+            );
             this._popups.set(id, popup);
             return popup;
         } else if (frameId === currentFrameId) {
@@ -133,13 +133,13 @@ export class PopupFactory {
             if (id === null) {
                 id = generateId(16);
             }
-            const popup = new Popup({
-                application: this._application,
+            const popup = new Popup(
+                this._application,
                 id,
                 depth,
-                frameId: currentFrameId,
+                currentFrameId,
                 childrenSupported
-            });
+            );
             if (parent !== null) {
                 if (parent.child !== null) {
                     throw new Error('Parent popup already has a child');
@@ -162,13 +162,13 @@ export class PopupFactory {
                 childrenSupported
             });
             id = info.id;
-            const popup = new PopupProxy({
-                application: this._application,
+            const popup = new PopupProxy(
+                this._application,
                 id,
-                depth: info.depth,
-                frameId: info.frameId,
-                frameOffsetForwarder: useFrameOffsetForwarder ? this._frameOffsetForwarder : null
-            });
+                info.depth,
+                info.frameId,
+                useFrameOffsetForwarder ? this._frameOffsetForwarder : null
+            );
             this._popups.set(id, popup);
             return popup;
         }

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -26,16 +26,13 @@ import {log} from '../core/log.js';
  */
 export class PopupProxy extends EventDispatcher {
     /**
-     * Creates a new instance.
-     * @param {import('popup').PopupProxyConstructorDetails} details Details about how to set up the instance.
+     * @param {import('../application.js').Application} application The main application instance.
+     * @param {string} id The identifier of the popup.
+     * @param {number} depth The depth of the popup.
+     * @param {number} frameId The frameId of the host frame.
+     * @param {?import('../comm/frame-offset-forwarder.js').FrameOffsetForwarder} frameOffsetForwarder A `FrameOffsetForwarder` instance which is used to determine frame positioning.
      */
-    constructor({
-        application,
-        id,
-        depth,
-        frameId,
-        frameOffsetForwarder
-    }) {
+    constructor(application, id, depth, frameId, frameOffsetForwarder) {
         super();
         /** @type {import('../application.js').Application} */
         this._application = application;

--- a/ext/js/app/popup-window.js
+++ b/ext/js/app/popup-window.js
@@ -24,15 +24,12 @@ import {EventDispatcher} from '../core/event-dispatcher.js';
  */
 export class PopupWindow extends EventDispatcher {
     /**
-     * Creates a new instance.
-     * @param {import('popup').PopupWindowConstructorDetails} details Details about how to set up the instance.
+     * @param {import('../application.js').Application} application The main application instance.
+     * @param {string} id The identifier of the popup.
+     * @param {number} depth The depth of the popup.
+     * @param {number} frameId The frameId of the host frame.
      */
-    constructor({
-        application,
-        id,
-        depth,
-        frameId
-    }) {
+    constructor(application, id, depth, frameId) {
         super();
         /** @type {import('../application.js').Application} */
         this._application = application;

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -32,16 +32,13 @@ import {ThemeController} from './theme-controller.js';
  */
 export class Popup extends EventDispatcher {
     /**
-     * Creates a new instance.
-     * @param {import('popup').PopupConstructorDetails} details The details used to construct the new instance.
+     * @param {import('../application.js').Application} application The main application instance.
+     * @param {string} id The identifier of the popup.
+     * @param {number} depth The depth of the popup.
+     * @param {number} frameId The frameId of the host frame.
+     * @param {boolean} childrenSupported Whether or not the popup is able to show child popups.
      */
-    constructor({
-        application,
-        id,
-        depth,
-        frameId,
-        childrenSupported
-    }) {
+    constructor(application, id, depth, frameId, childrenSupported) {
         super();
         /** @type {import('../application.js').Application} */
         this._application = application;

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -102,9 +102,7 @@ export class Backend {
         /** @type {RequestBuilder} */
         this._requestBuilder = new RequestBuilder();
         /** @type {AudioDownloader} */
-        this._audioDownloader = new AudioDownloader({
-            requestBuilder: this._requestBuilder
-        });
+        this._audioDownloader = new AudioDownloader(this._requestBuilder);
         /** @type {OptionsUtil} */
         this._optionsUtil = new OptionsUtil();
         /** @type {AccessibilityController} */

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -70,12 +70,12 @@ export class Backend {
             /** @type {Translator|TranslatorProxy} */
             this._translator = new Translator(this._dictionaryDatabase);
             /** @type {ClipboardReader|ClipboardReaderProxy} */
-            this._clipboardReader = new ClipboardReader({
+            this._clipboardReader = new ClipboardReader(
                 // eslint-disable-next-line no-undef
-                document: (typeof document === 'object' && document !== null ? document : null),
-                pasteTargetSelector: '#clipboard-paste-target',
-                richContentPasteTargetSelector: '#clipboard-rich-content-paste-target'
-            });
+                (typeof document === 'object' && document !== null ? document : null),
+                '#clipboard-paste-target',
+                '#clipboard-rich-content-paste-target'
+            );
         } else {
             /** @type {?OffscreenProxy} */
             this._offscreen = new OffscreenProxy(webExtension);

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -88,9 +88,7 @@ export class Backend {
         }
 
         /** @type {ClipboardMonitor} */
-        this._clipboardMonitor = new ClipboardMonitor({
-            clipboardReader: this._clipboardReader
-        });
+        this._clipboardMonitor = new ClipboardMonitor(this._clipboardReader);
         /** @type {?import('settings').Options} */
         this._options = null;
         /** @type {import('../data/json-schema.js').JsonSchema[]} */

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -68,9 +68,7 @@ export class Backend {
             /** @type {DictionaryDatabase|DictionaryDatabaseProxy} */
             this._dictionaryDatabase = new DictionaryDatabase();
             /** @type {Translator|TranslatorProxy} */
-            this._translator = new Translator({
-                database: this._dictionaryDatabase
-            });
+            this._translator = new Translator(this._dictionaryDatabase);
             /** @type {ClipboardReader|ClipboardReaderProxy} */
             this._clipboardReader = new ClipboardReader({
                 // eslint-disable-next-line no-undef

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -34,9 +34,7 @@ export class Offscreen {
         /** @type {DictionaryDatabase} */
         this._dictionaryDatabase = new DictionaryDatabase();
         /** @type {Translator} */
-        this._translator = new Translator({
-            database: this._dictionaryDatabase
-        });
+        this._translator = new Translator(this._dictionaryDatabase);
         /** @type {ClipboardReader} */
         this._clipboardReader = new ClipboardReader({
             document: (typeof document === 'object' && document !== null ? document : null),

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -36,11 +36,11 @@ export class Offscreen {
         /** @type {Translator} */
         this._translator = new Translator(this._dictionaryDatabase);
         /** @type {ClipboardReader} */
-        this._clipboardReader = new ClipboardReader({
-            document: (typeof document === 'object' && document !== null ? document : null),
-            pasteTargetSelector: '#clipboard-paste-target',
-            richContentPasteTargetSelector: '#clipboard-rich-content-paste-target'
-        });
+        this._clipboardReader = new ClipboardReader(
+            (typeof document === 'object' && document !== null ? document : null),
+            '#clipboard-paste-target',
+            '#clipboard-rich-content-paste-target'
+        );
 
 
         /* eslint-disable @stylistic/no-multi-spaces */

--- a/ext/js/comm/clipboard-monitor.js
+++ b/ext/js/comm/clipboard-monitor.js
@@ -24,9 +24,9 @@ import {isStringPartiallyJapanese} from '../language/ja/japanese.js';
  */
 export class ClipboardMonitor extends EventDispatcher {
     /**
-     * @param {{clipboardReader: import('clipboard-monitor').ClipboardReaderLike}} details
+     * @param {import('clipboard-monitor').ClipboardReaderLike} clipboardReader
      */
-    constructor({clipboardReader}) {
+    constructor(clipboardReader) {
         super();
         /** @type {import('clipboard-monitor').ClipboardReaderLike} */
         this._clipboardReader = clipboardReader;

--- a/ext/js/comm/clipboard-reader.js
+++ b/ext/js/comm/clipboard-reader.js
@@ -23,10 +23,11 @@ import {getFileExtensionFromImageMediaType} from '../media/media-util.js';
  */
 export class ClipboardReader {
     /**
-     * Creates a new instances of a clipboard reader.
-     * @param {{document: ?Document, pasteTargetSelector: ?string, richContentPasteTargetSelector: ?string}} details Details about how to set up the instance.
+     * @param {?Document} document
+     * @param {?string} pasteTargetSelector
+     * @param {?string} richContentPasteTargetSelector
      */
-    constructor({document = null, pasteTargetSelector = null, richContentPasteTargetSelector = null}) {
+    constructor(document, pasteTargetSelector, richContentPasteTargetSelector) {
         /** @type {?Document} */
         this._document = document;
         /** @type {?import('environment').Browser} */

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -26,9 +26,10 @@ import {StructuredContentGenerator} from './sandbox/structured-content-generator
 
 export class DisplayGenerator {
     /**
-     * @param {import('display').DisplayGeneratorConstructorDetails} details
+     * @param {import('./display-content-manager.js').DisplayContentManager} contentManager
+     * @param {?import('../input/hotkey-help-controller.js').HotkeyHelpController} hotkeyHelpController
      */
-    constructor({contentManager, hotkeyHelpController = null}) {
+    constructor(contentManager, hotkeyHelpController) {
         /** @type {import('./display-content-manager.js').DisplayContentManager} */
         this._contentManager = contentManager;
         /** @type {?import('../input/hotkey-help-controller.js').HotkeyHelpController} */

--- a/ext/js/display/display-history.js
+++ b/ext/js/display/display-history.js
@@ -24,9 +24,10 @@ import {generateId, isObject} from '../core/utilities.js';
  */
 export class DisplayHistory extends EventDispatcher {
     /**
-     * @param {{clearable?: boolean, useBrowserHistory?: boolean}} details
+     * @param {boolean} clearable
+     * @param {boolean} useBrowserHistory
      */
-    constructor({clearable = true, useBrowserHistory = false}) {
+    constructor(clearable, useBrowserHistory) {
         super();
         /** @type {boolean} */
         this._clearable = clearable;

--- a/ext/js/display/display-profile-selection.js
+++ b/ext/js/display/display-profile-selection.js
@@ -35,10 +35,7 @@ export class DisplayProfileSelection {
         /** @type {HTMLElement} */
         const profilePanelElement = querySelectorNotNull(document, '#profile-panel');
         /** @type {PanelElement} */
-        this._profilePanel = new PanelElement({
-            node: profilePanelElement,
-            closingAnimationDuration: 375 // Milliseconds; includes buffer
-        });
+        this._profilePanel = new PanelElement(profilePanelElement, 375); // Milliseconds; includes buffer
         /** @type {boolean} */
         this._profileListNeedsUpdate = false;
         /** @type {EventListenerCollection} */

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1705,8 +1705,7 @@ export class Display extends EventDispatcher {
         const popupFactory = new PopupFactory(this._application);
         popupFactory.prepare();
 
-        /** @type {import('frontend').ConstructorDetails} */
-        const setupNestedPopupsOptions = {
+        const frontend = new Frontend({
             application: this._application,
             useProxyPopup,
             parentPopupId,
@@ -1716,10 +1715,9 @@ export class Display extends EventDispatcher {
             pageType: this._pageType,
             allowRootFramePopupProxy: true,
             childrenSupported: this._childrenSupported,
-            hotkeyHandler: this._hotkeyHandler
-        };
-
-        const frontend = new Frontend(setupNestedPopupsOptions);
+            hotkeyHandler: this._hotkeyHandler,
+            canUseWindowPopup: true
+        });
         this._frontend = frontend;
         await frontend.prepare();
     }

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -83,10 +83,7 @@ export class Display extends EventDispatcher {
         /** @type {HotkeyHelpController} */
         this._hotkeyHelpController = new HotkeyHelpController();
         /** @type {DisplayGenerator} */
-        this._displayGenerator = new DisplayGenerator({
-            contentManager: this._contentManager,
-            hotkeyHelpController: this._hotkeyHelpController
-        });
+        this._displayGenerator = new DisplayGenerator(this._contentManager, this._hotkeyHelpController);
         /** @type {import('display').DirectApiMap} */
         this._directApiMap = new Map();
         /** @type {import('api-map').ApiMap<import('display').WindowApiSurface>} */ // import('display').WindowApiMap

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -126,11 +126,7 @@ export class Display extends EventDispatcher {
         /** @type {TextSourceGenerator} */
         this._textSourceGenerator = new TextSourceGenerator();
         /** @type {QueryParser} */
-        this._queryParser = new QueryParser({
-            api: application.api,
-            getSearchContext: this._getSearchContext.bind(this),
-            textSourceGenerator: this._textSourceGenerator
-        });
+        this._queryParser = new QueryParser(application.api, this._textSourceGenerator, this._getSearchContext.bind(this));
         /** @type {HTMLElement} */
         this._contentScrollElement = querySelectorNotNull(document, '#content-scroll');
         /** @type {HTMLElement} */

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -89,7 +89,7 @@ export class Display extends EventDispatcher {
         /** @type {import('api-map').ApiMap<import('display').WindowApiSurface>} */ // import('display').WindowApiMap
         this._windowApiMap = new Map();
         /** @type {DisplayHistory} */
-        this._history = new DisplayHistory({clearable: true, useBrowserHistory: false});
+        this._history = new DisplayHistory(true, false);
         /** @type {boolean} */
         this._historyChangeIgnore = false;
         /** @type {boolean} */

--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -27,9 +27,11 @@ import {TextScanner} from '../language/text-scanner.js';
  */
 export class QueryParser extends EventDispatcher {
     /**
-     * @param {import('display').QueryParserConstructorDetails} details
+     * @param {import('../comm/api.js').API} api
+     * @param {import('../dom/text-source-generator').TextSourceGenerator} textSourceGenerator
+     * @param {import('display').GetSearchContextCallback} getSearchContext
      */
-    constructor({api, getSearchContext, textSourceGenerator}) {
+    constructor(api, textSourceGenerator, getSearchContext) {
         super();
         /** @type {import('../comm/api.js').API} */
         this._api = api;

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -63,12 +63,12 @@ export class SearchDisplayController {
         this._introAnimationTimer = null;
         /** @type {boolean} */
         this._clipboardMonitorEnabled = false;
+        /** @type {import('clipboard-monitor').ClipboardReaderLike} */
+        const clipboardReader = {
+            getText: this._display.application.api.clipboardGet.bind(this._display.application.api)
+        };
         /** @type {ClipboardMonitor} */
-        this._clipboardMonitor = new ClipboardMonitor({
-            clipboardReader: {
-                getText: this._display.application.api.clipboardGet.bind(this._display.application.api)
-            }
-        });
+        this._clipboardMonitor = new ClipboardMonitor(clipboardReader);
         /** @type {import('application').ApiMap} */
         this._apiMap = createApiMap([
             ['searchDisplayControllerGetMode', this._onMessageGetMode.bind(this)],

--- a/ext/js/dom/dom-data-binder.js
+++ b/ext/js/dom/dom-data-binder.js
@@ -50,14 +50,14 @@ export class DOMDataBinder {
         /** @type {TaskAccumulator<import('dom-data-binder').ElementObserver<T>, import('dom-data-binder').AssignTaskValue>} */
         this._assignTasks = new TaskAccumulator(this._onBulkAssign.bind(this));
         /** @type {SelectorObserver<import('dom-data-binder').ElementObserver<T>>} */
-        this._selectorObserver = /** @type {SelectorObserver<import('dom-data-binder').ElementObserver<T>>} */ (new SelectorObserver({
+        this._selectorObserver = new SelectorObserver({
             selector,
             ignoreSelector: null,
             onAdded: this._createObserver.bind(this),
             onRemoved: this._removeObserver.bind(this),
             onChildrenUpdated: this._onObserverChildrenUpdated.bind(this),
             isStale: this._isObserverStale.bind(this)
-        }));
+        });
     }
 
     /**

--- a/ext/js/dom/dom-data-binder.js
+++ b/ext/js/dom/dom-data-binder.js
@@ -25,9 +25,14 @@ import {SelectorObserver} from './selector-observer.js';
  */
 export class DOMDataBinder {
     /**
-     * @param {import('dom-data-binder').ConstructorDetails<T>} details
+     * @param {string} selector
+     * @param {import('dom-data-binder').CreateElementMetadataCallback<T>} createElementMetadata
+     * @param {import('dom-data-binder').CompareElementMetadataCallback<T>} compareElementMetadata
+     * @param {import('dom-data-binder').GetValuesCallback<T>} getValues
+     * @param {import('dom-data-binder').SetValuesCallback<T>} setValues
+     * @param {import('dom-data-binder').OnErrorCallback<T>|null} [onError]
      */
-    constructor({selector, createElementMetadata, compareElementMetadata, getValues, setValues, onError = null}) {
+    constructor(selector, createElementMetadata, compareElementMetadata, getValues, setValues, onError = null) {
         /** @type {string} */
         this._selector = selector;
         /** @type {import('dom-data-binder').CreateElementMetadataCallback<T>} */

--- a/ext/js/dom/panel-element.js
+++ b/ext/js/dom/panel-element.js
@@ -23,9 +23,10 @@ import {EventDispatcher} from '../core/event-dispatcher.js';
  */
 export class PanelElement extends EventDispatcher {
     /**
-     * @param {import('panel-element').ConstructorDetails} details
+     * @param {HTMLElement} node
+     * @param {number} closingAnimationDuration
      */
-    constructor({node, closingAnimationDuration}) {
+    constructor(node, closingAnimationDuration) {
         super();
         /** @type {HTMLElement} */
         this._node = node;

--- a/ext/js/dom/selector-observer.js
+++ b/ext/js/dom/selector-observer.js
@@ -25,7 +25,14 @@ export class SelectorObserver {
      * Creates a new instance.
      * @param {import('selector-observer').ConstructorDetails<T>} details The configuration for the object.
      */
-    constructor({selector, ignoreSelector = null, onAdded = null, onRemoved = null, onChildrenUpdated = null, isStale = null}) {
+    constructor({
+        selector,
+        ignoreSelector = null,
+        onAdded = null,
+        onRemoved = null,
+        onChildrenUpdated = null,
+        isStale = null
+    }) {
         /** @type {string} */
         this._selector = selector;
         /** @type {?string} */

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -27,10 +27,9 @@ import {getAllLanguageTextPreprocessors} from './languages.js';
  */
 export class Translator {
     /**
-     * Creates a new Translator instance.
-     * @param {import('translator').ConstructorDetails} details The details for the class.
+     * @param {import('../dictionary/dictionary-database.js').DictionaryDatabase} database
      */
-    constructor({database}) {
+    constructor(database) {
         /** @type {import('../dictionary/dictionary-database.js').DictionaryDatabase} */
         this._database = database;
         /** @type {LanguageTransformer} */

--- a/ext/js/media/audio-downloader.js
+++ b/ext/js/media/audio-downloader.js
@@ -27,9 +27,9 @@ import {isStringEntirelyKana} from '../language/ja/japanese.js';
 
 export class AudioDownloader {
     /**
-     * @param {{requestBuilder: RequestBuilder}} details
+     * @param {RequestBuilder} requestBuilder
      */
-    constructor({requestBuilder}) {
+    constructor(requestBuilder) {
         /** @type {RequestBuilder} */
         this._requestBuilder = requestBuilder;
         /** @type {?JsonSchema} */

--- a/ext/js/pages/settings/generic-setting-controller.js
+++ b/ext/js/pages/settings/generic-setting-controller.js
@@ -31,13 +31,13 @@ export class GenericSettingController {
         /** @type {import('settings-modifications').OptionsScopeType} */
         this._defaultScope = 'profile';
         /** @type {DOMDataBinder<import('generic-setting-controller').ElementMetadata>} */
-        this._dataBinder = new DOMDataBinder({
-            selector: '[data-setting]',
-            createElementMetadata: this._createElementMetadata.bind(this),
-            compareElementMetadata: this._compareElementMetadata.bind(this),
-            getValues: this._getValues.bind(this),
-            setValues: this._setValues.bind(this)
-        });
+        this._dataBinder = new DOMDataBinder(
+            '[data-setting]',
+            this._createElementMetadata.bind(this),
+            this._compareElementMetadata.bind(this),
+            this._getValues.bind(this),
+            this._setValues.bind(this)
+        );
         /** @type {Map<import('generic-setting-controller').TransformType, import('generic-setting-controller').TransformFunction>} */
         this._transforms = new Map(/** @type {[key: import('generic-setting-controller').TransformType, value: import('generic-setting-controller').TransformFunction][]} */ ([
             ['setAttribute', this._setAttribute.bind(this)],

--- a/ext/js/pages/settings/modal.js
+++ b/ext/js/pages/settings/modal.js
@@ -23,10 +23,7 @@ export class Modal extends PanelElement {
      * @param {HTMLElement} node
      */
     constructor(node) {
-        super({
-            node,
-            closingAnimationDuration: 375 // Milliseconds; includes buffer
-        });
+        super(node, 375); // Milliseconds; includes buffer
         /** @type {?Element} */
         this._contentNode = null;
         /** @type {boolean} */

--- a/ext/js/pages/settings/status-footer.js
+++ b/ext/js/pages/settings/status-footer.js
@@ -24,10 +24,7 @@ export class StatusFooter extends PanelElement {
      * @param {HTMLElement} node
      */
     constructor(node) {
-        super({
-            node,
-            closingAnimationDuration: 375 // Milliseconds; includes buffer
-        });
+        super(node, 375); // Milliseconds; includes buffer
         /** @type {HTMLElement} */
         this._body = querySelectorNotNull(node, '.status-footer');
     }

--- a/types/ext/display.d.ts
+++ b/types/ext/display.d.ts
@@ -17,8 +17,6 @@
 
 import type {DisplayContentManager} from '../../ext/js/display/display-content-manager';
 import type {HotkeyHelpController} from '../../ext/js/input/hotkey-help-controller';
-import type {TextSourceGenerator} from '../../ext/js/dom/text-source-generator';
-import type {API} from '../../ext/js/comm/api';
 import type * as Dictionary from './dictionary';
 import type * as Extension from './extension';
 import type * as Settings from './settings';
@@ -126,12 +124,6 @@ export type HistoryContent = {
 export type SearchMode = null | 'popup' | 'action-popup';
 
 export type GetSearchContextCallback = TextScannerTypes.GetSearchContextCallbackSync;
-
-export type QueryParserConstructorDetails = {
-    api: API;
-    getSearchContext: GetSearchContextCallback;
-    textSourceGenerator: TextSourceGenerator;
-};
 
 export type QueryParserOptions = {
     selectedParser: string | null;

--- a/types/ext/display.d.ts
+++ b/types/ext/display.d.ts
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import type {DisplayContentManager} from '../../ext/js/display/display-content-manager';
-import type {HotkeyHelpController} from '../../ext/js/input/hotkey-help-controller';
 import type * as Dictionary from './dictionary';
 import type * as Extension from './extension';
 import type * as Settings from './settings';
@@ -161,11 +159,6 @@ export type Events = {
 };
 
 export type EventArgument<TName extends EventNames<Events>> = BaseEventArgument<Events, TName>;
-
-export type DisplayGeneratorConstructorDetails = {
-    contentManager: DisplayContentManager;
-    hotkeyHelpController?: HotkeyHelpController | null;
-};
 
 // Direct API
 

--- a/types/ext/dom-data-binder.d.ts
+++ b/types/ext/dom-data-binder.d.ts
@@ -38,15 +38,6 @@ export type SetValuesDetails<T = unknown> = {
 
 export type OnErrorCallback<T = unknown> = (error: Error, stale: boolean, element: Element, metadata: T) => void;
 
-export type ConstructorDetails<T = unknown> = {
-    selector: string;
-    createElementMetadata: CreateElementMetadataCallback<T>;
-    compareElementMetadata: CompareElementMetadataCallback<T>;
-    getValues: GetValuesCallback<T>;
-    setValues: SetValuesCallback<T>;
-    onError?: OnErrorCallback<T> | null;
-};
-
 export type ElementObserver<T = unknown> = {
     element: Element;
     type: NormalizedElementType;

--- a/types/ext/frontend.d.ts
+++ b/types/ext/frontend.d.ts
@@ -36,11 +36,11 @@ export type ConstructorDetails = {
     /** Whether or not proxy popups should be used. */
     useProxyPopup: boolean;
     /** Whether or not window popups can be used. */
-    canUseWindowPopup?: boolean;
+    canUseWindowPopup: boolean;
     /** Whether or not popups can be hosted in the root frame. */
     allowRootFramePopupProxy: boolean;
     /** Whether popups can create child popups or not. */
-    childrenSupported?: boolean;
+    childrenSupported: boolean;
     /** A HotkeyHandler instance. */
     hotkeyHandler: HotkeyHandler;
 };

--- a/types/ext/panel-element.d.ts
+++ b/types/ext/panel-element.d.ts
@@ -27,8 +27,3 @@ export type Events = {
 };
 
 export type EventArgument<TName extends EventNames<Events>> = BaseEventArgument<Events, TName>;
-
-export type ConstructorDetails = {
-    node: HTMLElement;
-    closingAnimationDuration: number;
-};

--- a/types/ext/popup.d.ts
+++ b/types/ext/popup.d.ts
@@ -18,8 +18,6 @@
 import type {Popup} from '../../ext/js/app/popup';
 import type {PopupProxy} from '../../ext/js/app/popup-proxy';
 import type {PopupWindow} from '../../ext/js/app/popup-window';
-import type {FrameOffsetForwarder} from '../../ext/js/comm/frame-offset-forwarder';
-import type {Application} from '../../ext/js/application';
 import type * as DocumentUtil from './document-util';
 import type * as Settings from './settings';
 import type {EventNames, EventArgument as BaseEventArgument} from './core';
@@ -90,43 +88,6 @@ export type ValidSize = {
     width: number;
     height: number;
     valid: boolean;
-};
-
-export type PopupConstructorDetails = {
-    /** The main application instance. */
-    application: Application;
-    /** The ID of the popup. */
-    id: string;
-    /** The depth of the popup. */
-    depth: number;
-    /** The ID of the host frame. */
-    frameId: number;
-    /** Whether or not the popup is able to show child popups. */
-    childrenSupported: boolean;
-};
-
-export type PopupWindowConstructorDetails = {
-    /** The main application instance. */
-    application: Application;
-    /** The ID of the popup. */
-    id: string;
-    /** The depth of the popup. */
-    depth: number;
-    /** The ID of the host frame. */
-    frameId: number;
-};
-
-export type PopupProxyConstructorDetails = {
-    /** The main application instance. */
-    application: Application;
-    /** The ID of the popup. */
-    id: string;
-    /** The depth of the popup. */
-    depth: number;
-    /** The ID of the host frame. */
-    frameId: number;
-    /** A `FrameOffsetForwarder` instance which is used to determine frame positioning. */
-    frameOffsetForwarder: FrameOffsetForwarder | null;
 };
 
 export type Events = {

--- a/types/ext/translator.d.ts
+++ b/types/ext/translator.d.ts
@@ -15,14 +15,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import type {DictionaryDatabase} from '../../ext/js/dictionary/dictionary-database';
 import type * as Dictionary from './dictionary';
 import type * as DictionaryDatabaseTypes from './dictionary-database';
-
-export type ConstructorDetails = {
-    /** An instance of DictionaryDatabase. */
-    database: DictionaryDatabase;
-};
 
 /**
  * Information about how popup content should be shown, specifically related to the outer popup frame.


### PR DESCRIPTION
This change simplifies a lot of the constructors to not take an unnecessary details object. Using a details object is generally only really helpful when there are either 1) lots of parameters and/or 2) several are optional. Otherwise, it is easier to just pass the parameters directly. This should also help reduce the need to go back and forth between multiple files when adjusting one of these constructors, i.e. the `.js` and the `.d.ts`.