### PR TITLE
Add option to allow adding duplicate cards

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -873,6 +873,7 @@
                                     "duplicateScope",
                                     "duplicateScopeCheckAllModels",
                                     "checkForDuplicates",
+                                    "allowDuplicates",
                                     "fieldTemplates",
                                     "suspendNewCards",
                                     "displayTags",
@@ -978,6 +979,10 @@
                                         "default": false
                                     },
                                     "checkForDuplicates": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "allowDuplicates": {
                                         "type": "boolean",
                                         "default": true
                                     },

--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -55,6 +55,7 @@ export class AnkiNoteBuilder {
         tags = [],
         requirements = [],
         checkForDuplicates = true,
+        allowDuplicates = false,
         duplicateScope = 'collection',
         duplicateScopeCheckAllModels = false,
         resultOutputMode = 'split',
@@ -111,7 +112,7 @@ export class AnkiNoteBuilder {
             deckName,
             modelName,
             options: {
-                allowDuplicate: !checkForDuplicates,
+                allowDuplicate: checkForDuplicates ? allowDuplicates : false,
                 duplicateScope,
                 duplicateScopeOptions: {
                     deckName: duplicateScopeDeckName,

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -533,7 +533,8 @@ export class OptionsUtil {
             this._updateVersion24,
             this._updateVersion25,
             this._updateVersion26,
-            this._updateVersion27
+            this._updateVersion27,
+            this._updateVersion28
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1199,6 +1200,15 @@ export class OptionsUtil {
         await this._applyAnkiFieldTemplatesPatch(options, '/data/templates/anki-field-templates-upgrade-v27.handlebars');
     }
 
+    /**
+     * - Added anki.allowDuplicates.
+     * @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion28(options) {
+        for (const profile of options.profiles) {
+            profile.options.anki.allowDuplicates = false;
+        }
+    }
 
     /**
      * @param {string} url

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1636,6 +1636,27 @@
                     <div class="settings-item-inner">
                         <div class="settings-item-left">
                             <div class="settings-item-label">
+                                Allow duplicate cards
+                                <a tabindex="0" class="more-toggle more-only" data-parent-distance="4">(?)</a>
+                            </div>
+                        </div>
+                        <div class="settings-item-right">
+                            <label class="toggle"><input type="checkbox" data-setting="anki.allowDuplicates"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                        </div>
+                    </div>
+                    <div class="settings-item-children more" hidden>
+                        <p>
+                            Allow cards detected as a duplicate to be added anyway.
+                        </p>
+                        <p>
+                            <a tabindex="0" class="more-toggle" data-parent-distance="3">Less&hellip;</a>
+                        </p>
+                    </div>
+                </div>
+                <div class="settings-item">
+                    <div class="settings-item-inner">
+                        <div class="settings-item-left">
+                            <div class="settings-item-label">
                                 Check for duplicates across all models
                                 <a tabindex="0" class="more-toggle more-only" data-parent-distance="4">(?)</a>
                             </div>

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -441,6 +441,7 @@ function createProfileOptionsUpdatedTestData1() {
             duplicateScopeCheckAllModels: false,
             displayTags: 'never',
             checkForDuplicates: true,
+            allowDuplicates: false,
             fieldTemplates: null,
             suspendNewCards: false,
             noteGuiMode: 'browse',

--- a/test/utilities/anki.js
+++ b/test/utilities/anki.js
@@ -108,6 +108,7 @@ export async function getTemplateRenderResults(dictionaryEntries, mode, template
             fields: createTestFields(dictionaryEntry.type),
             tags: ['yomitan'],
             checkForDuplicates: true,
+            allowDuplicates: false,
             duplicateScope: 'collection',
             duplicateScopeCheckAllModels: false,
             resultOutputMode: mode,

--- a/types/ext/anki-note-builder.d.ts
+++ b/types/ext/anki-note-builder.d.ts
@@ -36,6 +36,7 @@ export type CreateNoteDetails = {
     tags: string[];
     requirements: Requirement[];
     checkForDuplicates: boolean;
+    allowDuplicates: boolean;
     duplicateScope: Settings.AnkiDuplicateScope;
     duplicateScopeCheckAllModels: boolean;
     resultOutputMode: Settings.ResultOutputMode;

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -281,6 +281,7 @@ export type AnkiOptions = {
     duplicateScope: AnkiDuplicateScope;
     duplicateScopeCheckAllModels: boolean;
     checkForDuplicates: boolean;
+    allowDuplicates: boolean;
     fieldTemplates: string | null;
     suspendNewCards: boolean;
     displayTags: AnkiDisplayTags;


### PR DESCRIPTION
Because many words have multiple meanings listed in the same entry, I often create what Anki might consider duplicate cards. Despite this, I still value the View Notes button for displaying my existing cards so that I can decide whether or not to make the card.

For this reason I have added an option that will cause the add buttons to remain active if a duplicate is detected. I'm not thrilled with the solution I came up with, but it seemed slightly preferable to fiddling with the backend - at least for my first real PR here. Feedback greatly appreciated.