### PR TITLE
Fix clipboard monitor in popups

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -314,6 +314,9 @@ export class Backend {
      * @param {import('clipboard-monitor').EventArgument<'change'>} details
      */
     async _onClipboardTextChange({text}) {
+        // Only update if tab does not exist
+        if (await this._tabExists('/search.html')) { return; }
+
         const {
             general: {language},
             clipboard: {maximumSearchLength}
@@ -1197,6 +1200,16 @@ export class Backend {
             }
         };
         return /** @type {?import('backend').TabInfo} */ (await this._findTabs(1000, false, predicate, true));
+    }
+
+    /**
+     * @param {string} urlParam
+     * @returns {Promise<boolean>}
+     */
+    async _tabExists(urlParam) {
+        const baseUrl = chrome.runtime.getURL(urlParam);
+        const urlPredicate = (/** @type {?string} */ url) => url !== null && url.startsWith(baseUrl);
+        return await this._findSearchPopupTab(urlPredicate) !== null;
     }
 
     /**

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -66,11 +66,11 @@ export class SearchDisplayController {
         /** @type {boolean} */
         this._clipboardMonitorEnabled = false;
         /** @type {import('clipboard-monitor').ClipboardReaderLike} */
-        this.clipboardReaderLike = {
+        this._clipboardReaderLike = {
             getText: this._display.application.api.clipboardGet.bind(this._display.application.api)
         };
         /** @type {ClipboardMonitor} */
-        this._clipboardMonitor = new ClipboardMonitor(this.clipboardReaderLike);
+        this._clipboardMonitor = new ClipboardMonitor(this._clipboardReaderLike);
         /** @type {import('application').ApiMap} */
         this._apiMap = createApiMap([
             ['searchDisplayControllerGetMode', this._onMessageGetMode.bind(this)],
@@ -271,7 +271,7 @@ export class SearchDisplayController {
     /** */
     async _onCopy() {
         // Ignore copy from search page
-        this._clipboardMonitor.setPreviousText(document.hasFocus() ? await this.clipboardReaderLike.getText(false) : '');
+        this._clipboardMonitor.setPreviousText(document.hasFocus() ? await this._clipboardReaderLike.getText(false) : '');
     }
 
     /** @type {import('application').ApiHandler<'searchDisplayControllerUpdateSearchQuery'>} */

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -498,7 +498,6 @@ export class SearchDisplayController {
      */
     _canEnableClipboardMonitor() {
         switch (this._searchPersistentStateController.mode) {
-            case 'popup':
             case 'action-popup':
                 return false;
             default:


### PR DESCRIPTION
Allows the search page clipboard monitor to run in popups and disallows the global clipboard monitor from messing with popups after initialization.

This allows the search page to have control over the clipboard so things will work the same on both the search page popup and the normal search page when we're updating code there.

Fixes #786.

Also fixes a bug where text copied on the search page popup updates the search.