### PR TITLE
Ci updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
 
+      - name: Run unit tests (options)
+        run: npm run test:unit:options
+
   test-build:
     name: Test Build
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "bench": "vitest bench",
         "build": "node ./dev/bin/build.js",
         "build:libs": "node ./dev/bin/build-libs.js",
-        "test": "npm run test:js && npm run test:ts && npm run test:css && npm run test:html && npm run test:unit && npm run test:json && npm run test:md && npm run test:build",
+        "test": "npm run test:js && npm run test:ts && npm run test:css && npm run test:html && npm run test:unit && npm run test:unit:options && npm run test:json && npm run test:md && npm run test:build",
         "test:fast": "npm run test:js && npm run test:ts && npm run test:unit && npm run test:json:format",
         "test:static-analysis": "npm run test:js && npm run test:ts && npm run test:css && npm run test:html && npm run test:json && npm run test:md",
         "test:js": "npx eslint . --ignore-pattern **/*.json",

--- a/test/data/vitest.options.config.json
+++ b/test/data/vitest.options.config.json
@@ -1,7 +1,7 @@
 {
     "test": {
         "include": [
-            "../**/options-util.test.js"
+            "test/options-util.test.js"
         ]
     }
 }

--- a/test/data/vitest.write.config.json
+++ b/test/data/vitest.write.config.json
@@ -1,7 +1,7 @@
 {
     "test": {
         "include": [
-            "../**/*.write.js"
+            "test/*.write.js"
         ]
     }
 }

--- a/test/dictionary-data.write.js
+++ b/test/dictionary-data.write.js
@@ -28,7 +28,7 @@ import {createFindKanjiOptions, createFindTermsOptions} from './utilities/transl
  * @param {unknown} content
  */
 function writeJson(fileName, content) {
-    writeFileSync(fileName, JSON.stringify(content, null, 2));
+    writeFileSync(fileName, JSON.stringify(content, null, 2) + '\n');
 }
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Resolves #https://github.com/themoeway/yomitan/pull/733#issuecomment-1974770356.

Fixes an issue with the test data writing where it was missing an extra newline.

The standalone vitest config files were updated because it seems that the previous wildcard was being used relative to the root directory. So running `npm run test:unit:options` could actually end up invoking stuff outside of the project directory:

```
 ✓ ../yomitan-new/test/options-util.test.js (3)
 ✓ ../yomitan-old/test/options-util.test.js (3)
 ✓ ../yomichan/test/options-util.test.js (3)
 ✓ test/options-util.test.js (20)
```