### PR TITLE
Revert cardinalby/webext-buildtools-firefox-sign-xpi-action

### DIFF
--- a/.github/workflows/publish-firefox-development.yml
+++ b/.github/workflows/publish-firefox-development.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Sign Firefox xpi for offline distribution
         id: ffSignXpi
         continue-on-error: true
-        uses: cardinalby/webext-buildtools-firefox-sign-xpi-action@ed44ff06ca9eae47ac45dd34b12833379b683c78 # pin@v1.0.7
+        uses: cardinalby/webext-buildtools-firefox-sign-xpi-action@94a2e58141e33c4306a72a93f191e8540189df92 # pin@v1.0.6
         with:
           timeoutMs: 1200000
           extensionId: ${{ secrets.FF_OFFLINE_EXT_ID }}


### PR DESCRIPTION
cardinalby/webext-buildtools-firefox-sign-xpi-action v1.0.7 is problematic see https://github.com/themoeway/yomitan/actions/runs/8765698303

Partial revert of #798