### PR TITLE
Disallow breaking on rb tags when layout aware scanning is enabled

### DIFF
--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -418,6 +418,7 @@ export class DOMTextScanner {
         switch (element.nodeName.toUpperCase()) {
             case 'HEAD':
             case 'RT':
+            case 'RB':
             case 'SCRIPT':
             case 'STYLE':
                 return {enterable: false, newlines: 0};

--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -418,10 +418,11 @@ export class DOMTextScanner {
         switch (element.nodeName.toUpperCase()) {
             case 'HEAD':
             case 'RT':
-            case 'RB':
             case 'SCRIPT':
             case 'STYLE':
                 return {enterable: false, newlines: 0};
+            case 'RB':
+                return {enterable: true, newlines: 0};
             case 'BR':
                 return {enterable: false, newlines: 1};
             case 'TEXTAREA':


### PR DESCRIPTION
rb tags should be ignored by layout aware scanning. This bug only appears on firefox presumably due to chromium not properly supporting rb tags.

Fixes #888