### PR TITLE
Browser agnostic search page clipboard and selection handling

### DIFF
--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -66,11 +66,11 @@ export class SearchDisplayController {
         /** @type {boolean} */
         this._clipboardMonitorEnabled = false;
         /** @type {import('clipboard-monitor').ClipboardReaderLike} */
-        const clipboardReader = {
+        this.clipboardReaderLike = {
             getText: this._display.application.api.clipboardGet.bind(this._display.application.api)
         };
         /** @type {ClipboardMonitor} */
-        this._clipboardMonitor = new ClipboardMonitor(clipboardReader);
+        this._clipboardMonitor = new ClipboardMonitor(this.clipboardReaderLike);
         /** @type {import('application').ApiMap} */
         this._apiMap = createApiMap([
             ['searchDisplayControllerGetMode', this._onMessageGetMode.bind(this)],
@@ -268,10 +268,9 @@ export class SearchDisplayController {
     }
 
     /** */
-    _onCopy() {
+    async _onCopy() {
         // Ignore copy from search page
-        const selection = window.getSelection();
-        this._clipboardMonitor.setPreviousText(selection !== null ? selection.toString().trim() : '');
+        this._clipboardMonitor.setPreviousText(document.hasFocus() ? await this.clipboardReaderLike.getText(false) : '');
     }
 
     /** @type {import('application').ApiHandler<'searchDisplayControllerUpdateSearchQuery'>} */


### PR DESCRIPTION
Due to a 23 year old Firefox bug (https://bugzilla.mozilla.org/show_bug.cgi?id=85686) window.getSelection() does not behave the same on Firefox as it does on Chromium.

It is not possible to get the current selection using this if a textarea or input is where the selection is located on Firefox. It is possible to achieve this using other methods but none of these methods work for fetching the selection anywhere on the page. So there is no equivalent of window.getSelection() to be used.

To avoid jank I've rewritten the code to check whether the user has the browser page focused instead using document.hasFocus(). If the user has the browser page focused, updating the search from a clipboard copy is blocked.

I searched the blame for this code back to when it was added to check if there were any edge cases this was handling but there doesn't appear to be any specifc reason window.getSelection() was chosen so it should be fine to switch out.

The Yomitan bug this fixes is the search page updating when copying out of the textarea search box on the search page on Firefox.

Tested on Firefox and Chromium.