### PR TITLE
Fix sentence-furigana template

### DIFF
--- a/ext/data/templates/anki-field-templates-upgrade-v27.handlebars
+++ b/ext/data/templates/anki-field-templates-upgrade-v27.handlebars
@@ -1,0 +1,21 @@
+{{<<<<<<<}}
+{{#*inline "sentence-furigana"}}
+    {{~#if definition.cloze~}}
+        {{~#if (hasMedia "textFurigana" definition.cloze.sentence)~}}
+            {{getMedia "textFurigana" definition.cloze.sentence escape=false}}
+        {{~else~}}
+            {{definition.cloze.sentence}}
+        {{~/if~}}
+    {{~/if~}}
+{{/inline}}
+{{=======}}
+{{#*inline "sentence-furigana"}}
+    {{~#if definition.cloze~}}
+        {{~#if (hasMedia "textFurigana" definition.cloze.sentence)~}}
+            {{{getMedia "textFurigana" definition.cloze.sentence escape=false}}}
+        {{~else~}}
+            {{{definition.cloze.sentence}}}
+        {{~/if~}}
+    {{~/if~}}
+{{/inline}}
+{{>>>>>>>}}

--- a/ext/data/templates/default-anki-field-templates.handlebars
+++ b/ext/data/templates/default-anki-field-templates.handlebars
@@ -395,9 +395,9 @@
 {{#*inline "sentence-furigana"}}
     {{~#if definition.cloze~}}
         {{~#if (hasMedia "textFurigana" definition.cloze.sentence)~}}
-            {{getMedia "textFurigana" definition.cloze.sentence escape=false}}
+            {{{getMedia "textFurigana" definition.cloze.sentence escape=false}}}
         {{~else~}}
-            {{definition.cloze.sentence}}
+            {{{definition.cloze.sentence}}}
         {{~/if~}}
     {{~/if~}}
 {{/inline}}

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -532,7 +532,8 @@ export class OptionsUtil {
             this._updateVersion23,
             this._updateVersion24,
             this._updateVersion25,
-            this._updateVersion26
+            this._updateVersion26,
+            this._updateVersion27
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1156,9 +1157,11 @@ export class OptionsUtil {
      */
     async _updateVersion25(options) {
         for (const profile of options.profiles) {
-            for (const hotkey of profile.options.inputs.hotkeys) {
-                if (hotkey.action === 'viewNote') {
-                    hotkey.action = 'viewNotes';
+            if ('inputs' in profile.options && 'hotkeys' in profile.options.inputs) {
+                for (const hotkey of profile.options.inputs.hotkeys) {
+                    if (hotkey.action === 'viewNote') {
+                        hotkey.action = 'viewNotes';
+                    }
                 }
             }
         }
@@ -1186,6 +1189,14 @@ export class OptionsUtil {
                 delete profileOptions.translation[preprocessor];
             }
         }
+    }
+
+    /**
+     * - Updated handlebars.
+     * @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion27(options) {
+        await this._applyAnkiFieldTemplatesPatch(options, '/data/templates/anki-field-templates-upgrade-v27.handlebars');
     }
 
 

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -599,7 +599,7 @@ function createOptionsUpdatedTestData1() {
             }
         ],
         profileCurrent: 0,
-        version: 26,
+        version: 27,
         global: {
             database: {
                 prefixWildcardsSupported: false
@@ -1690,6 +1690,33 @@ describe('OptionsUtil', () => {
 {{~#*inline "pitch-accent-categories"~}}
     {{~#each (pitchCategories @root)~}}{{~.~}}{{~#unless @last~}},{{~/unless~}}{{~/each~}}
 {{~/inline~}}`.trimStart()
+            },
+            {
+                oldVersion: 24,
+                newVersion: 27,
+                old: `
+{{#*inline "sentence-furigana"}}
+    {{~#if definition.cloze~}}
+        {{~#if (hasMedia "textFurigana" definition.cloze.sentence)~}}
+            {{getMedia "textFurigana" definition.cloze.sentence escape=false}}
+        {{~else~}}
+            {{definition.cloze.sentence}}
+        {{~/if~}}
+    {{~/if~}}
+{{/inline}}
+`.trimStart(),
+
+                expected: `
+{{#*inline "sentence-furigana"}}
+    {{~#if definition.cloze~}}
+        {{~#if (hasMedia "textFurigana" definition.cloze.sentence)~}}
+            {{{getMedia "textFurigana" definition.cloze.sentence escape=false}}}
+        {{~else~}}
+            {{{definition.cloze.sentence}}}
+        {{~/if~}}
+    {{~/if~}}
+{{/inline}}
+`.trimStart()
             }
         ];
 


### PR DESCRIPTION
The output of sentence-furigana needs to not be escaped. With the new handlebars changes this requires using `{{{ }}}` syntax. https://handlebarsjs.com/guide/expressions.html#html-escaping

As far as I can tell this is the only handlebar with this issue but I haven't thoroughly tested every single one.

I also had to make a small change to the version 25 update or `npm run "test:unit:options"` test would fail due to one out of three profiles having `profile.options.input` set to undefined. (does anyone run this test when making changes?)
