### PR TITLE
Fix search header left margins on small screens

### DIFF
--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -87,7 +87,6 @@ h1 {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     white-space: pre-wrap;
     z-index: 1;
-    margin: 0 calc(-1 * var(--main-content-horizontal-padding));
 }
 .search-button {
     flex: 0 0 auto;
@@ -132,7 +131,7 @@ h1 {
 .search-options {
     display: flex;
     flex-flow: row wrap;
-    margin: 0.5em calc(-1 * var(--main-content-horizontal-padding));
+    margin: 0.5em 0;
     align-items: center;
 }
 .search-option {


### PR DESCRIPTION
Supercedes #781

Fixes a regression added in #754

Previously, the search bar and header were lined up with the arrow on dictionary listings to indicate the selected listing. This looks horrible on small screens due to the search bar being exactly on the edge of the screen on the left side.

Now, the search bar and header line up with the dictionary listings themselves instead of having a negative offset. 