### PR TITLE
Fix chance of multiple popups appearing when scan key is pressed multiple times without moving

### DIFF
--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -349,6 +349,7 @@ export class Frontend {
      */
     _onClosePopups() {
         this._clearSelection(true);
+        this._clearMousePosition();
     }
 
     /**
@@ -436,6 +437,11 @@ export class Frontend {
             this._isPointerOverPopup = false;
         }
         this._textScanner.clearSelection();
+    }
+
+    /** */
+    _clearMousePosition() {
+        this._textScanner.clearMousePosition();
     }
 
     /**

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -364,6 +364,11 @@ export class TextScanner extends EventDispatcher {
         }
     }
 
+    /** */
+    clearMousePosition() {
+        this._lastMouseMove = null;
+    }
+
     /**
      * @returns {?import('text-source').TextSource}
      */


### PR DESCRIPTION
This can occur if the scan button is pressed multiple times without moving the mouse after the popup appears and the popup contains a saved mouse position from a previous popup that matches the position of scannable text in the current popup.

This change clears the mouse position when the popup is closed so there will never be any saved mouse position when the popup is opened.

Minimal reproduction steps for this issue:
1. Scan a word
2. Mouse over scannable text within the popup
3. Close the popup without moving the mouse (press esc) while the cursor is still above the scannable text in the popup
4. Mouse over word scanned in step 1 and do not move the mouse after this
5. Press the scan button to scan the word
6. Press the scan button again

You will now have a second popup even though the mouse is not over the text that was just scanned inside the first popup.