### PR TITLE
Mark string and text glossary content as safe to avoid broken <br>

### DIFF
--- a/ext/js/templates/sandbox/anki-template-renderer.js
+++ b/ext/js/templates/sandbox/anki-template-renderer.js
@@ -665,12 +665,12 @@ export class AnkiTemplateRenderer {
         const [dictionary, content] = /** @type {[dictionary: string, content: import('dictionary-data').TermGlossaryContent]} */ (args);
         /** @type {import('anki-templates').NoteData} */
         const data = options.data.root;
-        if (typeof content === 'string') { return this._stringToMultiLineHtml(content); }
+        if (typeof content === 'string') { return this._safeString(this._stringToMultiLineHtml(content)); }
         if (!(typeof content === 'object' && content !== null)) { return ''; }
         switch (content.type) {
             case 'image': return this._formatGlossaryImage(content, dictionary, data);
             case 'structured-content': return this._formatStructuredContent(content, dictionary, data);
-            case 'text': return this._stringToMultiLineHtml(content.text);
+            case 'text': return this._safeString(this._stringToMultiLineHtml(content.text));
         }
         return '';
     }


### PR DESCRIPTION
Missed this in #722

_safeString only needs to be added to plaintext dictionary entries due to structured content and image already having it applied by _getHtml.