### PR TITLE
Update anki settings on Configure Anki card format click

### DIFF
--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -117,6 +117,8 @@ export class AnkiController {
         for (const node of nodes) {
             node.addEventListener('settingChanged', onAnkiSettingChanged);
         }
+        const ankiCardFormatSettingsEntry = querySelectorNotNull(document, '[data-modal-action="show,anki-cards"]');
+        ankiCardFormatSettingsEntry.addEventListener('click', onAnkiSettingChanged);
     }
 
     /**
@@ -581,17 +583,6 @@ class AnkiCardController {
         this._fields = fields;
 
         this._ankiCardFieldsContainer = this._node.querySelector('.anki-card-fields');
-
-        /** @type {HTMLTextAreaElement} */
-        const mainSettingsEntry = querySelectorNotNull(document, '[data-modal-action="show,anki-cards"]');
-        mainSettingsEntry.addEventListener('click', (() => {
-            const updatedCardOptions = this._getCardOptions(ankiOptions, this._optionsType);
-            if (updatedCardOptions === null) { return; }
-            this._deckController.prepare(deckControllerSelect, updatedCardOptions.deck);
-            this._modelController.prepare(modelControllerSelect, updatedCardOptions.model);
-            this._fields = updatedCardOptions.fields;
-            void this.updateAnkiState();
-        }).bind(this), false);
 
         this._setupFields();
 


### PR DESCRIPTION
 #934 had some edge cases where things wouldn't get properly updated due to old settings still being present. This reverts #934 and instead reloads all of the Anki settings when clicking on `Configure Anki card format...`.