### PR TITLE
Restore shift click behavior for search button opening as a popup

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -964,10 +964,10 @@ export class Backend {
     // Command handlers
 
     /**
-     * @param {undefined|{mode: 'existingOrNewTab'|'newTab', query?: string}} params
+     * @param {undefined|{mode: 'existingOrNewTab'|'newTab'|'popup', query?: string}} params
      */
     async _onCommandOpenSearchPage(params) {
-        /** @type {'existingOrNewTab'|'newTab'} */
+        /** @type {'existingOrNewTab'|'newTab'|'popup'} */
         let mode = 'existingOrNewTab';
         let query = '';
         if (typeof params === 'object' && params !== null) {
@@ -1023,6 +1023,8 @@ export class Backend {
             case 'newTab':
                 await this._createTab(queryUrl);
                 return;
+            case 'popup':
+                return;
         }
     }
 
@@ -1034,10 +1036,10 @@ export class Backend {
     }
 
     /**
-     * @param {undefined|{mode: 'existingOrNewTab'|'newTab'}} params
+     * @param {undefined|{mode: 'existingOrNewTab'|'newTab'|'popup'}} params
      */
     async _onCommandOpenSettingsPage(params) {
-        /** @type {'existingOrNewTab'|'newTab'} */
+        /** @type {'existingOrNewTab'|'newTab'|'popup'} */
         let mode = 'existingOrNewTab';
         if (typeof params === 'object' && params !== null) {
             mode = this._normalizeOpenSettingsPageMode(params.mode, mode);
@@ -2544,7 +2546,7 @@ export class Backend {
     }
 
     /**
-     * @param {'existingOrNewTab'|'newTab'} mode
+     * @param {'existingOrNewTab'|'newTab'|'popup'} mode
      */
     async _openSettingsPage(mode) {
         const manifest = chrome.runtime.getManifest();
@@ -2673,13 +2675,14 @@ export class Backend {
 
     /**
      * @param {unknown} mode
-     * @param {'existingOrNewTab'|'newTab'} defaultValue
-     * @returns {'existingOrNewTab'|'newTab'}
+     * @param {'existingOrNewTab'|'newTab'|'popup'} defaultValue
+     * @returns {'existingOrNewTab'|'newTab'|'popup'}
      */
     _normalizeOpenSettingsPageMode(mode, defaultValue) {
         switch (mode) {
             case 'existingOrNewTab':
             case 'newTab':
+            case 'popup':
                 return mode;
             default:
                 return defaultValue;

--- a/ext/js/pages/action-popup-main.js
+++ b/ext/js/pages/action-popup-main.js
@@ -114,7 +114,15 @@ class DisplayController {
                         const result = customHandler(e);
                         if (typeof result !== 'undefined') { return; }
                     }
-                    void this._api.commandExec(command, {mode: e.ctrlKey ? 'newTab' : 'existingOrNewTab'});
+
+                    let mode = 'existingOrNewTab';
+                    if (e.ctrlKey) {
+                        mode = 'newTab';
+                    } else if (e.shiftKey) {
+                        mode = 'popup';
+                    }
+
+                    void this._api.commandExec(command, {mode: mode});
                     e.preventDefault();
                 };
                 /**


### PR DESCRIPTION
Fixes #515

It isn't obvious from the code changes but this is what is going on here:

Old behavior:

```
shift click search button -> popup search opens -> popup search closes -> new tab opens with search page
```

This all happens instantly so the popup search is never seen.

New behavior:

```
shift click search button -> popup search opens -> search page opener sees 'popup' mode and does not open the search page
```