### PR TITLE
Add Cantonese

### DIFF
--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -254,7 +254,7 @@ const languageDescriptors = [
     },
     {
         iso: 'zh',
-        name: 'Mandarin',
+        name: 'Chinese',
         exampleText: '读'
     }
 ];

--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -248,8 +248,13 @@ const languageDescriptors = [
         textPreprocessors: capitalizationPreprocessors
     },
     {
+        iso: 'yue',
+        name: 'Cantonese',
+        exampleText: '讀'
+    },
+    {
         iso: 'zh',
-        name: 'Chinese',
+        name: 'Mandarin',
         exampleText: '读'
     }
 ];

--- a/types/ext/language-descriptors.d.ts
+++ b/types/ext/language-descriptors.d.ts
@@ -172,5 +172,6 @@ type AllTextProcessors = {
     vi: {
         pre: CapitalizationPreprocessors;
     };
+    yue: Record<string, never>;
     zh: Record<string, never>;
 };


### PR DESCRIPTION
Also wondering if it might make sense to separate mandarin into `zh-Hant`, `zh-Hans` since those have a distinction for font rendering.