### PR TITLE
Fix entry selection arrow padding in search

### DIFF
--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -87,7 +87,7 @@ h1 {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     white-space: pre-wrap;
     z-index: 1;
-    margin: 0;
+    margin: 0 calc(-1 * var(--main-content-horizontal-padding));
 }
 .search-button {
     flex: 0 0 auto;

--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -18,6 +18,7 @@
 
 /* Variables */
 :root {
+    --main-content-horizontal-padding: 0.72em;
     --entry-horizontal-padding: 0;
 
     --padding: calc(10em / var(--font-size-no-units));
@@ -131,7 +132,7 @@ h1 {
 .search-options {
     display: flex;
     flex-flow: row wrap;
-    margin: 0.5em 0;
+    margin: 0.5em calc(-1 * var(--main-content-horizontal-padding));
     align-items: center;
 }
 .search-option {


### PR DESCRIPTION
Fixes #753

This appears to have been changed in #705 to align the search options and search textbox but did not take into account the selection arrow. I've fixed the padding on the arrow while keeping the search options and search textbox aligned.