### PR TITLE
Fix Term display style and Reading mode css conflict

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -951,9 +951,6 @@ button.action-button:active {
 :root[data-term-display-mode=term-only] .headword-term>ruby>rt {
     display: none;
 }
-:root[data-term-display-mode=term-only] .query-parser-term>ruby>rt {
-    display: none;
-}
 
 
 /* Entry indicator */


### PR DESCRIPTION
In #862 I added css to remove the furigana on the query parser term when `Term display style` was set to Plain term. This created a conflict with the `Reading mode` setting which is what is supposed to control the query-parser-term styling instead.

This PR reverts `Term display style` to only controlling the headword-term and headword-reading. This does not revert any previously added functionality but currently the settings to get the behavior where the query-parser-term furigana is hidden are positioned horribly, #884 will fix that.