### PR TITLE
Catch and handle errors if getOptionsFull fails

### DIFF
--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -242,13 +242,15 @@ export class DictionaryImportController {
             return errors;
         }
 
-        void this._settingsController.application.api.triggerDatabaseUpdated('dictionary', 'import');
         const errors2 = await this._addDictionarySettings(result.sequenced, result.title);
 
+        await this._settingsController.application.api.triggerDatabaseUpdated('dictionary', 'import');
+
         if (errors.length > 0) {
-            const allErrors = [...errors, ...errors2];
-            allErrors.push(new Error(`Dictionary may not have been imported properly: ${allErrors.length} error${allErrors.length === 1 ? '' : 's'} reported.`));
-            this._showErrors(allErrors);
+            errors.push(new Error(`Dictionary may not have been imported properly: ${errors.length} error${errors.length === 1 ? '' : 's'} reported.`));
+            this._showErrors([...errors, ...errors2]);
+        } else if (errors2.length > 0) {
+            this._showErrors(errors2);
         }
     }
 
@@ -258,7 +260,18 @@ export class DictionaryImportController {
      * @returns {Promise<Error[]>}
      */
     async _addDictionarySettings(sequenced, title) {
-        const optionsFull = await this._settingsController.getOptionsFull();
+        let optionsFull;
+        // Workaround Firefox bug sometimes causing getOptionsFull to fail
+        for (let i = 0, success = false; (i < 10) && (success === false); i++) {
+            try {
+                optionsFull = await this._settingsController.getOptionsFull();
+                success = true;
+            } catch (error) {
+                log.error(error);
+            }
+        }
+        if (!optionsFull) { return [new Error('Failed to automatically set dictionary settings. A page refresh and manual enabling of the dictionary may be required.')]; }
+
         const profileIndex = this._settingsController.profileIndex;
         /** @type {import('settings-modifications').Modification[]} */
         const targets = [];


### PR DESCRIPTION
Fixes #723

I think this issue is due to calling `triggerDatabaseUpdated` without an await before `_addDictionarySettings` causing a race condition. But due to the nature of this bug there's no way to be 100% sure.

Simply awaiting `triggerDatabaseUpdated` doesn't work due to it calling `ensureDictionarySettings` conflicting with `_addDictionarySettings` and creating duplicate dict settings. (`ensureDictionarySettings` makes sure all dicts have settings entries and adds one if it is lacking. `_addDictionarySettings` adds a setting regardless of whether one exists already.) 

Running `triggerDatabaseUpdated` after `_addDictionarySettings` appears to work perfectly fine.

I've also allowed `getOptionsFull` to retry up to 10 times if it fails, catching any errors so the dict import process is not interrupted.

At a minimum these fixes will make it so firefox users don't have to worry about the dict import process randomly breaking when importing multiple dicts and requiring manually restarting the import. But hopefully this will entirely eliminate settings related errors for firefox imports.