### PR TITLE
Added Details and Summary tags to Structured Content

### DIFF
--- a/dev/data/structured-content-overrides.css
+++ b/dev/data/structured-content-overrides.css
@@ -75,3 +75,9 @@
 :root[data-glossary-layout-mode=compact] .gloss-sc-ul[data-sc-content=glossary] .gloss-sc-li:not(:first-child)::before {
     /* remove-rule */
 }
+.gloss-sc-details {
+    /* remove-rule */
+}
+.gloss-sc-summary {
+    /* remove-rule */
+}

--- a/ext/css/structured-content.css
+++ b/ext/css/structured-content.css
@@ -254,3 +254,12 @@
     display: inline;
     color: var(--text-color-light3);
 }
+.gloss-sc-details {
+    cursor: pointer;
+    padding-left: var(--list-padding2);
+    border-top: calc(1em / var(--font-size-no-units)) solid var(--medium-border-color);
+    border-bottom: calc(1em / var(--font-size-no-units)) solid var(--medium-border-color);
+}
+.gloss-sc-summary {
+    list-style-position: outside;
+}

--- a/ext/data/schemas/dictionary-term-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-bank-v3-schema.json
@@ -104,7 +104,7 @@
                             "properties": {
                                 "tag": {
                                     "type": "string",
-                                    "enum": ["span", "div", "ol", "ul", "li"]
+                                    "enum": ["span", "div", "ol", "ul", "li", "details", "summary"]
                                 },
                                 "content": {
                                     "$ref": "#/definitions/structuredContent"

--- a/ext/js/display/structured-content-generator.js
+++ b/ext/js/display/structured-content-generator.js
@@ -275,6 +275,8 @@ export class StructuredContentGenerator {
             case 'ol':
             case 'ul':
             case 'li':
+            case 'details':
+            case 'summary':
                 return this._createStructuredContentElement(tag, content, dictionary, language, 'simple', true, true);
             case 'img':
                 return this.createDefinitionImage(content, dictionary);

--- a/types/ext/structured-content.d.ts
+++ b/types/ext/structured-content.d.ts
@@ -122,7 +122,7 @@ export type TableElement = {
 };
 
 export type StyledElement = {
-    tag: 'span' | 'div' | 'ol' | 'ul' | 'li';
+    tag: 'span' | 'div' | 'ol' | 'ul' | 'li' | 'details' | 'summary';
     content?: Content;
     data?: Data;
     style?: StructuredContentStyle;


### PR DESCRIPTION
I added "details" and "summary" tags to what could be added to dictionary structured content so that there could be expandable information on word entries.

The only controversial part (I think) could be the default CSS I added, but I think it helps to delineate the expandable details tag from the rest of the content.