### PR TITLE
Fix duplicate check not working across note types

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -28,7 +28,7 @@ import {logErrorLevelToNumber} from '../core/log-utilities.js';
 import {log} from '../core/log.js';
 import {isObjectNotArray} from '../core/object-utilities.js';
 import {clone, deferPromise, promiseTimeout} from '../core/utilities.js';
-import {isNoteDataValid} from '../data/anki-util.js';
+import {invalidNoteId, isNoteDataValid} from '../data/anki-util.js';
 import {arrayBufferToBase64} from '../data/array-buffer-util.js';
 import {OptionsUtil} from '../data/options-util.js';
 import {getAllPermissions, hasPermissions, hasRequiredPermissionsForOptions} from '../data/permissions-util.js';
@@ -596,8 +596,7 @@ export class Backend {
             const valid = isNoteDataValid(note);
 
             if (isDuplicate && duplicateNoteIds[originalIndices.indexOf(i)].length === 0) {
-                // -1 indicates an invalid/unknown noteId, this id will never exist in anki
-                duplicateNoteIds[originalIndices.indexOf(i)] = [-1];
+                duplicateNoteIds[originalIndices.indexOf(i)] = [invalidNoteId];
             }
 
             const noteIds = isDuplicate ? duplicateNoteIds[originalIndices.indexOf(i)] : null;

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -596,6 +596,11 @@ export class Backend {
 
             const valid = isNoteDataValid(note);
 
+            if (isDuplicate && duplicateNoteIds[originalIndices.indexOf(i)].length === 0) {
+                // -1 indicates an invalid/unknown noteId, this id will never exist in anki
+                duplicateNoteIds[originalIndices.indexOf(i)] = [-1];
+            }
+
             const noteIds = isDuplicate ? duplicateNoteIds[originalIndices.indexOf(i)] : null;
             const noteInfos = (fetchAdditionalInfo && noteIds !== null && noteIds.length > 0) ? await this._anki.notesInfo(noteIds) : [];
 

--- a/ext/js/data/anki-util.js
+++ b/ext/js/data/anki-util.js
@@ -82,3 +82,5 @@ export function isNoteDataValid(note) {
         Object.entries(fields).length > 0
     );
 }
+
+export const invalidNoteId = -1;

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -425,7 +425,11 @@ export class DisplayAnki {
 
                 if (Array.isArray(noteIds) && noteIds.length > 0) {
                     if (allNoteIds === null) { allNoteIds = new Set(); }
-                    for (const noteId of noteIds) { allNoteIds.add(noteId); }
+                    for (const noteId of noteIds) {
+                        if (noteId !== -1) {
+                            allNoteIds.add(noteId);
+                        }
+                    }
                 }
 
                 if (displayTags !== 'never' && Array.isArray(noteInfos)) {

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -21,7 +21,7 @@ import {log} from '../core/log.js';
 import {toError} from '../core/to-error.js';
 import {deferPromise} from '../core/utilities.js';
 import {AnkiNoteBuilder} from '../data/anki-note-builder.js';
-import {isNoteDataValid} from '../data/anki-util.js';
+import {invalidNoteId, isNoteDataValid} from '../data/anki-util.js';
 import {PopupMenu} from '../dom/popup-menu.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
 import {TemplateRendererProxy} from '../templates/template-renderer-proxy.js';
@@ -426,7 +426,7 @@ export class DisplayAnki {
                 if (Array.isArray(noteIds) && noteIds.length > 0) {
                     if (allNoteIds === null) { allNoteIds = new Set(); }
                     for (const noteId of noteIds) {
-                        if (noteId !== -1) {
+                        if (noteId !== invalidNoteId) {
                             allNoteIds.add(noteId);
                         }
                     }


### PR DESCRIPTION
Fixes #788

It isn't possible to get the noteId for a duplicate note of a different note type without specifically searching exact sort field of every note type. A filler noteId that cannot exist in anki (`-1`) can be used to allow the dupe's identity to not be lost.