### PR TITLE
Update eslint unsafe rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -398,7 +398,7 @@
                 "@typescript-eslint/no-misused-promises": "off",
                 "@typescript-eslint/no-redundant-type-constituents": "error",
                 "@typescript-eslint/no-unsafe-argument": "error",
-                "@typescript-eslint/no-unsafe-assignment": "off",
+                "@typescript-eslint/no-unsafe-assignment": "error",
                 "@typescript-eslint/no-unsafe-call": "off",
                 "@typescript-eslint/no-unsafe-enum-comparison": "off",
                 "@typescript-eslint/no-unsafe-member-access": "off",

--- a/dev/dictionary-validate.js
+++ b/dev/dictionary-validate.js
@@ -80,6 +80,7 @@ async function validateDictionaryBanks(mode, entries, schemasDetails) {
 export async function validateDictionary(mode, archiveData, schemas) {
     const entries = await getDictionaryArchiveEntries(archiveData);
     const indexFileName = getIndexFileName();
+    /** @type {import('dictionary-data').Index} */
     const index = await getDictionaryArchiveJson(entries, indexFileName);
     const version = index.format || index.version;
 

--- a/ext/js/accessibility/google-docs-xray.js
+++ b/ext/js/accessibility/google-docs-xray.js
@@ -17,7 +17,7 @@
 
 /** Entry point. */
 function main() {
-    /** @type {Window} */
+    /** @type {unknown} */
     // @ts-expect-error - Firefox Xray vision
     const window2 = window.wrappedJSObject;
     if (!(typeof window2 === 'object' && window2 !== null)) { return; }

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1790,16 +1790,7 @@ export class Backend {
         }
 
         try {
-            const tabWindow = await new Promise((resolve, reject) => {
-                chrome.windows.get(tab.windowId, {}, (value) => {
-                    const e = chrome.runtime.lastError;
-                    if (e) {
-                        reject(new Error(e.message));
-                    } else {
-                        resolve(value);
-                    }
-                });
-            });
+            const tabWindow = await this._getWindow(tab.windowId);
             if (!tabWindow.focused) {
                 await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
                     chrome.windows.update(tab.windowId, {focused: true}, () => {
@@ -1815,6 +1806,23 @@ export class Backend {
         } catch (e) {
             // Edge throws exception for no reason here.
         }
+    }
+
+    /**
+     * @param {number} windowId
+     * @returns {Promise<chrome.windows.Window>}
+     */
+    _getWindow(windowId) {
+        return new Promise((resolve, reject) => {
+            chrome.windows.get(windowId, {}, (value) => {
+                const e = chrome.runtime.lastError;
+                if (e) {
+                    reject(new Error(e.message));
+                } else {
+                    resolve(value);
+                }
+            });
+        });
     }
 
     /**
@@ -2160,6 +2168,7 @@ export class Backend {
     async _injectAnkiNoteDictionaryMedia(ankiConnect, timestamp, definitionDetails, dictionaryMediaDetails) {
         const targets = [];
         const detailsList = [];
+        /** @type {Map<string, {dictionary: string, path: string, media: ?import('dictionary-database').MediaDataStringContent}>} */
         const detailsMap = new Map();
         for (const {dictionary, path} of dictionaryMediaDetails) {
             const target = {dictionary, path};

--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -88,6 +88,7 @@ export class OffscreenProxy {
         if (!chrome.runtime.getContexts) { // Chrome version below 116
             // Clients: https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/clients
             // @ts-expect-error - Types not set up for service workers yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             const matchedClients = await clients.matchAll();
             // @ts-expect-error - Types not set up for service workers yet
             return await matchedClients.some((client) => client.url === offscreenUrl);

--- a/ext/js/background/script-manager.js
+++ b/ext/js/background/script-manager.js
@@ -60,16 +60,7 @@ export function injectStylesheet(type, content, tabId, frameId, allFrames) {
  * @returns {Promise<boolean>} `true` if a script is registered, `false` otherwise.
  */
 export async function isContentScriptRegistered(id) {
-    const scripts = await new Promise((resolve, reject) => {
-        chrome.scripting.getRegisteredContentScripts({ids: [id]}, (result) => {
-            const e = chrome.runtime.lastError;
-            if (e) {
-                reject(new Error(e.message));
-            } else {
-                resolve(result);
-            }
-        });
-    });
+    const scripts = await getRegisteredContentScripts([id]);
     for (const script of scripts) {
         if (script.id === id) {
             return true;
@@ -154,4 +145,21 @@ function createContentScriptRegistrationOptions(details, id) {
         options.world = world;
     }
     return options;
+}
+
+/**
+ * @param {string[]} ids
+ * @returns {Promise<chrome.scripting.RegisteredContentScript[]>}
+ */
+function getRegisteredContentScripts(ids) {
+    return new Promise((resolve, reject) => {
+        chrome.scripting.getRegisteredContentScripts({ids}, (result) => {
+            const e = chrome.runtime.lastError;
+            if (e) {
+                reject(new Error(e.message));
+            } else {
+                resolve(result);
+            }
+        });
+    });
 }

--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -605,15 +605,15 @@ export class AnkiConnect {
             if (typeof modelName !== 'string') {
                 throw this._createError(`Unexpected result type at index ${i}, field modelName: expected string, received ${this._getTypeName(modelName)}`, result);
             }
-            if (typeof fields !== 'object' || fields === null) {
-                throw this._createError(`Unexpected result type at index ${i}, field fields: expected string, received ${this._getTypeName(fields)}`, result);
+            if (!isObjectNotArray(fields)) {
+                throw this._createError(`Unexpected result type at index ${i}, field fields: expected object, received ${this._getTypeName(fields)}`, result);
             }
             const tags2 = /** @type {string[]} */ (this._normalizeArray(tags, -1, 'string', ', field tags'));
             const cards2 = /** @type {number[]} */ (this._normalizeArray(cards, -1, 'number', ', field cards'));
             /** @type {{[key: string]: import('anki').NoteFieldInfo}} */
             const fields2 = {};
             for (const [key, fieldInfo] of Object.entries(fields)) {
-                if (typeof fieldInfo !== 'object' || fieldInfo === null) { continue; }
+                if (!isObjectNotArray(fieldInfo)) { continue; }
                 const {value, order} = fieldInfo;
                 if (typeof value !== 'string' || typeof order !== 'number') { continue; }
                 fields2[key] = {value, order};

--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -18,6 +18,7 @@
 
 import {ExtensionError} from '../core/extension-error.js';
 import {parseJson} from '../core/json.js';
+import {isObjectNotArray} from '../core/object-utilities.js';
 import {getRootDeckName} from '../data/anki-util.js';
 
 /**

--- a/ext/js/comm/frame-ancestry-handler.js
+++ b/ext/js/comm/frame-ancestry-handler.js
@@ -288,6 +288,7 @@ export class FrameAncestryHandler {
                 }
 
                 /** @type {?ShadowRoot|undefined} */
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 const shadowRoot = (
                     element.shadowRoot ||
                     // @ts-expect-error - openOrClosedShadowRoot is available to Firefox 63+ for WebExtensions

--- a/ext/js/comm/frame-client.js
+++ b/ext/js/comm/frame-client.js
@@ -83,6 +83,7 @@ export class FrameClient {
      */
     _connectInternal(frame, targetOrigin, hostFrameId, setupFrame, timeout) {
         return new Promise((resolve, reject) => {
+            /** @type {Map<string, string>} */
             const tokenMap = new Map();
             /** @type {?import('core').Timeout} */
             let timer = null;

--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -89,6 +89,7 @@ export class AnkiNoteBuilder {
         }
 
         const formattedFieldValues = await Promise.all(formattedFieldValuePromises);
+        /** @type {Map<string, import('anki-note-builder').Requirement>} */
         const uniqueRequirements = new Map();
         /** @type {import('anki').NoteFields} */
         const noteFields = {};

--- a/ext/js/data/database.js
+++ b/ext/js/data/database.js
@@ -194,10 +194,10 @@ export class Database {
         request.onsuccess = (e) => {
             const cursor = /** @type {IDBRequest<?IDBCursorWithValue>} */ (e.target).result;
             if (cursor) {
-                /** @type {TResult} */
+                /** @type {unknown} */
                 const value = cursor.value;
-                if (noPredicate || predicate(value, predicateArg)) {
-                    resolve(value, data);
+                if (noPredicate || predicate(/** @type {TResult} */ (value), predicateArg)) {
+                    resolve(/** @type {TResult} */ (value), data);
                 } else {
                     cursor.continue();
                 }
@@ -424,9 +424,9 @@ export class Database {
         request.onsuccess = (e) => {
             const cursor = /** @type {IDBRequest<?IDBCursorWithValue>} */ (e.target).result;
             if (cursor) {
-                /** @type {TResult} */
+                /** @type {unknown} */
                 const value = cursor.value;
-                results.push(value);
+                results.push(/** @type {TResult} */ (value));
                 cursor.continue();
             } else {
                 onSuccess(results, data);

--- a/ext/js/data/json-schema.js
+++ b/ext/js/data/json-schema.js
@@ -1263,7 +1263,7 @@ class JsonSchemaProxyHandler {
     /**
      * @param {import('ext/json-schema').ValueObjectOrArray} target
      * @param {string|number|symbol} property
-     * @param {import('core').SafeAny} value
+     * @param {unknown} value
      * @returns {boolean}
      * @throws {Error}
      */

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -27,6 +27,7 @@ import {JsonSchema} from './json-schema.js';
 // of the options object to a newer format. SafeAny is used for much of this, since every single
 // legacy format does not contain type definitions.
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
 export class OptionsUtil {
     constructor() {
@@ -1226,4 +1227,5 @@ export class OptionsUtil {
     }
 }
 
+/* eslint-enable @typescript-eslint/no-unsafe-assignment */
 /* eslint-enable @typescript-eslint/no-unsafe-argument */

--- a/ext/js/dictionary/dictionary-data-util.js
+++ b/ext/js/dictionary/dictionary-data-util.js
@@ -24,6 +24,7 @@ export function groupTermTags(dictionaryEntry) {
     const {headwords} = dictionaryEntry;
     const headwordCount = headwords.length;
     const uniqueCheck = (headwordCount > 1);
+    /** @type {Map<string, number>} */
     const resultsIndexMap = new Map();
     const results = [];
     for (let i = 0; i < headwordCount; ++i) {

--- a/ext/js/display/display-history.js
+++ b/ext/js/display/display-history.js
@@ -37,6 +37,7 @@ export class DisplayHistory extends EventDispatcher {
         /** @type {Map<string, import('display-history').Entry>} */
         this._historyMap = new Map();
 
+        /** @type {unknown} */
         const historyState = history.state;
         const {id, state} = (
             isObjectNotArray(historyState) ?
@@ -188,6 +189,7 @@ export class DisplayHistory extends EventDispatcher {
 
     /** */
     _updateStateFromHistory() {
+        /** @type {unknown} */
         let state = history.state;
         let id = null;
         if (isObjectNotArray(state)) {
@@ -208,7 +210,7 @@ export class DisplayHistory extends EventDispatcher {
 
         // Fallback
         this._current.id = (typeof id === 'string' ? id : this._generateId());
-        this._current.state = state;
+        this._current.state = /** @type {import('display-history').EntryState} */ (state);
         this._current.content = null;
         this._clear();
     }

--- a/ext/js/input/hotkey-help-controller.js
+++ b/ext/js/input/hotkey-help-controller.js
@@ -67,9 +67,10 @@ export class HotkeyHelpController {
             const hotkey = (global ? this._globalActionHotkeys : this._localActionHotkeys).get(action);
             for (let i = 0, ii = attributes.length; i < ii; ++i) {
                 const attribute = attributes[i];
+                /** @type {unknown} */
                 let value;
                 if (typeof hotkey !== 'undefined') {
-                    value = /** @type {unknown} */ (multipleValues ? values[i] : values);
+                    value = multipleValues ? values[i] : values;
                     if (typeof value === 'string') {
                         value = value.replace(replacementPattern, hotkey);
                     }
@@ -158,7 +159,8 @@ export class HotkeyHelpController {
         if (typeof hotkey !== 'string') { return null; }
         const data = /** @type {unknown} */ (parseJson(hotkey));
         if (!Array.isArray(data)) { return null; }
-        const [action, attributes, values] = /** @type {unknown[]} */ (data);
+        const dataArray = /** @type {unknown[]} */ (data);
+        const [action, attributes, values] = dataArray;
         if (typeof action !== 'string') { return null; }
         /** @type {string[]} */
         const attributesArray = [];

--- a/ext/js/language/ja/japanese-wanakana.js
+++ b/ext/js/language/ja/japanese-wanakana.js
@@ -19,12 +19,20 @@ import * as wanakana from '../../../lib/wanakana.js';
 
 /**
  * @param {string} text
+ * @returns {string}
+ */
+function toHiragana(text) {
+    return /** @type {import('wanakana')} */ (/** @type {unknown} */ (wanakana)).toHiragana(text);
+}
+
+/**
+ * @param {string} text
  * @param {?import('../../general/text-source-map.js').TextSourceMap} sourceMap
  * @param {number} sourceMapStart
  * @returns {string}
  */
 function convertAlphabeticPartToKana(text, sourceMap, sourceMapStart) {
-    const result = wanakana.toHiragana(text);
+    const result = toHiragana(text);
 
     // Generate source mapping
     if (sourceMap !== null) {
@@ -36,7 +44,7 @@ function convertAlphabeticPartToKana(text, sourceMap, sourceMapStart) {
             let iNext = i + 1;
             let resultPosNext = result.length;
             while (iNext < ii) {
-                const t = wanakana.toHiragana(text.substring(0, iNext));
+                const t = toHiragana(text.substring(0, iNext));
                 if (t === result.substring(0, t.length)) {
                     resultPosNext = t.length;
                     break;

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -285,6 +285,7 @@ export class Translator {
             return false;
         }
 
+        /** @type {Map<string, number>} */
         const frequencyCounter = new Map();
 
         for (const element of array1) {
@@ -396,6 +397,7 @@ export class Translator {
      * @returns {Map<string, import('translation-internal').DatabaseDeinflection[]>}
      */
     _groupDeinflectionsByTerm(deinflections) {
+        /** @type {Map<string, import('translation-internal').DatabaseDeinflection[]>} */
         const result = new Map();
         for (const deinflection of deinflections) {
             const {deinflectedText} = deinflection;
@@ -645,6 +647,7 @@ export class Translator {
         /** @type {import('dictionary-database').TermExactRequest[]} */
         const termList = [];
         const targetList = [];
+        /** @type {Map<string, {groups: import('translator').DictionaryEntryGroup[]}>} */
         const targetMap = new Map();
 
         for (const group of groupedDictionaryEntries) {
@@ -2038,6 +2041,7 @@ export class Translator {
      * @param {boolean} ascending
      */
     _updateSortFrequencies(dictionaryEntries, dictionary, ascending) {
+        /** @type {Map<number, number>} */
         const frequencyMap = new Map();
         for (const dictionaryEntry of dictionaryEntries) {
             const {definitions, frequencies} = dictionaryEntry;

--- a/ext/js/pages/settings/backup-controller.js
+++ b/ext/js/pages/settings/backup-controller.js
@@ -574,12 +574,16 @@ export class BackupController {
      * @returns {Promise<Blob>}
      */
     async _exportDatabase(databaseName) {
-        const db = await new Dexie(databaseName).open();
+        const DexieConstructor = /** @type {import('dexie').DexieConstructor} */ (/** @type {unknown} */ (Dexie));
+        const db = new DexieConstructor(databaseName);
+        await db.open();
+        /** @type {unknown} */
+        // @ts-expect-error - The export function is declared as an extension which has no type information.
         const blob = await db.export({
             progressCallback: this._databaseExportProgressCallback.bind(this)
         });
-        await db.close();
-        return blob;
+        db.close();
+        return /** @type {Blob} */ (blob);
     }
 
     /** */

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -299,6 +299,7 @@ export class DictionaryImportController {
      * @param {Error[]} errors
      */
     _showErrors(errors) {
+        /** @type {Map<string, number>} */
         const uniqueErrors = new Map();
         for (const error of errors) {
             log.error(error);

--- a/ext/js/templates/sandbox/anki-template-renderer.js
+++ b/ext/js/templates/sandbox/anki-template-renderer.js
@@ -659,12 +659,19 @@ export class AnkiTemplateRenderer {
     }
 
     /**
+     * @param {import('template-renderer').HelperOptions} options
+     * @returns {import('anki-templates').NoteData}
+     */
+    _getNoteDataFromOptions(options) {
+        return options.data.root;
+    }
+
+    /**
      * @type {import('template-renderer').HelperFunction<string>}
      */
     _formatGlossary(args, _context, options) {
         const [dictionary, content] = /** @type {[dictionary: string, content: import('dictionary-data').TermGlossaryContent]} */ (args);
-        /** @type {import('anki-templates').NoteData} */
-        const data = options.data.root;
+        const data = this._getNoteDataFromOptions(options);
         if (typeof content === 'string') { return this._safeString(this._stringToMultiLineHtml(content)); }
         if (!(typeof content === 'object' && content !== null)) { return ''; }
         switch (content.type) {
@@ -703,8 +710,7 @@ export class AnkiTemplateRenderer {
      * @type {import('template-renderer').HelperFunction<boolean>}
      */
     _hasMedia(args, _context, options) {
-        /** @type {import('anki-templates').NoteData} */
-        const data = options.data.root;
+        const data = this._getNoteDataFromOptions(options);
         return this._mediaProvider.hasMedia(data, args, options.hash);
     }
 
@@ -712,8 +718,7 @@ export class AnkiTemplateRenderer {
      * @type {import('template-renderer').HelperFunction<?string>}
      */
     _getMedia(args, _context, options) {
-        /** @type {import('anki-templates').NoteData} */
-        const data = options.data.root;
+        const data = this._getNoteDataFromOptions(options);
         return this._mediaProvider.getMedia(data, args, options.hash);
     }
 

--- a/ext/js/templates/sandbox/template-renderer-media-provider.js
+++ b/ext/js/templates/sandbox/template-renderer-media-provider.js
@@ -81,6 +81,8 @@ export class TemplateRendererMediaProvider {
         let {value} = data;
         const {escape = true} = namedArgs;
         if (escape) {
+            // Handlebars is a custom version of the library without type information, so it's assumed to be "any".
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             value = Handlebars.Utils.escapeExpression(value);
         }
         return value;

--- a/ext/js/templates/sandbox/template-renderer.js
+++ b/ext/js/templates/sandbox/template-renderer.js
@@ -117,6 +117,8 @@ export class TemplateRenderer {
         let instance = cache.get(template);
         if (typeof instance === 'undefined') {
             this._updateCacheSize(this._cacheMaxSize - 1);
+            // Handlebars is a custom version of the library without type information, so it's assumed to be "any".
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             instance = /** @type {import('handlebars').TemplateDelegate<import('anki-templates').NoteData>} */ (Handlebars.compileAST(template));
             cache.set(template, instance);
         }

--- a/test/dom-text-scanner.test.js
+++ b/test/dom-text-scanner.test.js
@@ -85,8 +85,13 @@ function createAbsoluteGetComputedStyle(window) {
     return (element, ...args) => {
         const style = getComputedStyleOld(element, ...args);
         return new Proxy(style, {
+            /**
+             * @param {CSSStyleDeclaration} target
+             * @param {string|symbol} property
+             * @returns {unknown}
+             */
             get: (target, property) => {
-                let result = /** @type {import('core').SafeAny} */ (target)[property];
+                let result = /** @type {Record<string|symbol, unknown>} */ (/** @type {unknown} */ (target))[property];
                 if (typeof result === 'string') {
                     /**
                      * @param {string} g0

--- a/test/fixtures/dom-test.js
+++ b/test/fixtures/dom-test.js
@@ -28,7 +28,9 @@ function prepareWindow(window) {
 
     // Define innerText setter as an alias for textContent setter
     Object.defineProperty(window.HTMLDivElement.prototype, 'innerText', {
+        /** @returns {string} */
         get() { return this.textContent; },
+        /** @param {string} value */
         set(value) { this.textContent = value; }
     });
 

--- a/test/handlebars.test.js
+++ b/test/handlebars.test.js
@@ -18,6 +18,22 @@
 import {describe, test} from 'vitest';
 import {Handlebars} from '../ext/lib/handlebars.js';
 
+/**
+ * @param {string} template
+ * @returns {import('handlebars').TemplateDelegate<unknown>}
+ */
+function compile(template) {
+    return Handlebars.compile(template);
+}
+
+/**
+ * @param {string} template
+ * @returns {import('handlebars').TemplateDelegate<unknown>}
+ */
+function compileAST(template) {
+    return Handlebars.compileAST(template);
+}
+
 describe('Handlebars', () => {
     test('compile vs compileAST 1', ({expect}) => {
         const template = '{{~test1~}}';
@@ -26,8 +42,8 @@ describe('Handlebars', () => {
             test1: '<div style="font-size: 4em;">Test</div>'
         };
 
-        const instance1 = Handlebars.compile(template);
-        const instance2 = Handlebars.compileAST(template);
+        const instance1 = compile(template);
+        const instance2 = compileAST(template);
 
         const result1 = instance1(data);
         const result2 = instance2(data);
@@ -44,8 +60,8 @@ describe('Handlebars', () => {
             }
         };
 
-        const instance1 = Handlebars.compile(template);
-        const instance2 = Handlebars.compileAST(template);
+        const instance1 = compile(template);
+        const instance2 = compileAST(template);
 
         const result1 = instance1(data);
         const result2 = instance2(data);


### PR DESCRIPTION
One more rule enabled to reduce the usage of the implicit `any` type.

There is a related issue I ran into while working on this which I opened an issue for.
https://github.com/typescript-eslint/typescript-eslint/issues/8594