### PR TITLE
Add word wrap to #extension-info on mobile to prevent page horizontal elongation

### DIFF
--- a/ext/css/action-popup.css
+++ b/ext/css/action-popup.css
@@ -496,4 +496,8 @@ select.profile-select {
         width: 100%;
         padding-top: 37.7%;
     }
+    #extension-info {
+        max-width: 95vw;
+        overflow-wrap: break-word;
+    }
 }


### PR DESCRIPTION
#extension-info is the thing that says "Yomitan v24.5.14.0" or whatever version in the mobile popup (theres some screenshots of this on #886). If the version number is too long (for example v99.99.99.99) this can horizontally extend the action popup page beyond the device's view.

Dev builds of Yomitan also suffer badly from this with the addition of the incredibly long "(development build)" text.

This fix puts "Yomitan" and the version number on different lines if it gets too long.