### PR TITLE
preserve whitespace in cloze-prefix and cloze-suffix

### DIFF
--- a/ext/data/templates/anki-field-templates-upgrade-v27.handlebars
+++ b/ext/data/templates/anki-field-templates-upgrade-v27.handlebars
@@ -1,0 +1,9 @@
+{{<<<<<<<}}
+{{#*inline "url"}}
+    <a href="{{definition.url}}">{{definition.url}}</a>
+{{/inline}}
+{{=======}}
+{{~#*inline "url"~}}
+    <a href="{{definition.url}}">{{definition.url}}</a>
+{{~/inline~}}
+{{>>>>>>>}}

--- a/ext/data/templates/default-anki-field-templates.handlebars
+++ b/ext/data/templates/default-anki-field-templates.handlebars
@@ -172,9 +172,9 @@
     {{~#mergeTags definition group merge}}{{this}}{{/mergeTags~}}
 {{/inline}}
 
-{{#*inline "url"}}
+{{~#*inline "url"~}}
     <a href="{{definition.url}}">{{definition.url}}</a>
-{{/inline}}
+{{~/inline~}}
 
 {{#*inline "screenshot"}}
     {{~#if (hasMedia "screenshot")~}}

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -532,7 +532,8 @@ export class OptionsUtil {
             this._updateVersion23,
             this._updateVersion24,
             this._updateVersion25,
-            this._updateVersion26
+            this._updateVersion26,
+            this._updateVersion27
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1188,6 +1189,13 @@ export class OptionsUtil {
         }
     }
 
+    /**
+     *  - Remove whitespace in URL handlebars template.
+     *  @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion27(options) {
+        await this._applyAnkiFieldTemplatesPatch(options, '/data/templates/anki-field-templates-upgrade-v27.handlebars');
+    }
 
     /**
      * @param {string} url

--- a/ext/js/templates/sandbox/template-renderer.js
+++ b/ext/js/templates/sandbox/template-renderer.js
@@ -140,7 +140,7 @@ export class TemplateRenderer {
         let additions2;
         try {
             additions1 = (typeof renderSetup === 'function' ? renderSetup(data) : null);
-            result = instance(data).trim();
+            result = instance(data).replace(/^\n+|\n+$/g, '');
         } finally {
             additions2 = (typeof renderCleanup === 'function' ? renderCleanup(data) : null);
         }

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -599,7 +599,7 @@ function createOptionsUpdatedTestData1() {
             }
         ],
         profileCurrent: 0,
-        version: 26,
+        version: 27,
         global: {
             database: {
                 prefixWildcardsSupported: false


### PR DESCRIPTION
Fixes #744 
Basically, it seems the handlebars `~` removes whitespace but not newlines. Instead of trimming the string outputted by handlebars this just removes the newlines. 