### PR TITLE
Make Scan selected text lazy and add Scan text at selection

### DIFF
--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -257,21 +257,21 @@ export class Frontend {
      * @returns {void}
      */
     _onActionScanSelectedText() {
-        void this._scanSelectedText(false, true);
+        void this._scanSelectedText({allowEmptyRange: false, disallowExpandSelection: true});
     }
 
     /**
      * @returns {void}
      */
     _onActionScanTextAtSelection() {
-        void this._scanSelectedText(false, false);
+        void this._scanSelectedText({allowEmptyRange: false, disallowExpandSelection: false});
     }
 
     /**
      * @returns {void}
      */
     _onActionScanTextAtCaret() {
-        void this._scanSelectedText(true, false);
+        void this._scanSelectedText({allowEmptyRange: true, disallowExpandSelection: false});
     }
 
     // API message handlers
@@ -926,11 +926,12 @@ export class Frontend {
     }
 
     /**
-     * @param {boolean} allowEmptyRange
-     * @param {boolean} disallowExpandSelection
+     * @param {object} params
+     * @param {boolean} params.allowEmptyRange
+     * @param {boolean} params.disallowExpandSelection
      * @returns {Promise<boolean>}
      */
-    async _scanSelectedText(allowEmptyRange, disallowExpandSelection) {
+    async _scanSelectedText({allowEmptyRange, disallowExpandSelection}) {
         const range = this._getFirstSelectionRange(allowEmptyRange);
         if (range === null) { return false; }
         const source = disallowExpandSelection ? TextSourceRange.createLazy(range) : TextSourceRange.create(range);

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -257,21 +257,21 @@ export class Frontend {
      * @returns {void}
      */
     _onActionScanSelectedText() {
-        void this._scanSelectedText({allowEmptyRange: false, disallowExpandSelection: true});
+        void this._scanSelectedText(false, true);
     }
 
     /**
      * @returns {void}
      */
     _onActionScanTextAtSelection() {
-        void this._scanSelectedText({allowEmptyRange: false, disallowExpandSelection: false});
+        void this._scanSelectedText(false, false);
     }
 
     /**
      * @returns {void}
      */
     _onActionScanTextAtCaret() {
-        void this._scanSelectedText({allowEmptyRange: true, disallowExpandSelection: false});
+        void this._scanSelectedText(true, false);
     }
 
     // API message handlers
@@ -926,12 +926,11 @@ export class Frontend {
     }
 
     /**
-     * @param {object} params
-     * @param {boolean} params.allowEmptyRange
-     * @param {boolean} params.disallowExpandSelection
+     * @param {boolean} allowEmptyRange
+     * @param {boolean} disallowExpandSelection
      * @returns {Promise<boolean>}
      */
-    async _scanSelectedText({allowEmptyRange, disallowExpandSelection}) {
+    async _scanSelectedText(allowEmptyRange, disallowExpandSelection) {
         const range = this._getFirstSelectionRange(allowEmptyRange);
         if (range === null) { return false; }
         const source = disallowExpandSelection ? TextSourceRange.createLazy(range) : TextSourceRange.create(range);

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -119,6 +119,7 @@ export class Frontend {
 
         this._hotkeyHandler.registerActions([
             ['scanSelectedText', this._onActionScanSelectedText.bind(this)],
+            ['scanSelectedTextLazy', this._onActionScanSelectedTextLazy.bind(this)],
             ['scanTextAtCaret',  this._onActionScanTextAtCaret.bind(this)]
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
@@ -256,14 +257,21 @@ export class Frontend {
      * @returns {void}
      */
     _onActionScanSelectedText() {
-        void this._scanSelectedText(false);
+        void this._scanSelectedText(false, false);
+    }
+
+    /**
+     * @returns {void}
+     */
+    _onActionScanSelectedTextLazy() {
+        void this._scanSelectedText(false, true);
     }
 
     /**
      * @returns {void}
      */
     _onActionScanTextAtCaret() {
-        void this._scanSelectedText(true);
+        void this._scanSelectedText(true, false);
     }
 
     // API message handlers
@@ -919,12 +927,13 @@ export class Frontend {
 
     /**
      * @param {boolean} allowEmptyRange
+     * @param {boolean} lazy
      * @returns {Promise<boolean>}
      */
-    async _scanSelectedText(allowEmptyRange) {
+    async _scanSelectedText(allowEmptyRange, lazy) {
         const range = this._getFirstSelectionRange(allowEmptyRange);
         if (range === null) { return false; }
-        const source = TextSourceRange.create(range);
+        const source = lazy ? TextSourceRange.createLazy(range) : TextSourceRange.create(range);
         await this._textScanner.search(source, {focus: true, restoreSelection: true});
         return true;
     }

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -927,13 +927,13 @@ export class Frontend {
 
     /**
      * @param {boolean} allowEmptyRange
-     * @param {boolean} lazy
+     * @param {boolean} disallowExpandSelection
      * @returns {Promise<boolean>}
      */
-    async _scanSelectedText(allowEmptyRange, lazy) {
+    async _scanSelectedText(allowEmptyRange, disallowExpandSelection) {
         const range = this._getFirstSelectionRange(allowEmptyRange);
         if (range === null) { return false; }
-        const source = lazy ? TextSourceRange.createLazy(range) : TextSourceRange.create(range);
+        const source = disallowExpandSelection ? TextSourceRange.createLazy(range) : TextSourceRange.create(range);
         await this._textScanner.search(source, {focus: true, restoreSelection: true});
         return true;
     }

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -119,7 +119,7 @@ export class Frontend {
 
         this._hotkeyHandler.registerActions([
             ['scanSelectedText', this._onActionScanSelectedText.bind(this)],
-            ['scanSelectedTextLazy', this._onActionScanSelectedTextLazy.bind(this)],
+            ['scanTextAtSelection', this._onActionScanTextAtSelection.bind(this)],
             ['scanTextAtCaret',  this._onActionScanTextAtCaret.bind(this)]
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
@@ -257,14 +257,14 @@ export class Frontend {
      * @returns {void}
      */
     _onActionScanSelectedText() {
-        void this._scanSelectedText(false, false);
+        void this._scanSelectedText(false, true);
     }
 
     /**
      * @returns {void}
      */
-    _onActionScanSelectedTextLazy() {
-        void this._scanSelectedText(false, true);
+    _onActionScanTextAtSelection() {
+        void this._scanSelectedText(false, false);
     }
 
     /**

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -42,9 +42,9 @@ export class TextSourceRange {
      * @param {?DOMRect} cachedSourceRect A cached `DOMRect` representing the rect of the `imposterSourceElement`,
      *   which can be used after the imposter element is removed from the page.
      *   Must not be `null` if imposterElement is specified.
-     * @param {boolean} selectContentLazy
+     * @param {boolean} disallowExpandSelection
      */
-    constructor(range, rangeStartOffset, content, imposterElement, imposterSourceElement, cachedRects, cachedSourceRect, selectContentLazy) {
+    constructor(range, rangeStartOffset, content, imposterElement, imposterSourceElement, cachedRects, cachedSourceRect, disallowExpandSelection) {
         /** @type {Range} */
         this._range = range;
         /** @type {number} */
@@ -60,7 +60,7 @@ export class TextSourceRange {
         /** @type {?DOMRect} */
         this._cachedSourceRect = cachedSourceRect;
         /** @type {boolean} */
-        this._selectContentLazy = selectContentLazy;
+        this._disallowExpandSelection = disallowExpandSelection;
     }
 
     /**
@@ -108,7 +108,7 @@ export class TextSourceRange {
             this._imposterSourceElement,
             this._cachedRects,
             this._cachedSourceRect,
-            this._selectContentLazy
+            this._disallowExpandSelection
         );
     }
 
@@ -150,7 +150,7 @@ export class TextSourceRange {
         const state = new DOMTextScanner(node, offset, !layoutAwareScan, layoutAwareScan).seek(length);
         this._range.setEnd(state.node, state.offset);
         const expandedContent = fromEnd ? this._content + state.content : state.content;
-        this._content = this._selectContentLazy ? expandedContent : this._content;
+        this._content = this._disallowExpandSelection ? expandedContent : this._content;
         return length - state.remainder;
     }
 

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -42,8 +42,9 @@ export class TextSourceRange {
      * @param {?DOMRect} cachedSourceRect A cached `DOMRect` representing the rect of the `imposterSourceElement`,
      *   which can be used after the imposter element is removed from the page.
      *   Must not be `null` if imposterElement is specified.
+     * @param {boolean} selectContentLazy
      */
-    constructor(range, rangeStartOffset, content, imposterElement, imposterSourceElement, cachedRects, cachedSourceRect) {
+    constructor(range, rangeStartOffset, content, imposterElement, imposterSourceElement, cachedRects, cachedSourceRect, selectContentLazy) {
         /** @type {Range} */
         this._range = range;
         /** @type {number} */
@@ -58,6 +59,8 @@ export class TextSourceRange {
         this._cachedRects = cachedRects;
         /** @type {?DOMRect} */
         this._cachedSourceRect = cachedSourceRect;
+        /** @type {boolean} */
+        this._selectContentLazy = selectContentLazy;
     }
 
     /**
@@ -104,7 +107,8 @@ export class TextSourceRange {
             this._imposterElement,
             this._imposterSourceElement,
             this._cachedRects,
-            this._cachedSourceRect
+            this._cachedSourceRect,
+            this._selectContentLazy
         );
     }
 
@@ -145,7 +149,8 @@ export class TextSourceRange {
         }
         const state = new DOMTextScanner(node, offset, !layoutAwareScan, layoutAwareScan).seek(length);
         this._range.setEnd(state.node, state.offset);
-        this._content = (fromEnd ? this._content + state.content : state.content);
+        const expandedContent = fromEnd ? this._content + state.content : state.content;
+        this._content = this._selectContentLazy ? expandedContent : this._content;
         return length - state.remainder;
     }
 
@@ -252,7 +257,16 @@ export class TextSourceRange {
      * @returns {TextSourceRange} A new instance of the class corresponding to the range.
      */
     static create(range) {
-        return new TextSourceRange(range, range.startOffset, range.toString(), null, null, null, null);
+        return new TextSourceRange(range, range.startOffset, range.toString(), null, null, null, null, true);
+    }
+
+    /**
+     * Creates a new instance for a given range without expanding the search.
+     * @param {Range} range The source range.
+     * @returns {TextSourceRange} A new instance of the class corresponding to the range.
+     */
+    static createLazy(range) {
+        return new TextSourceRange(range, range.startOffset, range.toString(), null, null, null, null, false);
     }
 
     /**
@@ -265,7 +279,7 @@ export class TextSourceRange {
     static createFromImposter(range, imposterElement, imposterSourceElement) {
         const cachedRects = convertMultipleRectZoomCoordinates(range.getClientRects(), range.startContainer);
         const cachedSourceRect = convertRectZoomCoordinates(imposterSourceElement.getBoundingClientRect(), imposterSourceElement);
-        return new TextSourceRange(range, range.startOffset, range.toString(), imposterElement, imposterSourceElement, cachedRects, cachedSourceRect);
+        return new TextSourceRange(range, range.startOffset, range.toString(), imposterElement, imposterSourceElement, cachedRects, cachedSourceRect, true);
     }
 
     /**

--- a/ext/js/pages/settings/keyboard-shortcuts-controller.js
+++ b/ext/js/pages/settings/keyboard-shortcuts-controller.js
@@ -69,6 +69,7 @@ export class KeyboardShortcutController {
             ['playAudioFromSource',              {scopes: new Set(['popup', 'search']), argument: {template: 'hotkey-argument-audio-source', default: 'jpod101'}}],
             ['copyHostSelection',                {scopes: new Set(['popup'])}],
             ['scanSelectedText',                 {scopes: new Set(['web'])}],
+            ['scanSelectedTextLazy',                 {scopes: new Set(['web'])}],
             ['scanTextAtCaret',                  {scopes: new Set(['web'])}],
             ['toggleOption',                     {scopes: new Set(['popup', 'search']), argument: {template: 'hotkey-argument-setting-path', default: ''}}]
         ]);

--- a/ext/js/pages/settings/keyboard-shortcuts-controller.js
+++ b/ext/js/pages/settings/keyboard-shortcuts-controller.js
@@ -69,7 +69,7 @@ export class KeyboardShortcutController {
             ['playAudioFromSource',              {scopes: new Set(['popup', 'search']), argument: {template: 'hotkey-argument-audio-source', default: 'jpod101'}}],
             ['copyHostSelection',                {scopes: new Set(['popup'])}],
             ['scanSelectedText',                 {scopes: new Set(['web'])}],
-            ['scanSelectedTextLazy',             {scopes: new Set(['web'])}],
+            ['scanTextAtSelection',              {scopes: new Set(['web'])}],
             ['scanTextAtCaret',                  {scopes: new Set(['web'])}],
             ['toggleOption',                     {scopes: new Set(['popup', 'search']), argument: {template: 'hotkey-argument-setting-path', default: ''}}]
         ]);

--- a/ext/js/pages/settings/keyboard-shortcuts-controller.js
+++ b/ext/js/pages/settings/keyboard-shortcuts-controller.js
@@ -69,7 +69,7 @@ export class KeyboardShortcutController {
             ['playAudioFromSource',              {scopes: new Set(['popup', 'search']), argument: {template: 'hotkey-argument-audio-source', default: 'jpod101'}}],
             ['copyHostSelection',                {scopes: new Set(['popup'])}],
             ['scanSelectedText',                 {scopes: new Set(['web'])}],
-            ['scanSelectedTextLazy',                 {scopes: new Set(['web'])}],
+            ['scanSelectedTextLazy',             {scopes: new Set(['web'])}],
             ['scanTextAtCaret',                  {scopes: new Set(['web'])}],
             ['toggleOption',                     {scopes: new Set(['popup', 'search']), argument: {template: 'hotkey-argument-setting-path', default: ''}}]
         ]);

--- a/ext/templates-settings.html
+++ b/ext/templates-settings.html
@@ -373,7 +373,7 @@
             <option value="playAudioFromSource">Play audio from source</option>
             <option value="copyHostSelection">Copy host window selection</option>
             <option value="scanSelectedText">Scan selected text</option>
-            <option value="scanSelectedTextLazy">Scan selected text lazy</option>
+            <option value="scanTextAtSelection">Scan text at selection</option>
             <option value="scanTextAtCaret">Scan text at caret</option>
             <option value="toggleOption">Toggle option</option>
         </select>

--- a/ext/templates-settings.html
+++ b/ext/templates-settings.html
@@ -373,6 +373,7 @@
             <option value="playAudioFromSource">Play audio from source</option>
             <option value="copyHostSelection">Copy host window selection</option>
             <option value="scanSelectedText">Scan selected text</option>
+            <option value="scanSelectedTextLazy">Scan selected text lazy</option>
             <option value="scanTextAtCaret">Scan text at caret</option>
             <option value="toggleOption">Toggle option</option>
         </select>


### PR DESCRIPTION
Currently, the `Scan selected text` keyboard shortcut ignores the selection if it finds a word bigger than the selection. It makes more sense that `Scan selected text` would only scan the selected text and not expand outside of it.

To not break existing use cases of the previous `Scan selected text` I've added `Scan text at selection` which has the previous behavior and is more in line with what would be expected of that name.

Fixes #792