### PR TITLE
Fix definition.cloze and text-based getMedia in handlebars being escaped

### DIFF
--- a/ext/data/templates/anki-field-templates-upgrade-v33.handlebars
+++ b/ext/data/templates/anki-field-templates-upgrade-v33.handlebars
@@ -57,3 +57,13 @@
     {{~#if (hasMedia "clipboardText")}}{{{getMedia "clipboardText"}}}{{/if~}}
 {{/inline}}
 {{>>>>>>>}}
+
+{{<<<<<<<}}
+{{#*inline "selection-text"}}
+    {{~#if (hasMedia "selectionText")}}{{getMedia "selectionText"}}{{/if~}}
+{{/inline}}
+{{=======}}
+{{#*inline "selection-text"}}
+    {{~#if (hasMedia "selectionText")}}{{{getMedia "selectionText"}}}{{/if~}}
+{{/inline}}
+{{>>>>>>>}}

--- a/ext/data/templates/anki-field-templates-upgrade-v33.handlebars
+++ b/ext/data/templates/anki-field-templates-upgrade-v33.handlebars
@@ -1,0 +1,49 @@
+{{<<<<<<<}}
+{{#*inline "sentence"}}
+    {{~#if definition.cloze}}{{definition.cloze.sentence}}{{/if~}}
+{{/inline}}
+{{=======}}
+{{#*inline "sentence"}}
+    {{~#if definition.cloze}}{{{definition.cloze.sentence}}}{{/if~}}
+{{/inline}}
+{{>>>>>>>}}
+
+{{<<<<<<<}}
+{{#*inline "cloze-prefix"}}
+    {{~#if definition.cloze}}{{definition.cloze.prefix}}{{/if~}}
+{{/inline}}
+{{=======}}
+{{#*inline "cloze-prefix"}}
+    {{~#if definition.cloze}}{{{definition.cloze.prefix}}}{{/if~}}
+{{/inline}}
+{{>>>>>>>}}
+
+{{<<<<<<<}}
+{{#*inline "cloze-body"}}
+    {{~#if definition.cloze}}{{definition.cloze.body}}{{/if~}}
+{{/inline}}
+{{=======}}
+{{#*inline "cloze-body"}}
+    {{~#if definition.cloze}}{{{definition.cloze.body}}}{{/if~}}
+{{/inline}}
+{{>>>>>>>}}
+
+{{<<<<<<<}}
+{{#*inline "cloze-body-kana"}}
+    {{~#if definition.cloze}}{{definition.cloze.bodyKana}}{{/if~}}
+{{/inline}}
+{{=======}}
+{{#*inline "cloze-body-kana"}}
+    {{~#if definition.cloze}}{{{definition.cloze.bodyKana}}}{{/if~}}
+{{/inline}}
+{{>>>>>>>}}
+
+{{<<<<<<<}}
+{{#*inline "cloze-suffix"}}
+    {{~#if definition.cloze}}{{definition.cloze.suffix}}{{/if~}}
+{{/inline}}
+{{=======}}
+{{#*inline "cloze-suffix"}}
+    {{~#if definition.cloze}}{{{definition.cloze.suffix}}}{{/if~}}
+{{/inline}}
+{{>>>>>>>}}

--- a/ext/data/templates/anki-field-templates-upgrade-v33.handlebars
+++ b/ext/data/templates/anki-field-templates-upgrade-v33.handlebars
@@ -47,3 +47,13 @@
     {{~#if definition.cloze}}{{{definition.cloze.suffix}}}{{/if~}}
 {{/inline}}
 {{>>>>>>>}}
+
+{{<<<<<<<}}
+{{#*inline "clipboard-text"}}
+    {{~#if (hasMedia "clipboardText")}}{{getMedia "clipboardText"}}{{/if~}}
+{{/inline}}
+{{=======}}
+{{#*inline "clipboard-text"}}
+    {{~#if (hasMedia "clipboardText")}}{{{getMedia "clipboardText"}}}{{/if~}}
+{{/inline}}
+{{>>>>>>>}}

--- a/ext/data/templates/default-anki-field-templates.handlebars
+++ b/ext/data/templates/default-anki-field-templates.handlebars
@@ -269,7 +269,7 @@
 {{/inline}}
 
 {{#*inline "clipboard-text"}}
-    {{~#if (hasMedia "clipboardText")}}{{getMedia "clipboardText"}}{{/if~}}
+    {{~#if (hasMedia "clipboardText")}}{{{getMedia "clipboardText"}}}{{/if~}}
 {{/inline}}
 
 {{#*inline "conjugation"}}

--- a/ext/data/templates/default-anki-field-templates.handlebars
+++ b/ext/data/templates/default-anki-field-templates.handlebars
@@ -393,7 +393,7 @@
 {{/inline}}
 
 {{#*inline "selection-text"}}
-    {{~#if (hasMedia "selectionText")}}{{getMedia "selectionText"}}{{/if~}}
+    {{~#if (hasMedia "selectionText")}}{{{getMedia "selectionText"}}}{{/if~}}
 {{/inline}}
 
 {{#*inline "sentence-furigana"}}

--- a/ext/data/templates/default-anki-field-templates.handlebars
+++ b/ext/data/templates/default-anki-field-templates.handlebars
@@ -149,23 +149,23 @@
 {{/inline}}
 
 {{#*inline "sentence"}}
-    {{~#if definition.cloze}}{{definition.cloze.sentence}}{{/if~}}
+    {{~#if definition.cloze}}{{{definition.cloze.sentence}}}{{/if~}}
 {{/inline}}
 
 {{#*inline "cloze-prefix"}}
-    {{~#if definition.cloze}}{{definition.cloze.prefix}}{{/if~}}
+    {{~#if definition.cloze}}{{{definition.cloze.prefix}}}{{/if~}}
 {{/inline}}
 
 {{#*inline "cloze-body"}}
-    {{~#if definition.cloze}}{{definition.cloze.body}}{{/if~}}
+    {{~#if definition.cloze}}{{{definition.cloze.body}}}{{/if~}}
 {{/inline}}
 
 {{#*inline "cloze-body-kana"}}
-    {{~#if definition.cloze}}{{definition.cloze.bodyKana}}{{/if~}}
+    {{~#if definition.cloze}}{{{definition.cloze.bodyKana}}}{{/if~}}
 {{/inline}}
 
 {{#*inline "cloze-suffix"}}
-    {{~#if definition.cloze}}{{definition.cloze.suffix}}{{/if~}}
+    {{~#if definition.cloze}}{{{definition.cloze.suffix}}}{{/if~}}
 {{/inline}}
 
 {{#*inline "tags"}}

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -538,7 +538,8 @@ export class OptionsUtil {
             this._updateVersion29,
             this._updateVersion30,
             this._updateVersion31,
-            this._updateVersion32
+            this._updateVersion32,
+            this._updateVersion33
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1258,6 +1259,13 @@ export class OptionsUtil {
         }
     }
 
+    /**
+     * - Updated handlebars to fix escaping when using `definition.cloze`.
+     * @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion33(options) {
+        await this._applyAnkiFieldTemplatesPatch(options, '/data/templates/anki-field-templates-upgrade-v33.handlebars');
+    }
 
     /**
      * @param {string} url

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -1260,7 +1260,7 @@ export class OptionsUtil {
     }
 
     /**
-     * - Updated handlebars to fix escaping when using `definition.cloze`.
+     * - Updated handlebars to fix escaping when using `definition.cloze` or text-based `getMedia`.
      * @type {import('options-util').UpdateFunction}
      */
     async _updateVersion33(options) {

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -1747,6 +1747,10 @@ describe('OptionsUtil', () => {
 {{#*inline "cloze-suffix"}}
     {{~#if definition.cloze}}{{definition.cloze.suffix}}{{/if~}}
 {{/inline}}
+
+{{#*inline "clipboard-text"}}
+    {{~#if (hasMedia "clipboardText")}}{{getMedia "clipboardText"}}{{/if~}}
+{{/inline}}
 `.trimStart(),
 
                 expected: `
@@ -1768,6 +1772,10 @@ describe('OptionsUtil', () => {
 
 {{#*inline "cloze-suffix"}}
     {{~#if definition.cloze}}{{{definition.cloze.suffix}}}{{/if~}}
+{{/inline}}
+
+{{#*inline "clipboard-text"}}
+    {{~#if (hasMedia "clipboardText")}}{{{getMedia "clipboardText"}}}{{/if~}}
 {{/inline}}
 `.trimStart()
             }

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -1751,6 +1751,10 @@ describe('OptionsUtil', () => {
 {{#*inline "clipboard-text"}}
     {{~#if (hasMedia "clipboardText")}}{{getMedia "clipboardText"}}{{/if~}}
 {{/inline}}
+
+{{#*inline "selection-text"}}
+    {{~#if (hasMedia "selectionText")}}{{getMedia "selectionText"}}{{/if~}}
+{{/inline}}
 `.trimStart(),
 
                 expected: `
@@ -1776,6 +1780,10 @@ describe('OptionsUtil', () => {
 
 {{#*inline "clipboard-text"}}
     {{~#if (hasMedia "clipboardText")}}{{{getMedia "clipboardText"}}}{{/if~}}
+{{/inline}}
+
+{{#*inline "selection-text"}}
+    {{~#if (hasMedia "selectionText")}}{{{getMedia "selectionText"}}}{{/if~}}
 {{/inline}}
 `.trimStart()
             }

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -605,7 +605,7 @@ function createOptionsUpdatedTestData1() {
             }
         ],
         profileCurrent: 0,
-        version: 32,
+        version: 33,
         global: {
             database: {
                 prefixWildcardsSupported: false
@@ -1721,6 +1721,53 @@ describe('OptionsUtil', () => {
             {{{definition.cloze.sentence}}}
         {{~/if~}}
     {{~/if~}}
+{{/inline}}
+`.trimStart()
+            },
+            {
+                oldVersion: 32,
+                newVersion: 33,
+                old: `
+{{#*inline "sentence"}}
+    {{~#if definition.cloze}}{{definition.cloze.sentence}}{{/if~}}
+{{/inline}}
+
+{{#*inline "cloze-prefix"}}
+    {{~#if definition.cloze}}{{definition.cloze.prefix}}{{/if~}}
+{{/inline}}
+
+{{#*inline "cloze-body"}}
+    {{~#if definition.cloze}}{{definition.cloze.body}}{{/if~}}
+{{/inline}}
+
+{{#*inline "cloze-body-kana"}}
+    {{~#if definition.cloze}}{{definition.cloze.bodyKana}}{{/if~}}
+{{/inline}}
+
+{{#*inline "cloze-suffix"}}
+    {{~#if definition.cloze}}{{definition.cloze.suffix}}{{/if~}}
+{{/inline}}
+`.trimStart(),
+
+                expected: `
+{{#*inline "sentence"}}
+    {{~#if definition.cloze}}{{{definition.cloze.sentence}}}{{/if~}}
+{{/inline}}
+
+{{#*inline "cloze-prefix"}}
+    {{~#if definition.cloze}}{{{definition.cloze.prefix}}}{{/if~}}
+{{/inline}}
+
+{{#*inline "cloze-body"}}
+    {{~#if definition.cloze}}{{{definition.cloze.body}}}{{/if~}}
+{{/inline}}
+
+{{#*inline "cloze-body-kana"}}
+    {{~#if definition.cloze}}{{{definition.cloze.bodyKana}}}{{/if~}}
+{{/inline}}
+
+{{#*inline "cloze-suffix"}}
+    {{~#if definition.cloze}}{{{definition.cloze.suffix}}}{{/if~}}
 {{/inline}}
 `.trimStart()
             }


### PR DESCRIPTION
Turns out there were some other handlebars that needed fixing besides `{sentence-furigana}` #733

The output of definition.cloze needs to not be escaped. This requires using `{{{ }}}` syntax. https://handlebarsjs.com/guide/expressions.html#html-escaping

Text-based `getMedia` also should not be escaped (`{clipboard-text}` and `{selection-text}`).

Fixes #856