### PR TITLE
log anki error when hiding button

### DIFF
--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -413,6 +413,9 @@ export class DisplayAnki {
                 if (button !== null) {
                     button.disabled = !canAdd;
                     button.hidden = (ankiError !== null);
+                    if (ankiError) {
+                        log.error(ankiError);
+                    }
 
                     // If entry has noteIds, show the "add duplicate" button.
                     if (Array.isArray(noteIds) && noteIds.length > 0) {


### PR DESCRIPTION
Looking at #818 and the code, I think the buttons are missing entirely, rather then grayed out, only when there is an anki error. The `ankiError` here seems to not get logged anywhere, so at least logging it to see what error it is might help. 