### PR TITLE
Add note about refreshing page in api invoke error

### DIFF
--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -395,7 +395,7 @@ export class API {
                             resolve(/** @type {import('api').ApiReturn<TAction>} */ (result));
                         }
                     } else {
-                        const message = response === null ? 'Unexpected null response' : `Unexpected response of type ${typeof response}`;
+                        const message = response === null ? 'Unexpected null response. You may need to refresh the page.' : `Unexpected response of type ${typeof response}. You may need to refresh the page.`;
                         reject(new Error(`${message} (${JSON.stringify(data)})`));
                     }
                 });


### PR DESCRIPTION
This error is sometimes user facing and it could be confusing to users as to what to do about it. Almost always this is fixed by refreshing the page.