### PR TITLE
Fix collection import error and progress display

### DIFF
--- a/ext/settings.html
+++ b/ext/settings.html
@@ -2051,6 +2051,20 @@
                 </div>
             </div>
         </div></div>
+        <div class="settings-item"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-progress-report" id="db-ops-progress-report">
+                    Placeholder text.
+                </div>
+            </div>
+        </div></div>
+        <div class="settings-item"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-error-report" id="db-ops-error-report">
+                    Placeholder text.
+                </div>
+            </div>
+        </div></div>
     </div>
 
     <!-- Accessibility -->


### PR DESCRIPTION
These got mistakenly removed in the settings rework and causes an error to throw upon trying to import or export a dictionary collection.

Ideally these settings items would be hidden while not importing or erroring since they make things look a bit ugly but for now the previous behavior can just be restored.