### PR TITLE
Fix #818: Revert to using canAddNotes

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -537,24 +537,16 @@ export class Backend {
 
     /**
      * @param {import('anki').Note[]} notes
-     * @returns {Promise<({ canAdd: true; } | { canAdd: false; error: string; })[]>}
+     * @returns {Promise<import('backend').CanAddResults>}
      */
-    async detectDuplicateNotes(notes) {
+    async partitionAddibleNotes(notes) {
         // `allowDuplicate` is on for all notes by default, so we temporarily set it to false
         // to check which notes are duplicates.
         const notesNoDuplicatesAllowed = notes.map((note) => ({...note, options: {...note.options, allowDuplicate: false}}));
 
-        return await this._anki.canAddNotesWithErrorDetail(notesNoDuplicatesAllowed);
-    }
-
-    /**
-     * Partitions notes between those that can / cannot be added.
-     * It further sets the `isDuplicate` strings for notes that have a duplicate.
-     * @param {import('anki').Note[]} notes
-     * @returns {Promise<import('backend').CanAddResults>}
-     */
-    async partitionAddibleNotes(notes) {
-        const canAddResults = await this.detectDuplicateNotes(notes);
+        // If only older AnkiConnect available, use `canAddNotes`.
+        const withDuplicatesAllowed = await this._anki.canAddNotes(notes);
+        const noDuplicatesAllowed = await this._anki.canAddNotes(notesNoDuplicatesAllowed);
 
         /** @type {{ note: import('anki').Note, isDuplicate: boolean }[]} */
         const canAddArray = [];
@@ -562,16 +554,11 @@ export class Backend {
         /** @type {import('anki').Note[]} */
         const cannotAddArray = [];
 
-        for (let i = 0; i < canAddResults.length; i++) {
-            const result = canAddResults[i];
-
-            // If the note is a duplicate, the error is "cannot create note because it is a duplicate".
-            if (result.canAdd) {
+        for (let i = 0; i < withDuplicatesAllowed.length; i++) {
+            if (withDuplicatesAllowed[i] === noDuplicatesAllowed[i]) {
                 canAddArray.push({note: notes[i], isDuplicate: false});
-            } else if (result.error.endsWith('duplicate')) {
-                canAddArray.push({note: notes[i], isDuplicate: true});
             } else {
-                cannotAddArray.push(notes[i]);
+                canAddArray.push({note: notes[i], isDuplicate: true});
             }
         }
 

--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -128,15 +128,16 @@ export class AnkiConnect {
         return result;
     }
 
+
     /**
      * @param {import('anki').Note[]} notes
-     * @returns {Promise<({ canAdd: true } | { canAdd: false, error: string })[]>}
+     * @returns {Promise<boolean[]>}
      */
-    async canAddNotesWithErrorDetail(notes) {
+    async canAddNotes(notes) {
         if (!this._enabled) { return []; }
         await this._checkVersion();
-        const result = await this._invoke('canAddNotesWithErrorDetail', {notes});
-        return this._normalizeCanAddNotesWithErrorDetailArray(result, notes.length);
+        const result = await this._invoke('canAddNotes', {notes});
+        return this._normalizeArray(result, notes.length, 'boolean');
     }
 
     /**
@@ -577,52 +578,6 @@ export class AnkiConnect {
             }
         }
         return /** @type {T[]} */ (result);
-    }
-
-    /**
-     * @param {unknown} result
-     * @param {number} expectedCount
-     * @returns {import('anki-connect.js').CanAddResult[]}
-     * @throws {Error}
-     */
-    _normalizeCanAddNotesWithErrorDetailArray(result, expectedCount) {
-        if (!Array.isArray(result)) {
-            throw this._createUnexpectedResultError('array', result, '');
-        }
-        if (expectedCount !== result.length) {
-            throw this._createError(`Unexpected result array size: expected ${expectedCount}, received ${result.length}`, result);
-        }
-        /** @type {import('anki-connect.js').CanAddResult[]} */
-        const result2 = [];
-        for (let i = 0; i < expectedCount; ++i) {
-            const item = /** @type {unknown} */ (result[i]);
-            if (item === null || typeof item !== 'object') {
-                throw this._createError(`Unexpected result type at index ${i}: expected object, received ${this._getTypeName(item)}`, result);
-            }
-
-            const {canAdd, error} = /** @type {{[key: string]: unknown}} */ (item);
-            if (typeof canAdd !== 'boolean') {
-                throw this._createError(`Unexpected result type at index ${i}, field canAdd: expected boolean, received ${this._getTypeName(canAdd)}`, result);
-            }
-
-            if (canAdd && typeof error !== 'undefined') {
-                throw this._createError(`Unexpected result type at index ${i}, field error: expected undefined, received ${this._getTypeName(error)}`, result);
-            }
-            if (!canAdd && typeof error !== 'string') {
-                throw this._createError(`Unexpected result type at index ${i}, field error: expected string, received ${this._getTypeName(error)}`, result);
-            }
-
-            if (canAdd) {
-                result2.push({canAdd});
-            } else if (typeof error === 'string') {
-                const item2 = {
-                    canAdd,
-                    error
-                };
-                result2.push(item2);
-            }
-        }
-        return result2;
     }
 
     /**

--- a/test/playwright/playwright-util.js
+++ b/test/playwright/playwright-util.js
@@ -138,7 +138,7 @@ function getResponseBody(action) {
         case 'deckNames': return ['Mock Deck'];
         case 'modelNames': return ['Mock Model'];
         case 'modelFieldNames': return [...getMockModelFields().keys()];
-        case 'canAddNotesWithErrorDetail': return [{canAdd: true}, {canAdd: true}];
+        case 'canAddNotes': return [true, true];
         case 'storeMediaFile': return 'mock_audio.mp3';
         case 'addNote': return 102312488912;
         case 'multi': return [];


### PR DESCRIPTION
Fixes #818.

Reverting to using canAddNotes to avoid issues for users with older AnkiConnect version not supporting `canAddNotesWithErrorDetail` (introduced in [24.1.21.0](https://git.foosoft.net/alex/anki-connect/commit/bbf271c5ac611705accbf4ec9dbaa3382ba439ec)).

## Test plan

To simulate the original issue:

- [ ] go to the files for your installed AnkiConnect (`Anki2/addons21/2055492159`, can be reached from Anki by going to `Add-ons` > `AnkiConnect` > `Show files`)
- [ ] in `__init__.py`, comment out the `canAddNotesWithErrorDetail` method from line 791 to 801 in the latest version
- [ ] using Yomitan, try to add a note for a term with duplicate notes in Anki
  - [ ] make sure `Check for card duplicates` is on in the Yomitan settings
- [ ] the red stacked add button should appear (same as if you uncomment the above code)