### PR TITLE
Fix mobile action-popup

### DIFF
--- a/ext/action-popup.html
+++ b/ext/action-popup.html
@@ -18,7 +18,7 @@
 
 <div id="mini">
     <label class="toggle">
-        <input type="checkbox" id="enable-search">
+        <input type="checkbox" class="enable-search">
         <div class="toggle-group">
             <span class="toggle-on">On</span>
             <span class="toggle-off">Off</span>
@@ -57,8 +57,13 @@
 
 <div id="full">
     <h3 id="extension-info">Yomitan</h3>
-    <label class="link-group">
-        <span class="link-group-icon"><input type="checkbox" id="enable-search2"></span><span class="link-group-label">Enable content scanning</span>
+    <label class="toggle">
+        <input type="checkbox" class="enable-search">
+        <div class="toggle-group">
+            <span class="toggle-on">On</span>
+            <span class="toggle-off">Off</span>
+            <span class="toggle-handle"></span>
+        </div>
     </label>
     <a tabindex="0" class="link-group action-open-settings">
         <span class="link-group-icon" data-icon="chevron"></span>

--- a/ext/action-popup.html
+++ b/ext/action-popup.html
@@ -66,24 +66,24 @@
         </div>
     </label>
     <a tabindex="0" class="link-group action-open-settings">
-        <span class="link-group-icon" data-icon="chevron"></span>
+        <span class="link-group-icon" data-icon="cog"></span>
         <span class="link-group-label">Settings</span>
         <span class="link-group-badge">
             <div class="flex-margin-left warning-badge no-dictionaries-enabled-warning" hidden><span class="icon" data-icon="exclamation-point-short"></span></div>
         </span>
     </a>
     <a tabindex="0" class="link-group action-open-permissions" hidden>
-        <span class="link-group-icon" data-icon="chevron"></span>
+        <span class="link-group-icon" data-icon="key"></span>
         <span class="link-group-label">Permissions</span>
         <span class="link-group-badge">
             <div class="flex-margin-left warning-badge permissions-required-warning" hidden><span class="icon" data-icon="exclamation-point-short"></span></div>
         </span>
     </a>
     <a tabindex="0" class="link-group action-open-search">
-        <span class="link-group-icon" data-icon="chevron"></span><span class="link-group-label">Search</span>
+        <span class="link-group-icon" data-icon="magnifying-glass"></span><span class="link-group-label">Search</span>
     </a>
     <a tabindex="0" class="link-group action-open-info">
-        <span class="link-group-icon" data-icon="chevron"></span><span class="link-group-label">Information</span>
+        <span class="link-group-icon" data-icon="question-mark-circle"></span><span class="link-group-label">Information</span>
     </a>
 </div>
 

--- a/ext/css/action-popup.css
+++ b/ext/css/action-popup.css
@@ -35,6 +35,7 @@ body {
     font-family: 'Segoe UI', Tahoma, sans-serif;
     font-size: var(--font-size);
     width: max-content;
+    height: max-content;
 }
 
 h3 {
@@ -165,14 +166,13 @@ label {
 }
 .toggle {
     box-sizing: border-box;
-    width: 60px;
-    height: 34px;
+    width: 100%;
+    padding-top: 37.7%;
     position: relative;
     overflow: hidden;
     border: 1px solid #245580;
     border-radius: 4px;
     display: inline-block;
-    padding: 6px 12px;
 }
 .toggle-group {
     position: absolute;
@@ -189,7 +189,9 @@ body[data-loaded=true] .toggle-group {
 .toggle-on,
 .toggle-off,
 .toggle-handle {
-    display: block;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     padding: 6px 12px;
     font-size: var(--font-size);
     font-weight: normal;
@@ -463,4 +465,27 @@ select.profile-select {
     right: 0;
     bottom: 0;
     background-color: var(--warning-color);
+}
+
+/* Mobile overrides */
+
+/* Treat devices that can't hover as mobile devices */
+@media (hover: none) {
+    #full {
+        display: initial;
+    }
+    #mini {
+        display: none;
+    }
+    body {
+        width: 95%;
+        font-size: calc(var(--font-size) * 2);
+        text-align: center;
+    }
+    h3 {
+        font-size: calc(var(--font-size) * 3.4);
+    }
+    .toggle-on, .toggle-off, .toggle-handle {
+        font-size: calc(var(--font-size) * 4);
+    }
 }

--- a/ext/css/action-popup.css
+++ b/ext/css/action-popup.css
@@ -478,7 +478,8 @@ select.profile-select {
         display: none;
     }
     body {
-        width: 95%;
+        min-width: 95%;
+        width: max-content;
         font-size: calc(var(--font-size) * 2);
         text-align: center;
     }

--- a/ext/css/action-popup.css
+++ b/ext/css/action-popup.css
@@ -129,21 +129,19 @@ label {
     vertical-align: middle;
     display: inline-block;
     margin-right: 0.25em;
+    background-repeat: no-repeat;
+    background-size: contain;
 }
 .link-group-icon>input {
     margin: 0;
     padding: 0;
 }
-.link-group-icon[data-icon=chevron]::after {
-    content: '';
-    display: block;
-    width: 100%;
-    height: 100%;
-    background-image: url(/images/right-chevron.svg);
-    background-repeat: no-repeat;
-    background-position: center center;
-    background-size: contain;
-}
+.link-group-icon[data-icon=chevron] { background-image: url(/images/right-chevron.svg); }
+.link-group-icon[data-icon=cog] { background-image: url(/images/cog.svg); }
+.link-group-icon[data-icon=key] { background-image: url(/images/key.svg); }
+.link-group-icon[data-icon=magnifying-glass] { background-image: url(/images/magnifying-glass.svg); }
+.link-group-icon[data-icon=question-mark-circle] { background-image: url(/images/question-mark-circle.svg); }
+
 .link-group-label {
     vertical-align: middle;
 }

--- a/ext/css/action-popup.css
+++ b/ext/css/action-popup.css
@@ -123,8 +123,8 @@ label {
     background-color: rgba(0, 0, 0, 0.1);
 }
 .link-group-icon {
-    width: 16px;
-    height: 16px;
+    width: 26px;
+    height: 26px;
     text-align: center;
     vertical-align: middle;
     display: inline-block;
@@ -485,7 +485,12 @@ select.profile-select {
     h3 {
         font-size: calc(var(--font-size) * 3.4);
     }
-    .toggle-on, .toggle-off, .toggle-handle {
+    .toggle-on, .toggle-off {
         font-size: calc(var(--font-size) * 4);
+    }
+    .toggle-handle {
+        padding-left: 65px;
+        padding-right: 65px;
+        border-radius: 10px;
     }
 }

--- a/ext/js/pages/action-popup-main.js
+++ b/ext/js/pages/action-popup-main.js
@@ -187,7 +187,7 @@ class DisplayController {
     _setupOptions({options}) {
         const extensionEnabled = options.general.enable;
         const onToggleChanged = () => this._api.commandExec('toggleTextScanning');
-        for (const toggle of /** @type {NodeListOf<HTMLInputElement>} */ (document.querySelectorAll('#enable-search,#enable-search2'))) {
+        for (const toggle of /** @type {NodeListOf<HTMLInputElement>} */ (document.querySelectorAll('.enable-search,.enable-search2'))) {
             toggle.checked = extensionEnabled;
             toggle.addEventListener('change', onToggleChanged, false);
         }


### PR DESCRIPTION
Tested on Firefox android, Kiwi browser, and Chromium desktop (to verify it only displays on mobile).

This does not affect the look of the desktop popup even though some values have been changed there it matches exactly.

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/themoeway/yomitan/assets/61125188/12eb3ec7-bacd-4051-8483-712b1bf08b05) | ![Screenshot_20240506-113352](https://github.com/themoeway/yomitan/assets/61125188/065e15a8-fa45-4ee3-b679-e20d0b060e62)
