### PR TITLE
Add check for counts and counts.termMeta

### DIFF
--- a/ext/js/pages/settings/sort-frequency-dictionary-controller.js
+++ b/ext/js/pages/settings/sort-frequency-dictionary-controller.js
@@ -107,7 +107,7 @@ export class SortFrequencyDictionaryController {
         option.textContent = 'None';
         fragment.appendChild(option);
         for (const {title, counts} of dictionaries) {
-            if (counts.termMeta.freq > 0) {
+            if (counts && counts.termMeta && counts.termMeta.freq > 0) {
                 option = document.createElement('option');
                 option.value = title;
                 option.textContent = title;


### PR DESCRIPTION
These aren't supposed to be able to be null/undefined but a user reported hitting an issue where it was undefined and caused an error when trying to access `counts.termMeta`. Possibly something with a malformed dictionary. But regardless we should handle this case.