### PR TITLE
Support build.js target positional arguments

### DIFF
--- a/dev/bin/build.js
+++ b/dev/bin/build.js
@@ -247,7 +247,7 @@ export async function main() {
     };
 
     const argv = process.argv.slice(2);
-    const {values: args} = parseArgs({args: argv, options: parseArgsConfigOptions});
+    const {values: args, positionals: targets} = parseArgs({args: argv, options: parseArgsConfigOptions, allowPositionals: true});
 
     const dryRun = /** @type {boolean} */ (args.dryRun);
     const dryRunBuildZip = /** @type {boolean} */ (args.dryRunBuildZip);
@@ -265,7 +265,7 @@ export async function main() {
         const variantNames = /** @type {string[]} */ ((
             argv.length === 0 || args.all ?
             manifestUtil.getVariants().filter(({buildable}) => buildable !== false).map(({name}) => name) :
-            []
+            targets
         ));
         await build(buildDir, extDir, manifestUtil, variantNames, manifestPath, dryRun, dryRunBuildZip, yomitanVersion);
     } finally {


### PR DESCRIPTION
After reading the CONTRIBUTING.md, it seemed to me that the supposed support for the positional target CLI args for build.js is missing, so I went ahead and added it in.

If I'm mistakenly implementing an existing feature, please let me know!