### PR TITLE
Change Details and Summary Tags CSS

### DIFF
--- a/dev/data/structured-content-overrides.css
+++ b/dev/data/structured-content-overrides.css
@@ -81,3 +81,6 @@
 .gloss-sc-summary {
     /* remove-rule */
 }
+.gloss-sc-details[open] .gloss-sc-summary {
+    /* remove-rule */
+}

--- a/ext/css/structured-content.css
+++ b/ext/css/structured-content.css
@@ -255,11 +255,11 @@
     color: var(--text-color-light3);
 }
 .gloss-sc-details {
-    cursor: pointer;
-    padding-left: var(--list-padding2);
-    border-top: calc(1em / var(--font-size-no-units)) solid var(--medium-border-color);
     border-bottom: calc(1em / var(--font-size-no-units)) solid var(--medium-border-color);
 }
 .gloss-sc-summary {
     list-style-position: outside;
+}
+.gloss-sc-details[open] .gloss-sc-summary {
+    border-bottom: calc(1em / var(--font-size-no-units)) solid var(--medium-border-color);
 }


### PR DESCRIPTION
I edited the CSS a bit so that it looks more pleasing. Before, if there were many details next to each other the grey lines would overlap and it looked quite bad. Here are example pictures:
![1715204781](https://github.com/themoeway/yomitan/assets/18152455/265d77f0-0ab2-403e-8f69-e789f07613fc)
![1715204794](https://github.com/themoeway/yomitan/assets/18152455/7dd6c1fb-c036-40db-b391-16e9044d201e)
