### PR TITLE
Update anki settings when Configure Anki card format button is clicked instead of requiring page refresh

### DIFF
--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -582,6 +582,17 @@ class AnkiCardController {
 
         this._ankiCardFieldsContainer = this._node.querySelector('.anki-card-fields');
 
+        /** @type {HTMLTextAreaElement} */
+        const mainSettingsEntry = querySelectorNotNull(document, '#configure-anki-card-format-main-settings-entry');
+        mainSettingsEntry.addEventListener('click', (() => {
+            const updatedCardOptions = this._getCardOptions(ankiOptions, this._optionsType);
+            if (updatedCardOptions === null) { return; }
+            this._deckController.prepare(deckControllerSelect, updatedCardOptions.deck);
+            this._modelController.prepare(modelControllerSelect, updatedCardOptions.model);
+            this._fields = updatedCardOptions.fields;
+            void this.updateAnkiState();
+        }).bind(this), false);
+
         this._setupFields();
 
         this._eventListeners.addEventListener(this._deckController.select, 'change', this._onCardDeckChange.bind(this), false);

--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -583,7 +583,7 @@ class AnkiCardController {
         this._ankiCardFieldsContainer = this._node.querySelector('.anki-card-fields');
 
         /** @type {HTMLTextAreaElement} */
-        const mainSettingsEntry = querySelectorNotNull(document, '#configure-anki-card-format-main-settings-entry');
+        const mainSettingsEntry = querySelectorNotNull(document, '[data-modal-action="show,anki-cards"]');
         mainSettingsEntry.addEventListener('click', (() => {
             const updatedCardOptions = this._getCardOptions(ankiOptions, this._optionsType);
             if (updatedCardOptions === null) { return; }

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1838,7 +1838,7 @@
                 </p>
             </div>
         </div>
-        <div class="settings-item settings-item-button" data-modal-action="show,anki-cards"><div class="settings-item-inner">
+        <div class="settings-item settings-item-button" data-modal-action="show,anki-cards" id="configure-anki-card-format-main-settings-entry"><div class="settings-item-inner">
             <div class="settings-item-left">
                 <div class="settings-item-label">Configure Anki card format&hellip;</div>
             </div>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1838,7 +1838,7 @@
                 </p>
             </div>
         </div>
-        <div class="settings-item settings-item-button" data-modal-action="show,anki-cards" id="configure-anki-card-format-main-settings-entry"><div class="settings-item-inner">
+        <div class="settings-item settings-item-button" data-modal-action="show,anki-cards"><div class="settings-item-inner">
             <div class="settings-item-left">
                 <div class="settings-item-label">Configure Anki card format&hellip;</div>
             </div>


### PR DESCRIPTION
Nice UX thing. If it fails (anki not open or something), it just does nothing.