### PR TITLE
Allow keyboard shortcut hotkeys to be modifiers only

### DIFF
--- a/ext/js/input/hotkey-handler.js
+++ b/ext/js/input/hotkey-handler.js
@@ -172,7 +172,7 @@ export class HotkeyHandler extends EventDispatcher {
      */
     _onKeyDown(event) {
         let hotkeyInfo = this._hotkeys.get(event.code);
-        const modifierKeycodes = ['ControlLeft', 'ControlRight', 'ShiftLeft', 'ShiftRight', 'AltLeft', 'AltRight'];
+        const modifierKeycodes = ['ControlLeft', 'ControlRight', 'ShiftLeft', 'ShiftRight', 'AltLeft', 'AltRight', 'MetaLeft', 'MetaRight'];
         if (modifierKeycodes.includes(event.code)) {
             hotkeyInfo = this._hotkeys.get(null); // Hotkeys with only modifiers are stored as null
         }

--- a/ext/js/input/hotkey-handler.js
+++ b/ext/js/input/hotkey-handler.js
@@ -32,7 +32,7 @@ export class HotkeyHandler extends EventDispatcher {
         super();
         /** @type {Map<string, (argument: unknown) => (boolean|void)>} */
         this._actions = new Map();
-        /** @type {Map<string, import('hotkey-handler').HotkeyHandlers>} */
+        /** @type {Map<(string | null), import('hotkey-handler').HotkeyHandlers>} */
         this._hotkeys = new Map();
         /** @type {Map<import('settings').InputsHotkeyScope, import('settings').InputsHotkeyOptions[]>} */
         this._hotkeyRegistrations = new Map();
@@ -171,7 +171,11 @@ export class HotkeyHandler extends EventDispatcher {
      * @param {KeyboardEvent} event
      */
     _onKeyDown(event) {
-        const hotkeyInfo = this._hotkeys.get(event.code);
+        let hotkeyInfo = this._hotkeys.get(event.code);
+        const modifierKeycodes = ['ControlLeft', 'ControlRight', 'ShiftLeft', 'ShiftRight', 'AltLeft', 'AltRight'];
+        if (modifierKeycodes.includes(event.code)) {
+            hotkeyInfo = this._hotkeys.get(null); // Hotkeys with only modifiers are stored as null
+        }
         if (typeof hotkeyInfo !== 'undefined') {
             const eventModifiers = getActiveModifiers(event);
             if (this._invokeHandlers(eventModifiers, hotkeyInfo, event.key)) {
@@ -228,8 +232,7 @@ export class HotkeyHandler extends EventDispatcher {
         this._hotkeys.clear();
         for (const [scope, registrations] of this._hotkeyRegistrations.entries()) {
             for (const {action, argument, key, modifiers, scopes, enabled} of registrations) {
-                if (!(enabled && key !== null && action !== '' && scopes.includes(scope))) { continue; }
-
+                if (!(enabled && (key !== null || modifiers !== null) && action !== '' && scopes.includes(scope))) { continue; }
                 let hotkeyInfo = this._hotkeys.get(key);
                 if (typeof hotkeyInfo === 'undefined') {
                     hotkeyInfo = {handlers: []};


### PR DESCRIPTION
Currently, shortcuts can be set in the settings using modifiers only without any other key but these shortcuts don't function.

This fixes that by allowing the key to be null when registering hotkeys.