### PR TITLE
Disallow hotkeys with no keys or modifiers

### DIFF
--- a/ext/js/input/hotkey-handler.js
+++ b/ext/js/input/hotkey-handler.js
@@ -232,7 +232,7 @@ export class HotkeyHandler extends EventDispatcher {
         this._hotkeys.clear();
         for (const [scope, registrations] of this._hotkeyRegistrations.entries()) {
             for (const {action, argument, key, modifiers, scopes, enabled} of registrations) {
-                if (!(enabled && (key !== null || modifiers !== null) && action !== '' && scopes.includes(scope))) { continue; }
+                if (!(enabled && (key !== null || modifiers.length > 0) && action !== '' && scopes.includes(scope))) { continue; }
                 let hotkeyInfo = this._hotkeys.get(key);
                 if (typeof hotkeyInfo === 'undefined') {
                     hotkeyInfo = {handlers: []};


### PR DESCRIPTION
In #916 I fixed support for shortcuts that were modifiers only. However, I mistakenly null checked the modifiers array instead of length checking it.

This allows for setting and registering a shortcut that has no key trigger conditions. I'm not exactly sure what is going on with shortcuts like this but they do wacky things and trigger "randomly" when they shouldn't.