### PR TITLE
add source and target language dictionary metadata

### DIFF
--- a/ext/data/schemas/dictionary-index-schema.json
+++ b/ext/data/schemas/dictionary-index-schema.json
@@ -47,6 +47,14 @@
             "type": "string",
             "description": "Attribution information for the dictionary data."
         },
+        "sourceLanguage": {
+            "type": "string",
+            "description": "Language of the terms in the dictionary."
+        },
+        "targetLanguage": {
+            "type": "string",
+            "description": "Main language of the definitions in the dictionary."
+        },
         "frequencyMode": {
             "type": "string",
             "enum": ["occurrence-based", "rank-based"]

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -285,12 +285,14 @@ export class DictionaryImporter {
             counts
         };
 
-        const {author, url, description, attribution, frequencyMode} = index;
+        const {author, url, description, attribution, frequencyMode, sourceLanguage, targetLanguage} = index;
         if (typeof author === 'string') { summary.author = author; }
         if (typeof url === 'string') { summary.url = url; }
         if (typeof description === 'string') { summary.description = description; }
         if (typeof attribution === 'string') { summary.attribution = attribution; }
         if (typeof frequencyMode === 'string') { summary.frequencyMode = frequencyMode; }
+        if (typeof sourceLanguage === 'string') { summary.sourceLanguage = sourceLanguage; }
+        if (typeof targetLanguage === 'string') { summary.targetLanguage = targetLanguage; }
 
         return summary;
     }

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -211,12 +211,14 @@ class DictionaryEntry {
      * @returns {boolean}
      */
     _setupDetails(detailsTable) {
-        /** @type {[label: string, key: 'author'|'url'|'description'|'attribution'][]} */
+        /** @type {[label: string, key: 'author'|'url'|'description'|'attribution'|'sourceLanguage'|'targetLanguage'][]} */
         const targets = [
             ['Author', 'author'],
             ['URL', 'url'],
             ['Description', 'description'],
-            ['Attribution', 'attribution']
+            ['Attribution', 'attribution'],
+            ['Source Language', 'sourceLanguage'],
+            ['Target Language', 'targetLanguage']
         ];
 
         const dictionaryInfo = this._dictionaryInfo;

--- a/types/ext/dictionary-data.d.ts
+++ b/types/ext/dictionary-data.d.ts
@@ -29,6 +29,8 @@ export type Index = {
     url?: string;
     description?: string;
     attribution?: string;
+    sourceLanguage?: string;
+    targetLanguage?: string;
     frequencyMode?: 'occurrence-based' | 'rank-based';
     tagMeta?: IndexTagMeta;
 };

--- a/types/ext/dictionary-importer.d.ts
+++ b/types/ext/dictionary-importer.d.ts
@@ -65,6 +65,8 @@ export type Summary = {
     url?: string;
     description?: string;
     attribution?: string;
+    sourceLanguage?: string;
+    targetLanguage?: string;
     frequencyMode?: 'occurrence-based' | 'rank-based';
 };
 


### PR DESCRIPTION
![image](https://github.com/themoeway/yomitan/assets/24891609/4647a821-804d-4009-a726-c5bb21fa4c84)

This is just displaying them like the rest of the metadata, but I think it may also be useful in the future for

- installing dicts from URL
- organizing dict (like #796)
- maybe new handlebars for all dicts of a language