### PR TITLE
Allow trailing commas in ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -117,7 +117,7 @@
         "@stylistic/arrow-spacing": ["error", {"before": true, "after": true}],
         "@stylistic/block-spacing": ["error", "always"],
         "@stylistic/brace-style": ["error", "1tbs", {"allowSingleLine": true}],
-        "@stylistic/comma-dangle": ["error", "never"],
+        "@stylistic/comma-dangle": ["error", "always-multiline"],
         "@stylistic/comma-spacing": ["error", {"before": false, "after": true}],
         "@stylistic/comma-style": ["error", "last"],
         "@stylistic/computed-property-spacing": ["error", "never"],

--- a/benches/language-transformer.bench.js
+++ b/benches/language-transformer.bench.js
@@ -37,7 +37,7 @@ describe('language transformer', () => {
             '愛しかった',
             '愛しくありません',
             '愛しくありませんでした',
-            '愛しき'
+            '愛しき',
         ];
 
         const verbInflections = [
@@ -80,14 +80,14 @@ describe('language transformer', () => {
             '食べておる',
             '食べてる',
             '食べとる',
-            '食べてしまう'
+            '食べてしまう',
         ];
 
         const inflectionCombinations = [
             '抱き抱えていなければ',
             '抱きかかえていなければ',
             '打ち込んでいませんでした',
-            '食べさせられたくなかった'
+            '食べさせられたくなかった',
         ];
 
         const kuruInflections = [
@@ -133,7 +133,7 @@ describe('language transformer', () => {
             'きておる',
             'きてる',
             'きとる',
-            'きてしまう'
+            'きてしまう',
         ];
 
         const suruInflections = [
@@ -184,7 +184,7 @@ describe('language transformer', () => {
             'しておる',
             'してる',
             'しとる',
-            'してしまう'
+            'してしまう',
         ];
 
         const kansaibenInflections = [
@@ -195,7 +195,7 @@ describe('language transformer', () => {
             '買わへんかった',
             '買うて',
             '買うた',
-            '買うたら'
+            '買うたら',
         ];
 
         const basicTransformations = [...adjectiveInflections, ...verbInflections, ...inflectionCombinations];

--- a/dev/bin/build.js
+++ b/dev/bin/build.js
@@ -55,11 +55,11 @@ async function createZip(directory, excludeFiles, outputFileName, sevenZipExes, 
                         'a',
                         outputFileName,
                         '.',
-                        ...excludeArguments
+                        ...excludeArguments,
                     ],
                     {
-                        cwd: directory
-                    }
+                        cwd: directory,
+                    },
                 );
                 return;
             } catch (e) {
@@ -85,7 +85,7 @@ async function createJSZip(directory, excludeFiles, outputFileName, onUpdate, dr
         zip.file(
             fileName.replace(/\\/g, '/'),
             fs.readFileSync(path.join(directory, fileName), {encoding: null, flag: 'r'}),
-            {}
+            {},
         );
     }
 
@@ -96,7 +96,7 @@ async function createJSZip(directory, excludeFiles, outputFileName, onUpdate, dr
     const data = await zip.generateAsync({
         type: 'nodebuffer',
         compression: 'DEFLATE',
-        compressionOptions: {level: 9}
+        compressionOptions: {level: 9},
     }, onUpdate);
     process.stdout.write('\n');
 
@@ -223,27 +223,27 @@ export async function main() {
     const parseArgsConfigOptions = {
         all: {
             type: 'boolean',
-            default: false
+            default: false,
         },
         default: {
             type: 'boolean',
-            default: false
+            default: false,
         },
         manifest: {
-            type: 'string'
+            type: 'string',
         },
         dryRun: {
             type: 'boolean',
-            default: false
+            default: false,
         },
         dryRunBuildZip: {
             type: 'boolean',
-            default: false
+            default: false,
         },
         version: {
             type: 'string',
-            default: '0.0.0.0'
-        }
+            default: '0.0.0.0',
+        },
     };
 
     const argv = process.argv.slice(2);

--- a/dev/bin/dictionary-validate.js
+++ b/dev/bin/dictionary-validate.js
@@ -24,7 +24,7 @@ async function main() {
     if (dictionaryFileNames.length === 0) {
         console.log([
             'Usage:',
-            '  node dictionary-validate [--ajv] <dictionary-file-names>...'
+            '  node dictionary-validate [--ajv] <dictionary-file-names>...',
         ].join('\n'));
         return;
     }

--- a/dev/bin/schema-validate.js
+++ b/dev/bin/schema-validate.js
@@ -27,7 +27,7 @@ function main() {
     if (args.length < 2) {
         console.log([
             'Usage:',
-            '  node schema-validate [--ajv] <schema-file-name> <data-file-names>...'
+            '  node schema-validate [--ajv] <schema-file-name> <data-file-names>...',
         ].join('\n'));
         return;
     }

--- a/dev/build-libs.js
+++ b/dev/build-libs.js
@@ -41,8 +41,8 @@ async function buildLib(scriptPath) {
         outfile: path.join(extDir, 'lib', path.basename(scriptPath)),
         external: ['fs'],
         banner: {
-            js: '// @ts-nocheck'
-        }
+            js: '// @ts-nocheck',
+        },
     });
 }
 
@@ -52,7 +52,7 @@ async function buildLib(scriptPath) {
 export async function buildLibs() {
     const devLibPath = path.join(dirname, 'lib');
     const files = await fs.promises.readdir(devLibPath, {
-        withFileTypes: true
+        withFileTypes: true,
     });
     for (const f of files) {
         if (f.isFile()) {
@@ -71,7 +71,7 @@ export async function buildLibs() {
     const ajv = new Ajv({
         schemas,
         code: {source: true, esm: true},
-        allowUnionTypes: true
+        allowUnionTypes: true,
     });
     const moduleCode = standaloneCode(ajv);
 

--- a/dev/dictionary-archive-util.js
+++ b/dev/dictionary-archive-util.js
@@ -32,7 +32,7 @@ export async function createDictionaryArchiveData(dictionaryDirectory, dictionar
     // Level 0 compression used since decompression in the node environment is not supported.
     // See dev/lib/zip.js for more details.
     const zipWriter = new ZipWriter(zipFileWriter, {
-        level: 0
+        level: 0,
     });
     for (const fileName of fileNames) {
         if (/\.json$/.test(fileName)) {

--- a/dev/dictionary-validate.js
+++ b/dev/dictionary-validate.js
@@ -99,7 +99,7 @@ export async function validateDictionary(mode, archiveData, schemas) {
         [/^term_meta_bank_(\d+)\.json$/, schemas.termMetaBankV3],
         [/^kanji_bank_(\d+)\.json$/, version === 1 ? schemas.kanjiBankV1 : schemas.kanjiBankV3],
         [/^kanji_meta_bank_(\d+)\.json$/, schemas.kanjiMetaBankV3],
-        [/^tag_bank_(\d+)\.json$/, schemas.tagBankV3]
+        [/^tag_bank_(\d+)\.json$/, schemas.tagBankV3],
     ];
 
     await validateDictionaryBanks(mode, entries, schemasDetails);
@@ -118,7 +118,7 @@ export function getSchemas() {
         tagBankV3: readSchema('../ext/data/schemas/dictionary-tag-bank-v3-schema.json'),
         termBankV1: readSchema('../ext/data/schemas/dictionary-term-bank-v1-schema.json'),
         termBankV3: readSchema('../ext/data/schemas/dictionary-term-bank-v3-schema.json'),
-        termMetaBankV3: readSchema('../ext/data/schemas/dictionary-term-meta-bank-v3-schema.json')
+        termMetaBankV3: readSchema('../ext/data/schemas/dictionary-term-meta-bank-v3-schema.json'),
     };
 }
 

--- a/dev/generate-css-json.js
+++ b/dev/generate-css-json.js
@@ -31,13 +31,13 @@ export function getTargets() {
         {
             cssFilePath: path.join(dirname, '..', 'ext/css/structured-content.css'),
             overridesCssFilePath: path.join(dirname, 'data/structured-content-overrides.css'),
-            outputPath: path.join(dirname, '..', 'ext/data/structured-content-style.json')
+            outputPath: path.join(dirname, '..', 'ext/data/structured-content-style.json'),
         },
         {
             cssFilePath: path.join(dirname, '..', 'ext/css/display-pronunciation.css'),
             overridesCssFilePath: path.join(dirname, 'data/display-pronunciation-overrides.css'),
-            outputPath: path.join(dirname, '..', 'ext/data/pronunciation-style.json')
-        }
+            outputPath: path.join(dirname, '..', 'ext/data/pronunciation-style.json'),
+        },
     ];
 }
 

--- a/dev/manifest-util.js
+++ b/dev/manifest-util.js
@@ -99,7 +99,7 @@ export class ManifestUtil {
         const {stdout, stderr, status} = childProcess.spawnSync(command, args, {
             cwd: dirname,
             stdio: 'pipe',
-            shell: false
+            shell: false,
         });
         if (status !== 0) {
             const message = stderr.toString('utf8').trim();

--- a/dev/schema-validate.js
+++ b/dev/schema-validate.js
@@ -31,7 +31,7 @@ class JsonSchemaAjv {
         const ajv = new Ajv({
             meta: false,
             strictTuples: false,
-            allowUnionTypes: true
+            allowUnionTypes: true,
         });
         const metaSchemaPath = fileURLToPath(import.meta.resolve('ajv/dist/refs/json-schema-draft-07.json'));
         /** @type {import('ajv').AnySchemaObject} */

--- a/ext/js/accessibility/accessibility-controller.js
+++ b/ext/js/accessibility/accessibility-controller.js
@@ -115,8 +115,8 @@ export class AccessibilityController {
             js: [
                 xray ?
                 'js/accessibility/google-docs-xray.js' :
-                'js/accessibility/google-docs.js'
-            ]
+                'js/accessibility/google-docs.js',
+            ],
         };
         if (!xray) { details.world = 'MAIN'; }
         return registerContentScript(id, details);

--- a/ext/js/accessibility/google-docs-util.js
+++ b/ext/js/accessibility/google-docs-util.js
@@ -62,7 +62,7 @@ export class GoogleDocsUtil {
             const style = document.createElement('style');
             style.textContent = [
                 '.kix-canvas-tile-content{pointer-events:none!important;}',
-                '.kix-canvas-tile-content svg>g>rect{pointer-events:all!important;}'
+                '.kix-canvas-tile-content svg>g>rect{pointer-events:all!important;}',
             ].join('\n');
             const parent = document.head || document.documentElement;
             if (parent !== null) {

--- a/ext/js/app/content-script-main.js
+++ b/ext/js/app/content-script-main.js
@@ -39,7 +39,7 @@ await Application.main(false, async (application) => {
         canUseWindowPopup: true,
         allowRootFramePopupProxy: true,
         childrenSupported: true,
-        hotkeyHandler
+        hotkeyHandler,
     });
     await frontend.prepare();
 });

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -45,7 +45,7 @@ export class Frontend {
         canUseWindowPopup = true,
         allowRootFramePopupProxy,
         childrenSupported = true,
-        hotkeyHandler
+        hotkeyHandler,
     }) {
         /** @type {import('../application.js').Application} */
         this._application = application;
@@ -92,7 +92,7 @@ export class Frontend {
             getSearchContext: this._getSearchContext.bind(this),
             searchTerms: true,
             searchKanji: true,
-            textSourceGenerator: this._textSourceGenerator
+            textSourceGenerator: this._textSourceGenerator,
         });
         /** @type {boolean} */
         this._textScannerHasBeenEnabled = false;
@@ -114,13 +114,13 @@ export class Frontend {
         this._runtimeApiMap = createApiMap([
             ['frontendRequestReadyBroadcast',   this._onMessageRequestFrontendReadyBroadcast.bind(this)],
             ['frontendSetAllVisibleOverride',   this._onApiSetAllVisibleOverride.bind(this)],
-            ['frontendClearAllVisibleOverride', this._onApiClearAllVisibleOverride.bind(this)]
+            ['frontendClearAllVisibleOverride', this._onApiClearAllVisibleOverride.bind(this)],
         ]);
 
         this._hotkeyHandler.registerActions([
             ['scanSelectedText', this._onActionScanSelectedText.bind(this)],
             ['scanTextAtSelection', this._onActionScanTextAtSelection.bind(this)],
-            ['scanTextAtCaret',  this._onActionScanTextAtCaret.bind(this)]
+            ['scanTextAtCaret',  this._onActionScanTextAtCaret.bind(this)],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
     }
@@ -188,7 +188,7 @@ export class Frontend {
             ['frontendCopySelection',    this._onApiCopySelection.bind(this)],
             ['frontendGetSelectionText', this._onApiGetSelectionText.bind(this)],
             ['frontendGetPopupInfo',     this._onApiGetPopupInfo.bind(this)],
-            ['frontendGetPageInfo',      this._onApiGetPageInfo.bind(this)]
+            ['frontendGetPageInfo',      this._onApiGetPageInfo.bind(this)],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
 
@@ -296,7 +296,7 @@ export class Frontend {
     /** @type {import('cross-frame-api').ApiHandler<'frontendGetPopupInfo'>} */
     _onApiGetPopupInfo() {
         return {
-            popupId: (this._popup !== null ? this._popup.id : null)
+            popupId: (this._popup !== null ? this._popup.id : null),
         };
     }
 
@@ -304,7 +304,7 @@ export class Frontend {
     _onApiGetPageInfo() {
         return {
             url: window.location.href,
-            documentTitle: document.title
+            documentTitle: document.title,
         };
     }
 
@@ -501,7 +501,7 @@ export class Frontend {
             layoutAwareScan: scanningOptions.layoutAwareScan,
             matchTypePrefix: scanningOptions.matchTypePrefix,
             preventMiddleMouse,
-            sentenceParsingOptions
+            sentenceParsingOptions,
         });
         this._updateTextScannerEnabled();
 
@@ -605,7 +605,7 @@ export class Frontend {
         return await this._popupFactory.getOrCreatePopup({
             frameId,
             depth: this._depth,
-            childrenSupported: this._childrenSupported
+            childrenSupported: this._childrenSupported,
         });
     }
 
@@ -617,7 +617,7 @@ export class Frontend {
             frameId: this._parentFrameId,
             depth: this._depth,
             parentPopupId: this._parentPopupId,
-            childrenSupported: this._childrenSupported
+            childrenSupported: this._childrenSupported,
         });
     }
 
@@ -641,7 +641,7 @@ export class Frontend {
         const popup = await this._popupFactory.getOrCreatePopup({
             frameId: targetFrameId,
             id: popupId,
-            childrenSupported: this._childrenSupported
+            childrenSupported: this._childrenSupported,
         });
         popup.on('offsetNotFound', () => {
             this._allowRootFramePopupProxy = false;
@@ -657,7 +657,7 @@ export class Frontend {
         return await this._popupFactory.getOrCreatePopup({
             depth: this._depth,
             popupWindow: true,
-            childrenSupported: this._childrenSupported
+            childrenSupported: this._childrenSupported,
         });
     }
 
@@ -713,14 +713,14 @@ export class Frontend {
         const detailsState = {
             focusEntry: 0,
             optionsContext,
-            url
+            url,
         };
         if (sentence !== null) { detailsState.sentence = sentence; }
         if (documentTitle !== null) { detailsState.documentTitle = documentTitle; }
         const {tabId, frameId} = this._application;
         /** @type {import('display').HistoryContent} */
         const detailsContent = {
-            contentOrigin: {tabId, frameId}
+            contentOrigin: {tabId, frameId},
         };
         if (dictionaryEntries !== null) {
             detailsContent.dictionaryEntries = dictionaryEntries;
@@ -732,10 +732,10 @@ export class Frontend {
             params: {
                 type,
                 query,
-                wildcards: 'off'
+                wildcards: 'off',
             },
             state: detailsState,
-            content: detailsContent
+            content: detailsContent,
         };
         if (textSource instanceof TextSourceElement && textSource.fullContent !== query) {
             details.params.full = textSource.fullContent;
@@ -761,9 +761,9 @@ export class Frontend {
                 {
                     optionsContext,
                     sourceRects,
-                    writingMode: textSource.getWritingMode()
+                    writingMode: textSource.getWritingMode(),
                 },
-                details
+                details,
             ) :
             Promise.resolve()
         );
@@ -927,7 +927,7 @@ export class Frontend {
 
         return {
             optionsContext,
-            detail: {documentTitle}
+            detail: {documentTitle},
         };
     }
 

--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -62,7 +62,7 @@ export class PopupFactory {
             ['popupFactoryUpdateTheme',          this._onApiUpdateTheme.bind(this)],
             ['popupFactorySetCustomOuterCss',    this._onApiSetCustomOuterCss.bind(this)],
             ['popupFactoryGetFrameSize',         this._onApiGetFrameSize.bind(this)],
-            ['popupFactorySetFrameSize',         this._onApiSetFrameSize.bind(this)]
+            ['popupFactorySetFrameSize',         this._onApiSetFrameSize.bind(this)],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
     }
@@ -78,7 +78,7 @@ export class PopupFactory {
         parentPopupId = null,
         depth = null,
         popupWindow = false,
-        childrenSupported = false
+        childrenSupported = false,
     }) {
         // Find by existing id
         if (id !== null) {
@@ -124,7 +124,7 @@ export class PopupFactory {
                 this._application,
                 id,
                 depth,
-                currentFrameId
+                currentFrameId,
             );
             this._popups.set(id, popup);
             return popup;
@@ -138,7 +138,7 @@ export class PopupFactory {
                 id,
                 depth,
                 currentFrameId,
-                childrenSupported
+                childrenSupported,
             );
             if (parent !== null) {
                 if (parent.child !== null) {
@@ -159,7 +159,7 @@ export class PopupFactory {
                 id,
                 parentPopupId,
                 frameId,
-                childrenSupported
+                childrenSupported,
             });
             id = info.id;
             const popup = new PopupProxy(
@@ -167,7 +167,7 @@ export class PopupFactory {
                 id,
                 info.depth,
                 info.frameId,
-                useFrameOffsetForwarder ? this._frameOffsetForwarder : null
+                useFrameOffsetForwarder ? this._frameOffsetForwarder : null,
             );
             this._popups.set(id, popup);
             return popup;
@@ -249,7 +249,7 @@ export class PopupFactory {
         return {
             id: popup.id,
             depth: popup.depth,
-            frameId: popup.frameId
+            frameId: popup.frameId,
         };
     }
 
@@ -402,7 +402,7 @@ export class PopupFactory {
             const promise = popup.clearVisibleOverride(token)
                 .then(
                     (v) => v,
-                    () => false
+                    () => false,
                 );
             promises.push(promise);
         }

--- a/ext/js/app/popup-window.js
+++ b/ext/js/app/popup-window.js
@@ -286,7 +286,7 @@ export class PopupWindow extends EventDispatcher {
                     this._popupTabId,
                     frameId,
                     'displayPopupMessage2',
-                    message
+                    message,
                 ));
             } catch (e) {
                 if (this._application.webExtension.unloaded) {
@@ -307,7 +307,7 @@ export class PopupWindow extends EventDispatcher {
             this._popupTabId,
             frameId,
             'displayPopupMessage2',
-            message
+            message,
         ));
     }
 }

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -424,7 +424,7 @@ export class Popup extends EventDispatcher {
                     if (injectPromise !== this._injectPromise) { return; }
                     this._injectPromiseComplete = true;
                 },
-                () => {}
+                () => {},
             );
         }
         return injectPromise;
@@ -489,7 +489,7 @@ export class Popup extends EventDispatcher {
             parentFrameId: this._frameId,
             childrenSupported: this._childrenSupported,
             scale: this._contentScale,
-            optionsContext: this._optionsContext
+            optionsContext: this._optionsContext,
         };
         await this._invokeSafe('displayConfigure', configureParams);
     }
@@ -699,7 +699,7 @@ export class Popup extends EventDispatcher {
         return /** @type {import('display').DirectApiReturn<TName>} */ (await this._application.crossFrame.invoke(
             this._frameClient.frameId,
             'displayPopupMessage1',
-            /** @type {import('display').DirectApiFrameClientMessageAny} */ (wrappedMessage)
+            /** @type {import('display').DirectApiFrameClientMessageAny} */ (wrappedMessage),
         ));
     }
 
@@ -837,7 +837,7 @@ export class Popup extends EventDispatcher {
             frameWidth,
             viewport.left,
             viewport.right,
-            true
+            true,
         );
         const [top, height, below] = this._getConstrainedPositionBinary(
             sourceRect.top - verticalOffset,
@@ -845,7 +845,7 @@ export class Popup extends EventDispatcher {
             frameHeight,
             viewport.top,
             viewport.bottom,
-            preferBelow
+            preferBelow,
         );
         return {left, top, width, height, after, below};
     }
@@ -868,7 +868,7 @@ export class Popup extends EventDispatcher {
             frameWidth,
             viewport.left,
             viewport.right,
-            preferRight
+            preferRight,
         );
         const [top, height, below] = this._getConstrainedPosition(
             sourceRect.bottom - verticalOffset,
@@ -876,7 +876,7 @@ export class Popup extends EventDispatcher {
             frameHeight,
             viewport.top,
             viewport.bottom,
-            true
+            true,
         );
         return {left, top, width, height, after, below};
     }
@@ -984,7 +984,7 @@ export class Popup extends EventDispatcher {
                     left,
                     top,
                     right: left + width,
-                    bottom: top + height
+                    bottom: top + height,
                 };
             } else {
                 const scale = visualViewport.scale;
@@ -992,7 +992,7 @@ export class Popup extends EventDispatcher {
                     left: 0,
                     top: 0,
                     right: Math.max(left + width, width * scale),
-                    bottom: Math.max(top + height, height * scale)
+                    bottom: Math.max(top + height, height * scale),
                 };
             }
         }
@@ -1001,7 +1001,7 @@ export class Popup extends EventDispatcher {
             left: 0,
             top: 0,
             right: window.innerWidth,
-            bottom: window.innerHeight
+            bottom: window.innerHeight,
         };
     }
 
@@ -1121,7 +1121,7 @@ export class Popup extends EventDispatcher {
             left: rect.left * scale,
             top: rect.top * scale,
             right: rect.right * scale,
-            bottom: rect.bottom * scale
+            bottom: rect.bottom * scale,
         };
     }
 }

--- a/ext/js/app/theme-controller.js
+++ b/ext/js/app/theme-controller.js
@@ -212,7 +212,7 @@ export class ThemeController {
             Number.parseInt(m[1], 10),
             Number.parseInt(m[2], 10),
             Number.parseInt(m[3], 10),
-            m4 ? Math.max(0, Math.min(1, Number.parseFloat(m4))) : 1
+            m4 ? Math.max(0, Math.min(1, Number.parseFloat(m4))) : 1,
         ];
     }
 }

--- a/ext/js/application.js
+++ b/ext/js/application.js
@@ -115,7 +115,7 @@ export class Application extends EventDispatcher {
             ['applicationGetUrl',          this._onMessageGetUrl.bind(this)],
             ['applicationOptionsUpdated',  this._onMessageOptionsUpdated.bind(this)],
             ['applicationDatabaseUpdated', this._onMessageDatabaseUpdated.bind(this)],
-            ['applicationZoomChanged',     this._onMessageZoomChanged.bind(this)]
+            ['applicationZoomChanged',     this._onMessageZoomChanged.bind(this)],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
     }

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -75,7 +75,7 @@ export class Backend {
                 // eslint-disable-next-line no-undef
                 (typeof document === 'object' && document !== null ? document : null),
                 '#clipboard-paste-target',
-                '#clipboard-rich-content-paste-target'
+                '#clipboard-rich-content-paste-target',
             );
         } else {
             /** @type {?OffscreenProxy} */
@@ -185,7 +185,7 @@ export class Backend {
             ['getTermFrequencies',           this._onApiGetTermFrequencies.bind(this)],
             ['findAnkiNotes',                this._onApiFindAnkiNotes.bind(this)],
             ['openCrossFramePort',           this._onApiOpenCrossFramePort.bind(this)],
-            ['getLanguageSummaries',         this._onApiGetLanguageSummaries.bind(this)]
+            ['getLanguageSummaries',         this._onApiGetLanguageSummaries.bind(this)],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
 
@@ -195,7 +195,7 @@ export class Backend {
             ['openInfoPage', this._onCommandOpenInfoPage.bind(this)],
             ['openSettingsPage', this._onCommandOpenSettingsPage.bind(this)],
             ['openSearchPage', this._onCommandOpenSearchPage.bind(this)],
-            ['openPopupWindow', this._onCommandOpenPopupWindow.bind(this)]
+            ['openPopupWindow', this._onCommandOpenPopupWindow.bind(this)],
         ]));
     }
 
@@ -214,7 +214,7 @@ export class Backend {
                 (error) => {
                     this._prepareError = true;
                     this._prepareCompleteReject(error);
-                }
+                },
             );
             void promise.finally(() => this._updateBadge());
             this._preparePromise = promise;
@@ -319,7 +319,7 @@ export class Backend {
 
         const {
             general: {language},
-            clipboard: {maximumSearchLength}
+            clipboard: {maximumSearchLength},
         } = this._getProfileOptions({current: true}, false);
         if (!isTextLookupWorthy(text, language)) { return; }
         if (text.length > maximumSearchLength) {
@@ -372,7 +372,7 @@ export class Backend {
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                     handler(...args);
                 },
-                () => {} // NOP
+                () => {}, // NOP
             );
         });
     }
@@ -385,7 +385,7 @@ export class Backend {
 
         this._prepareCompletePromise.then(
             () => { this._onMessage(message, sender, sendResponse); },
-            () => { sendResponse(); }
+            () => { sendResponse(); },
         );
         return true;
     }
@@ -499,7 +499,7 @@ export class Backend {
     async _onApiParseText({text, optionsContext, scanLength, useInternalParser, useMecabParser}) {
         const [internalResults, mecabResults] = await Promise.all([
             (useInternalParser ? this._textParseScanning(text, scanLength, optionsContext) : null),
-            (useMecabParser ? this._textParseMecab(text) : null)
+            (useMecabParser ? this._textParseMecab(text) : null),
         ]);
 
         /** @type {import('api').ParseTextResultItem[]} */
@@ -510,7 +510,7 @@ export class Backend {
                 id: 'scan',
                 source: 'scanning-parser',
                 dictionary: null,
-                content: internalResults
+                content: internalResults,
             });
         }
 
@@ -520,7 +520,7 @@ export class Backend {
                     id: `mecab-${dictionary}`,
                     source: 'mecab',
                     dictionary,
-                    content
+                    content,
                 });
             }
         }
@@ -619,7 +619,7 @@ export class Backend {
                 canAdd: valid,
                 valid,
                 noteIds: noteIds,
-                noteInfos: noteInfos
+                noteInfos: noteInfos,
             };
 
             results.push(info);
@@ -637,7 +637,7 @@ export class Backend {
             audioDetails,
             screenshotDetails,
             clipboardDetails,
-            dictionaryMediaDetails
+            dictionaryMediaDetails,
         );
     }
 
@@ -715,7 +715,7 @@ export class Backend {
         const frameId = sender.frameId;
         return {
             tabId: typeof tabId === 'number' ? tabId : null,
-            frameId: typeof frameId === 'number' ? frameId : null
+            frameId: typeof frameId === 'number' ? frameId : null,
         };
     }
 
@@ -928,13 +928,13 @@ export class Backend {
         const sourceDetails = {
             name: 'cross-frame-communication-port',
             otherTabId: targetTabId,
-            otherFrameId: targetFrameId
+            otherFrameId: targetFrameId,
         };
         /** @type {import('cross-frame-api').CrossFrameCommunicationPortDetails} */
         const targetDetails = {
             name: 'cross-frame-communication-port',
             otherTabId: sourceTabId,
-            otherFrameId: sourceFrameId
+            otherFrameId: sourceFrameId,
         };
         /** @type {?chrome.runtime.Port} */
         let sourcePort = chrome.tabs.connect(sourceTabId, {frameId: sourceFrameId, name: JSON.stringify(sourceDetails)});
@@ -1067,7 +1067,7 @@ export class Backend {
             path: 'general.enable',
             value: !options.general.enable,
             scope: 'profile',
-            optionsContext: {current: true}
+            optionsContext: {current: true},
         };
         await this._modifySettings([modification], 'backend');
     }
@@ -1172,7 +1172,7 @@ export class Backend {
         await this._sendMessageTabPromise(
             id,
             {action: 'searchDisplayControllerSetMode', params: {mode: 'popup'}},
-            {frameId: 0}
+            {frameId: 0},
         );
 
         this._searchPopupTabId = id;
@@ -1192,7 +1192,7 @@ export class Backend {
                 const mode = await this._sendMessageTabPromise(
                     id,
                     {action: 'searchDisplayControllerGetMode'},
-                    {frameId: 0}
+                    {frameId: 0},
                 );
                 return mode === 'popup';
             } catch (e) {
@@ -1226,7 +1226,7 @@ export class Backend {
             left: useLeft ? left : void 0,
             top: useTop ? top : void 0,
             type: windowType,
-            state: 'normal'
+            state: 'normal',
         };
     }
 
@@ -1245,7 +1245,7 @@ export class Backend {
                     } else {
                         resolve(/** @type {chrome.windows.Window} */ (result));
                     }
-                }
+                },
             );
         });
     }
@@ -1267,7 +1267,7 @@ export class Backend {
                     } else {
                         resolve(result);
                     }
-                }
+                },
             );
         });
     }
@@ -1282,7 +1282,7 @@ export class Backend {
         await this._sendMessageTabPromise(
             tabId,
             {action: 'searchDisplayControllerUpdateSearchQuery', params: {text, animate}},
-            {frameId: 0}
+            {frameId: 0},
         );
     }
 
@@ -1455,7 +1455,7 @@ export class Backend {
             const {dictionaryEntries, originalTextLength} = await this._translator.findTerms(
                 mode,
                 text.substring(i, i + scanLength),
-                findTermsOptions
+                findTermsOptions,
             );
             const codePoint = /** @type {number} */ (text.codePointAt(i));
             const character = String.fromCodePoint(codePoint);
@@ -1509,7 +1509,7 @@ export class Backend {
                     for (const {text: text2, reading: reading2} of distributeFuriganaInflected(
                         term.length > 0 ? term : source,
                         jpConvertKatakanaToHiragana(reading),
-                        source
+                        source,
                     )) {
                         termParts.push({text: text2, reading: reading2});
                     }
@@ -1721,7 +1721,7 @@ export class Backend {
             const response = await this._sendMessageTabPromise(
                 tabId,
                 {action: 'applicationGetUrl'},
-                {frameId: 0}
+                {frameId: 0},
             );
             const url = typeof response === 'object' && response !== null ? /** @type {import('core').SerializableObject} */ (response).url : void 0;
             if (typeof url === 'string') {
@@ -1799,7 +1799,7 @@ export class Backend {
             const checkTabPromises = tabs.map((tab) => checkTab(tab, add));
             await Promise.race([
                 Promise.all(checkTabPromises),
-                promiseTimeout(timeout)
+                promiseTimeout(timeout),
             ]);
             return results;
         } else {
@@ -1819,7 +1819,7 @@ export class Backend {
             await Promise.race([
                 promise,
                 Promise.all(checkTabPromises),
-                promiseTimeout(timeout)
+                promiseTimeout(timeout),
             ]);
             resolve();
             return result;
@@ -1919,7 +1919,7 @@ export class Backend {
                         cleanup();
                         resolve();
                     },
-                    () => {} // NOP
+                    () => {}, // NOP
                 );
 
             if (timeout !== null) {
@@ -2136,7 +2136,7 @@ export class Backend {
             clipboardText,
             audioFileName,
             dictionaryMedia,
-            errors: errors
+            errors: errors,
         };
     }
 
@@ -2161,7 +2161,7 @@ export class Backend {
                 preferredAudioIndex,
                 term,
                 reading,
-                idleTimeout
+                idleTimeout,
             ));
         } catch (e) {
             const error = this._getAudioDownloadError(e);
@@ -2269,7 +2269,7 @@ export class Backend {
                 fileName = this._generateAnkiNoteMediaFileName(
                     `yomitan_dictionary_media_${i + 1}`,
                     extension !== null ? extension : '',
-                    timestamp
+                    timestamp,
                 );
                 try {
                     fileName = await ankiConnect.storeMediaFile(fileName, content);
@@ -2443,8 +2443,8 @@ export class Backend {
             scanning: {alphanumeric},
             translation: {
                 textReplacements: textReplacementsOptions,
-                searchResolution
-            }
+                searchResolution,
+            },
         } = options;
         const textReplacements = this._getTranslatorTextReplacements(textReplacementsOptions);
         let excludeDictionaryDefinitions = null;
@@ -2454,7 +2454,7 @@ export class Backend {
                 priority: 0,
                 allowSecondarySearches: false,
                 partsOfSpeechFilter: true,
-                useDeinflections: true
+                useDeinflections: true,
             });
             excludeDictionaryDefinitions = new Set();
             excludeDictionaryDefinitions.add(mainDictionary);
@@ -2470,7 +2470,7 @@ export class Backend {
             textReplacements,
             enabledDictionaryMap,
             excludeDictionaryDefinitions,
-            language
+            language,
         };
     }
 
@@ -2483,7 +2483,7 @@ export class Backend {
         const enabledDictionaryMap = this._getTranslatorEnabledDictionaryMap(options);
         return {
             enabledDictionaryMap,
-            removeNonJapaneseCharacters: !options.scanning.alphanumeric
+            removeNonJapaneseCharacters: !options.scanning.alphanumeric,
         };
     }
 
@@ -2501,7 +2501,7 @@ export class Backend {
                 priority,
                 allowSecondarySearches,
                 partsOfSpeechFilter,
-                useDeinflections
+                useDeinflections,
             });
         }
         return enabledDictionaryMap;
@@ -2545,7 +2545,7 @@ export class Backend {
         if (!result.openedWelcomePage) {
             await Promise.all([
                 this._openWelcomeGuidePage(),
-                chrome.storage.session.set({openedWelcomePage: true})
+                chrome.storage.session.set({openedWelcomePage: true}),
             ]);
         }
     }
@@ -2625,7 +2625,7 @@ export class Backend {
                     } else {
                         resolve(result);
                     }
-                }
+                },
             );
         });
     }

--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -72,9 +72,9 @@ export class OffscreenProxy {
         this._creatingOffscreen = chrome.offscreen.createDocument({
             url: 'offscreen.html',
             reasons: [
-                /** @type {chrome.offscreen.Reason} */ ('CLIPBOARD')
+                /** @type {chrome.offscreen.Reason} */ ('CLIPBOARD'),
             ],
-            justification: 'Access to the clipboard'
+            justification: 'Access to the clipboard',
         });
         await this._creatingOffscreen;
         this._creatingOffscreen = null;
@@ -96,9 +96,9 @@ export class OffscreenProxy {
 
         const contexts = await chrome.runtime.getContexts({
             contextTypes: [
-                /** @type {chrome.runtime.ContextType} */ ('OFFSCREEN_DOCUMENT')
+                /** @type {chrome.runtime.ContextType} */ ('OFFSCREEN_DOCUMENT'),
             ],
-            documentUrls: [offscreenUrl]
+            documentUrls: [offscreenUrl],
         });
         return contexts.length > 0;
     }
@@ -199,7 +199,7 @@ export class TranslatorProxy {
         /** @type {import('offscreen').FindKanjiOptionsOffscreen} */
         const modifiedOptions = {
             ...options,
-            enabledDictionaryMap: enabledDictionaryMapList
+            enabledDictionaryMap: enabledDictionaryMapList,
         };
         return this._offscreen.sendMessagePromise({action: 'findKanjiOffscreen', params: {text, options: modifiedOptions}});
     }
@@ -222,7 +222,7 @@ export class TranslatorProxy {
             ...options,
             enabledDictionaryMap: enabledDictionaryMapList,
             excludeDictionaryDefinitions: excludeDictionaryDefinitionsList,
-            textReplacements: textReplacementsSerialized
+            textReplacements: textReplacementsSerialized,
         };
         return this._offscreen.sendMessagePromise({action: 'findTermsOffscreen', params: {mode, text, options: modifiedOptions}});
     }

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -39,7 +39,7 @@ export class Offscreen {
         this._clipboardReader = new ClipboardReader(
             (typeof document === 'object' && document !== null ? document : null),
             '#clipboard-paste-target',
-            '#clipboard-rich-content-paste-target'
+            '#clipboard-rich-content-paste-target',
         );
 
 
@@ -57,7 +57,7 @@ export class Offscreen {
             ['findKanjiOffscreen',           this._findKanjiHandler.bind(this)],
             ['findTermsOffscreen',           this._findTermsHandler.bind(this)],
             ['getTermFrequenciesOffscreen',  this._getTermFrequenciesHandler.bind(this)],
-            ['clearDatabaseCachesOffscreen', this._clearDatabaseCachesHandler.bind(this)]
+            ['clearDatabaseCachesOffscreen', this._clearDatabaseCachesHandler.bind(this)],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
 
@@ -120,7 +120,7 @@ export class Offscreen {
         /** @type {import('translation').FindKanjiOptions} */
         const modifiedOptions = {
             ...options,
-            enabledDictionaryMap: new Map(options.enabledDictionaryMap)
+            enabledDictionaryMap: new Map(options.enabledDictionaryMap),
         };
         return await this._translator.findKanji(text, modifiedOptions);
     }
@@ -147,7 +147,7 @@ export class Offscreen {
             ...options,
             enabledDictionaryMap,
             excludeDictionaryDefinitions,
-            textReplacements
+            textReplacements,
         };
         return this._translator.findTerms(mode, text, modifiedOptions);
     }

--- a/ext/js/background/profile-conditions-util.js
+++ b/ext/js/background/profile-conditions-util.js
@@ -31,18 +31,18 @@ const descriptors = new Map([
                 ['lessThan', createSchemaPopupLevelLessThan.bind(this)],
                 ['greaterThan', createSchemaPopupLevelGreaterThan.bind(this)],
                 ['lessThanOrEqual', createSchemaPopupLevelLessThanOrEqual.bind(this)],
-                ['greaterThanOrEqual', createSchemaPopupLevelGreaterThanOrEqual.bind(this)]
-            ]))
-        }
+                ['greaterThanOrEqual', createSchemaPopupLevelGreaterThanOrEqual.bind(this)],
+            ])),
+        },
     ],
     [
         'url',
         {
             operators: new Map(/** @type {import('profile-conditions-util').OperatorMapArray} */ ([
                 ['matchDomain', createSchemaUrlMatchDomain.bind(this)],
-                ['matchRegExp', createSchemaUrlMatchRegExp.bind(this)]
-            ]))
-        }
+                ['matchRegExp', createSchemaUrlMatchRegExp.bind(this)],
+            ])),
+        },
     ],
     [
         'modifierKeys',
@@ -51,9 +51,9 @@ const descriptors = new Map([
                 ['are', createSchemaModifierKeysAre.bind(this)],
                 ['areNot', createSchemaModifierKeysAreNot.bind(this)],
                 ['include', createSchemaModifierKeysInclude.bind(this)],
-                ['notInclude', createSchemaModifierKeysNotInclude.bind(this)]
-            ]))
-        }
+                ['notInclude', createSchemaModifierKeysNotInclude.bind(this)],
+            ])),
+        },
     ],
     [
         'flags',
@@ -62,10 +62,10 @@ const descriptors = new Map([
                 ['are', createSchemaFlagsAre.bind(this)],
                 ['areNot', createSchemaFlagsAreNot.bind(this)],
                 ['include', createSchemaFlagsInclude.bind(this)],
-                ['notInclude', createSchemaFlagsNotInclude.bind(this)]
-            ]))
-        }
-    ]
+                ['notInclude', createSchemaFlagsNotInclude.bind(this)],
+            ])),
+        },
+    ],
 ]);
 
 /**
@@ -156,8 +156,8 @@ function createSchemaPopupLevelEqual(value) {
     return {
         required: ['depth'],
         properties: {
-            depth: {const: number}
-        }
+            depth: {const: number},
+        },
     };
 }
 
@@ -168,8 +168,8 @@ function createSchemaPopupLevelEqual(value) {
 function createSchemaPopupLevelNotEqual(value) {
     return {
         not: {
-            anyOf: [createSchemaPopupLevelEqual(value)]
-        }
+            anyOf: [createSchemaPopupLevelEqual(value)],
+        },
     };
 }
 
@@ -182,8 +182,8 @@ function createSchemaPopupLevelLessThan(value) {
     return {
         required: ['depth'],
         properties: {
-            depth: {type: 'number', exclusiveMaximum: number}
-        }
+            depth: {type: 'number', exclusiveMaximum: number},
+        },
     };
 }
 
@@ -196,8 +196,8 @@ function createSchemaPopupLevelGreaterThan(value) {
     return {
         required: ['depth'],
         properties: {
-            depth: {type: 'number', exclusiveMinimum: number}
-        }
+            depth: {type: 'number', exclusiveMinimum: number},
+        },
     };
 }
 
@@ -210,8 +210,8 @@ function createSchemaPopupLevelLessThanOrEqual(value) {
     return {
         required: ['depth'],
         properties: {
-            depth: {type: 'number', maximum: number}
-        }
+            depth: {type: 'number', maximum: number},
+        },
     };
 }
 
@@ -224,8 +224,8 @@ function createSchemaPopupLevelGreaterThanOrEqual(value) {
     return {
         required: ['depth'],
         properties: {
-            depth: {type: 'number', minimum: number}
-        }
+            depth: {type: 'number', minimum: number},
+        },
     };
 }
 
@@ -245,8 +245,8 @@ function createSchemaUrlMatchDomain(value) {
     return {
         required: ['domain'],
         properties: {
-            domain: {oneOf}
-        }
+            domain: {oneOf},
+        },
     };
 }
 
@@ -258,8 +258,8 @@ function createSchemaUrlMatchRegExp(value) {
     return {
         required: ['url'],
         properties: {
-            url: {type: 'string', pattern: value, patternFlags: 'i'}
-        }
+            url: {type: 'string', pattern: value, patternFlags: 'i'},
+        },
     };
 }
 
@@ -280,8 +280,8 @@ function createSchemaModifierKeysAre(value) {
 function createSchemaModifierKeysAreNot(value) {
     return {
         not: {
-            anyOf: [createSchemaArrayCheck('modifierKeys', value, true, false)]
-        }
+            anyOf: [createSchemaArrayCheck('modifierKeys', value, true, false)],
+        },
     };
 }
 
@@ -318,8 +318,8 @@ function createSchemaFlagsAre(value) {
 function createSchemaFlagsAreNot(value) {
     return {
         not: {
-            anyOf: [createSchemaArrayCheck('flags', value, true, false)]
-        }
+            anyOf: [createSchemaArrayCheck('flags', value, true, false)],
+        },
     };
 }
 
@@ -355,14 +355,14 @@ function createSchemaArrayCheck(key, value, exact, none) {
         if (item.length === 0) { continue; }
         containsList.push({
             contains: {
-                const: item
-            }
+                const: item,
+            },
         });
     }
     const containsListCount = containsList.length;
     /** @type {import('ext/json-schema').Schema} */
     const schema = {
-        type: 'array'
+        type: 'array',
     };
     if (exact) {
         schema.maxItems = containsListCount;
@@ -380,7 +380,7 @@ function createSchemaArrayCheck(key, value, exact, none) {
     return {
         required: [key],
         properties: {
-            [key]: schema
-        }
+            [key]: schema,
+        },
     };
 }

--- a/ext/js/background/request-builder.js
+++ b/ext/js/background/request-builder.js
@@ -63,29 +63,29 @@ export class RequestBuilder {
                 condition: {
                     urlFilter: `|${this._escapeDnrUrl(url)}|`,
                     resourceTypes: [
-                        /** @type {chrome.declarativeNetRequest.ResourceType} */ ('xmlhttprequest')
-                    ]
+                        /** @type {chrome.declarativeNetRequest.ResourceType} */ ('xmlhttprequest'),
+                    ],
                 },
                 action: {
                     type: /** @type {chrome.declarativeNetRequest.RuleActionType} */ ('modifyHeaders'),
                     requestHeaders: [
                         {
                             operation: /** @type {chrome.declarativeNetRequest.HeaderOperation} */ ('remove'),
-                            header: 'Cookie'
+                            header: 'Cookie',
                         },
                         {
                             operation: /** @type {chrome.declarativeNetRequest.HeaderOperation} */ ('set'),
                             header: 'Origin',
-                            value: originUrl
-                        }
+                            value: originUrl,
+                        },
                     ],
                     responseHeaders: [
                         {
                             operation: /** @type {chrome.declarativeNetRequest.HeaderOperation} */ ('remove'),
-                            header: 'Set-Cookie'
-                        }
-                    ]
-                }
+                            header: 'Set-Cookie',
+                        },
+                    ],
+                },
             }];
 
             await this._updateSessionRules({addRules});

--- a/ext/js/background/script-manager.js
+++ b/ext/js/background/script-manager.js
@@ -32,7 +32,7 @@ export function injectStylesheet(type, content, tabId, frameId, allFrames) {
         /** @type {chrome.scripting.InjectionTarget} */
         const target = {
             tabId,
-            allFrames
+            allFrames,
         };
         /** @type {chrome.scripting.CSSInjection} */
         const details = (
@@ -124,7 +124,7 @@ function createContentScriptRegistrationOptions(details, id) {
     /** @type {chrome.scripting.RegisteredContentScript} */
     const options = {
         id: id,
-        persistAcrossSessions: true
+        persistAcrossSessions: true,
     };
     if (Array.isArray(css)) {
         options.css = [...css];

--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -367,7 +367,7 @@ export class AnkiConnect {
         const resultActions2 = /** @type {string[]} */ (this._normalizeArray(resultActions, -1, 'string', ', field scopes'));
         return {
             scopes: resultScopes2,
-            actions: resultActions2
+            actions: resultActions2,
         };
     }
 
@@ -435,11 +435,11 @@ export class AnkiConnect {
                 cache: 'default',
                 credentials: 'omit',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
                 },
                 redirect: 'follow',
                 referrerPolicy: 'no-referrer',
-                body: JSON.stringify(body)
+                body: JSON.stringify(body),
             });
         } catch (e) {
             const error = new ExtensionError('Anki connection failure');
@@ -654,7 +654,7 @@ export class AnkiConnect {
                 tags: tags2,
                 fields: fields2,
                 modelName,
-                cards: cards2
+                cards: cards2,
             };
             result2.push(item2);
         }

--- a/ext/js/comm/cross-frame-api.js
+++ b/ext/js/comm/cross-frame-api.js
@@ -94,7 +94,7 @@ export class CrossFrameAPIPort extends EventDispatcher {
                 responseTimeout,
                 action,
                 ack: false,
-                timer: null
+                timer: null,
             };
             this._activeInvocations.set(id, invocation);
 
@@ -248,7 +248,7 @@ export class CrossFrameAPIPort extends EventDispatcher {
             params,
             [],
             (data) => this._sendResult(id, data),
-            () => this._sendError(id, new Error(`Unknown action: ${action}`))
+            () => this._sendError(id, new Error(`Unknown action: ${action}`)),
         );
     }
 

--- a/ext/js/comm/frame-ancestry-handler.js
+++ b/ext/js/comm/frame-ancestry-handler.js
@@ -51,7 +51,7 @@ export class FrameAncestryHandler {
         if (this._isPrepared) { return; }
         window.addEventListener('message', this._onWindowMessage.bind(this), false);
         this._crossFrameApi.registerHandlers([
-            ['frameAncestryHandlerRequestFrameInfoResponse', this._onFrameAncestryHandlerRequestFrameInfoResponse.bind(this)]
+            ['frameAncestryHandlerRequestFrameInfoResponse', this._onFrameAncestryHandlerRequestFrameInfoResponse.bind(this)],
         ]);
         this._isPrepared = true;
     }
@@ -234,7 +234,7 @@ export class FrameAncestryHandler {
     _requestFrameInfo(targetWindow, originFrameId, childFrameId, uniqueId, nonce) {
         targetWindow.postMessage({
             action: this._requestMessageId,
-            params: {originFrameId, childFrameId, uniqueId, nonce}
+            params: {originFrameId, childFrameId, uniqueId, nonce},
         }, '*');
     }
 

--- a/ext/js/comm/frame-client.js
+++ b/ext/js/comm/frame-client.js
@@ -69,7 +69,7 @@ export class FrameClient {
         return {
             token: /** @type {string} */ (this._token),
             secret: /** @type {string} */ (this._secret),
-            data
+            data,
         };
     }
 

--- a/ext/js/comm/frame-offset-forwarder.js
+++ b/ext/js/comm/frame-offset-forwarder.js
@@ -35,7 +35,7 @@ export class FrameOffsetForwarder {
     prepare() {
         this._frameAncestryHandler.prepare();
         this._crossFrameApi.registerHandlers([
-            ['frameOffsetForwarderGetChildFrameRect', this._onMessageGetChildFrameRect.bind(this)]
+            ['frameOffsetForwarderGetChildFrameRect', this._onMessageGetChildFrameRect.bind(this)],
         ]);
     }
 

--- a/ext/js/core/api-map.js
+++ b/ext/js/core/api-map.js
@@ -80,7 +80,7 @@ export function invokeApiMapHandler(map, name, params, extraParams, callback, ha
         if (promiseOrResult instanceof Promise) {
             /** @type {Promise<unknown>} */ (promiseOrResult).then(
                 (result) => { callback({result}); },
-                (error) => { callback({error: ExtensionError.serialize(error)}); }
+                (error) => { callback({error: ExtensionError.serialize(error)}); },
             );
             return true;
         } else {

--- a/ext/js/core/extension-error.js
+++ b/ext/js/core/extension-error.js
@@ -49,7 +49,7 @@ export class ExtensionError extends Error {
                 const result = {
                     name: typeof name === 'string' ? name : '',
                     message: typeof message === 'string' ? message : '',
-                    stack: typeof stack === 'string' ? stack : ''
+                    stack: typeof stack === 'string' ? stack : '',
                 };
                 if (error instanceof ExtensionError) {
                     result.data = error.data;
@@ -61,7 +61,7 @@ export class ExtensionError extends Error {
         }
         return /** @type {import('core').SerializedError2} */ ({
             value: error,
-            hasValue: true
+            hasValue: true,
         });
     }
 

--- a/ext/js/core/fetch-utilities.js
+++ b/ext/js/core/fetch-utilities.js
@@ -28,7 +28,7 @@ async function fetchAsset(url) {
         cache: 'default',
         credentials: 'omit',
         redirect: 'follow',
-        referrerPolicy: 'no-referrer'
+        referrerPolicy: 'no-referrer',
     });
     if (!response.ok) {
         throw new Error(`Failed to fetch ${url}: ${response.status}`);

--- a/ext/js/core/utilities.js
+++ b/ext/js/core/utilities.js
@@ -249,7 +249,7 @@ export function deferPromise() {
     return {
         promise,
         resolve: /** @type {(value: T) => void} */ (resolve),
-        reject: /** @type {(reason?: import('core').RejectionReason) => void} */ (reject)
+        reject: /** @type {(reason?: import('core').RejectionReason) => void} */ (reject),
     };
 }
 

--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -59,7 +59,7 @@ export class AnkiNoteBuilder {
         resultOutputMode = 'split',
         glossaryLayoutMode = 'default',
         compactTags = false,
-        mediaOptions = null
+        mediaOptions = null,
     }) {
         let duplicateScopeDeckName = null;
         let duplicateScopeCheckChildren = false;
@@ -116,9 +116,9 @@ export class AnkiNoteBuilder {
                 duplicateScopeOptions: {
                     deckName: duplicateScopeDeckName,
                     checkChildren: duplicateScopeCheckChildren,
-                    checkAllModels: duplicateScopeCheckAllModels
-                }
-            }
+                    checkAllModels: duplicateScopeCheckAllModels,
+                },
+            },
         };
         return {note, errors: allErrors, requirements: [...uniqueRequirements.values()]};
     }
@@ -134,7 +134,7 @@ export class AnkiNoteBuilder {
         resultOutputMode = 'split',
         glossaryLayoutMode = 'default',
         compactTags = false,
-        marker
+        marker,
     }) {
         const commonData = this._createData(dictionaryEntry, mode, context, resultOutputMode, glossaryLayoutMode, compactTags, void 0);
         return await this._templateRenderer.getModifiedData({marker, commonData}, 'ankiNote');
@@ -191,7 +191,7 @@ export class AnkiNoteBuilder {
             resultOutputMode,
             glossaryLayoutMode,
             compactTags,
-            media
+            media,
         };
     }
 
@@ -314,7 +314,7 @@ export class AnkiNoteBuilder {
                 templateItems.push({
                     type: /** @type {import('anki-templates').RenderMode} */ ('ankiNote'),
                     commonData,
-                    datas
+                    datas,
                 });
             }
             items.push({template, templateItems});
@@ -439,7 +439,7 @@ export class AnkiNoteBuilder {
             audioDetails,
             screenshotDetails,
             clipboardDetails,
-            dictionaryMediaDetails
+            dictionaryMediaDetails,
         );
         const {audioFileName, screenshotFileName, clipboardImageFileName, clipboardText, dictionaryMedia: dictionaryMediaArray, errors} = injectedMedia;
         const textFurigana = textFuriganaPromise !== null ? await textFuriganaPromise : [];
@@ -463,7 +463,7 @@ export class AnkiNoteBuilder {
             clipboardText: (typeof clipboardText === 'string' ? {value: clipboardText} : void 0),
             selectionText: (typeof selectionText === 'string' ? {value: selectionText} : void 0),
             textFurigana,
-            dictionaryMedia
+            dictionaryMedia,
         };
         return {media, errors};
     }

--- a/ext/js/data/anki-note-data-creator.js
+++ b/ext/js/data/anki-note-data-creator.js
@@ -32,7 +32,7 @@ export function createAnkiNoteData(marker, {
     glossaryLayoutMode,
     compactTags,
     context,
-    media
+    media,
 }) {
     const definition = createCachedValue(getDefinition.bind(null, dictionaryEntry, context, resultOutputMode));
     const uniqueExpressions = createCachedValue(getUniqueExpressions.bind(null, dictionaryEntry));
@@ -50,7 +50,7 @@ export function createAnkiNoteData(marker, {
             clipboardText: void 0,
             selectionText: void 0,
             textFurigana: [],
-            dictionaryMedia: {}
+            dictionaryMedia: {},
         };
     }
     /** @type {import('anki-templates').NoteData} */
@@ -72,13 +72,13 @@ export function createAnkiNoteData(marker, {
         get phoneticTranscriptions() { return getCachedValue(phoneticTranscriptions); },
         get context() { return getCachedValue(context2); },
         media,
-        dictionaryEntry
+        dictionaryEntry,
     };
     Object.defineProperty(result, 'dictionaryEntry', {
         configurable: false,
         enumerable: false,
         writable: false,
-        value: dictionaryEntry
+        value: dictionaryEntry,
     });
     return result;
 }
@@ -165,8 +165,8 @@ function getPublicContext(context) {
         query,
         fullQuery,
         document: {
-            title: documentTitle
-        }
+            title: documentTitle,
+        },
     };
 }
 
@@ -255,7 +255,7 @@ function getPitches(dictionaryEntry) {
                     devoicePositions,
                     tags: convertPitchTags(tags),
                     exclusiveExpressions: exclusiveTerms,
-                    exclusiveReadings
+                    exclusiveReadings,
                 });
             }
             results.push({dictionary, pitches});
@@ -284,7 +284,7 @@ function getPhoneticTranscriptions(dictionaryEntry) {
                     ipa,
                     tags,
                     exclusiveExpressions: exclusiveTerms,
-                    exclusiveReadings
+                    exclusiveReadings,
                 });
             }
             results.push({dictionary, phoneticTranscriptions});
@@ -350,7 +350,7 @@ function getKanjiDefinition(dictionaryEntry, context) {
         get frequencyHarmonic() { return getCachedValue(frequencyHarmonic); },
         get frequencyAverage() { return getCachedValue(frequencyAverage); },
         url,
-        get cloze() { return getCachedValue(cloze); }
+        get cloze() { return getCachedValue(cloze); },
     };
 }
 
@@ -379,7 +379,7 @@ function convertKanjiStat({name, category, content, order, score, dictionary, va
         order,
         score,
         dictionary,
-        value
+        value,
     };
 }
 
@@ -396,10 +396,10 @@ function getKanjiFrequencies(dictionaryEntry) {
             dictionary,
             dictionaryOrder: {
                 index: dictionaryIndex,
-                priority: dictionaryPriority
+                priority: dictionaryPriority,
             },
             character,
-            frequency: displayValue !== null ? displayValue : frequency
+            frequency: displayValue !== null ? displayValue : frequency,
         });
     }
     return results;
@@ -453,7 +453,7 @@ function getTermDefinition(dictionaryEntry, context, resultOutputMode) {
         get dictionary() { return getCachedValue(dictionaryNames)[0]; },
         dictionaryOrder: {
             index: dictionaryIndex,
-            priority: dictionaryPriority
+            priority: dictionaryPriority,
         },
         get dictionaryNames() { return getCachedValue(dictionaryNames); },
         get expression() {
@@ -477,7 +477,7 @@ function getTermDefinition(dictionaryEntry, context, resultOutputMode) {
         sourceTermExactMatchCount,
         url,
         get cloze() { return getCachedValue(cloze); },
-        get furiganaSegments() { return getCachedValue(furiganaSegments); }
+        get furiganaSegments() { return getCachedValue(furiganaSegments); },
     };
 }
 
@@ -530,7 +530,7 @@ function getTermDictionaryEntryCommonInfo(dictionaryEntry, type) {
             dictionary,
             glossary: entries,
             definitionTags: definitionTags2,
-            only
+            only,
         });
     }
 
@@ -538,7 +538,7 @@ function getTermDictionaryEntryCommonInfo(dictionaryEntry, type) {
         uniqueTerms,
         uniqueReadings,
         definitionTags,
-        definitions: hasDefinitions ? definitions : void 0
+        definitions: hasDefinitions ? definitions : void 0,
     };
 }
 
@@ -557,12 +557,12 @@ function getTermFrequencies(dictionaryEntry) {
             dictionary,
             dictionaryOrder: {
                 index: dictionaryIndex,
-                priority: dictionaryPriority
+                priority: dictionaryPriority,
             },
             expression: term,
             reading,
             hasReading,
-            frequency: displayValue !== null ? displayValue : frequency
+            frequency: displayValue !== null ? displayValue : frequency,
         });
     }
     return results;
@@ -585,11 +585,11 @@ function getTermPitches(dictionaryEntry) {
             dictionary,
             dictionaryOrder: {
                 index: dictionaryIndex,
-                priority: dictionaryPriority
+                priority: dictionaryPriority,
             },
             expression: term,
             reading,
-            get pitches() { return getCachedValue(cachedPitches); }
+            get pitches() { return getCachedValue(cachedPitches); },
         });
     }
     return results;
@@ -605,7 +605,7 @@ function getTermPitchesInner(pitches) {
         const cachedTags = createCachedValue(convertTags.bind(null, tags));
         results.push({
             position,
-            get tags() { return getCachedValue(cachedTags); }
+            get tags() { return getCachedValue(cachedTags); },
         });
     }
     return results;
@@ -628,11 +628,11 @@ function getTermPhoneticTranscriptions(dictionaryEntry) {
             dictionary,
             dictionaryOrder: {
                 index: dictionaryIndex,
-                priority: dictionaryPriority
+                priority: dictionaryPriority,
             },
             expression: term,
             reading,
-            get phoneticTranscriptions() { return termPhoneticTranscriptions; }
+            get phoneticTranscriptions() { return termPhoneticTranscriptions; },
         });
     }
 
@@ -649,7 +649,7 @@ function getTermPhoneticTranscriptionsInner(phoneticTranscriptions) {
         const cachedTags = createCachedValue(convertTags.bind(null, tags));
         results.push({
             ipa,
-            get tags() { return getCachedValue(cachedTags); }
+            get tags() { return getCachedValue(cachedTags); },
         });
     }
     return results;
@@ -678,7 +678,7 @@ function getTermExpressions(dictionaryEntry) {
             get pitches() { return getCachedValue(pitches); },
             get furiganaSegments() { return getCachedValue(furiganaSegments); },
             get termFrequency() { return getCachedValue(termFrequency); },
-            wordClasses
+            wordClasses,
         };
         results.push(item);
     }
@@ -702,12 +702,12 @@ function getTermExpressionFrequencies(dictionaryEntry, i) {
             dictionary,
             dictionaryOrder: {
                 index: dictionaryIndex,
-                priority: dictionaryPriority
+                priority: dictionaryPriority,
             },
             expression: term,
             reading,
             hasReading,
-            frequency: displayValue !== null ? displayValue : frequency
+            frequency: displayValue !== null ? displayValue : frequency,
         });
     }
     return results;
@@ -732,11 +732,11 @@ function getTermExpressionPitches(dictionaryEntry, i) {
             dictionary,
             dictionaryOrder: {
                 index: dictionaryIndex,
-                priority: dictionaryPriority
+                priority: dictionaryPriority,
             },
             expression: term,
             reading,
-            get pitches() { return getCachedValue(cachedPitches); }
+            get pitches() { return getCachedValue(cachedPitches); },
         });
     }
     return results;
@@ -807,7 +807,7 @@ function convertTag({name, category, content, order, score, dictionaries, redund
         order,
         score,
         dictionary: (dictionaries.length > 0 ? dictionaries[0] : ''),
-        redundant
+        redundant,
     };
 }
 
@@ -835,7 +835,7 @@ function convertPitchTag({name, category, content, order, score, dictionaries, r
         score,
         content: [...content],
         dictionaries: [...dictionaries],
-        redundant
+        redundant,
     };
 }
 
@@ -881,7 +881,7 @@ function getCloze(dictionaryEntry, context) {
         prefix: text.substring(0, offset),
         body: text.substring(offset, offset + originalText.length),
         bodyKana: textSegments.join(''),
-        suffix: text.substring(offset + originalText.length)
+        suffix: text.substring(offset + originalText.length),
     };
 }
 

--- a/ext/js/data/anki-template-util.js
+++ b/ext/js/data/anki-template-util.js
@@ -63,7 +63,7 @@ export function getStandardFieldMarkers(type) {
                 'sentence',
                 'sentence-furigana',
                 'tags',
-                'url'
+                'url',
             ];
         case 'kanji':
             return [
@@ -91,7 +91,7 @@ export function getStandardFieldMarkers(type) {
                 'sentence-furigana',
                 'stroke-count',
                 'tags',
-                'url'
+                'url',
             ];
         default:
             throw new Error(`Unsupported type: ${type}`);

--- a/ext/js/data/json-schema.js
+++ b/ext/js/data/json-schema.js
@@ -355,8 +355,8 @@ export class JsonSchema {
                     schema: propertySchema,
                     stack: [
                         {schema: properties, path: 'properties'},
-                        {schema: propertySchema, path: property}
-                    ]
+                        {schema: propertySchema, path: property},
+                    ],
                 };
             }
         }
@@ -380,8 +380,8 @@ export class JsonSchema {
                     schema: itemSchema,
                     stack: [
                         {schema: prefixItems, path: 'prefixItems'},
-                        {schema: itemSchema, path: index}
-                    ]
+                        {schema: itemSchema, path: index},
+                    ],
                 };
             }
         }
@@ -395,15 +395,15 @@ export class JsonSchema {
                             schema: itemSchema,
                             stack: [
                                 {schema: items, path: 'items'},
-                                {schema: itemSchema, path: index}
-                            ]
+                                {schema: itemSchema, path: index},
+                            ],
                         };
                     }
                 }
             } else {
                 return {
                     schema: items,
-                    stack: [{schema: items, path: 'items'}]
+                    stack: [{schema: items, path: 'items'}],
                 };
             }
         }
@@ -517,7 +517,7 @@ export class JsonSchema {
                 const {schema: schema2, stack: stack2} = this._getReference(ref);
                 return {
                     schema: schema2,
-                    stack: [...stack, ...stack2]
+                    stack: [...stack, ...stack2],
                 };
             }
         }

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -82,7 +82,7 @@ export class OptionsUtil {
             profiles.push({
                 name: 'Default',
                 options: defaultProfileOptions,
-                conditionGroups: []
+                conditionGroups: [],
             });
         }
 
@@ -257,12 +257,12 @@ export class OptionsUtil {
                 const replacements = [
                     [
                         '{{#*inline "audio"}}{{/inline}}',
-                        '{{#*inline "audio"}}\n    {{~#if definition.audioFileName~}}\n        [sound:{{definition.audioFileName}}]\n    {{~/if~}}\n{{/inline}}'
+                        '{{#*inline "audio"}}\n    {{~#if definition.audioFileName~}}\n        [sound:{{definition.audioFileName}}]\n    {{~/if~}}\n{{/inline}}',
                     ],
                     [
                         '{{#*inline "tags"}}\n    {{~#each definition.definitionTags}}{{name}}{{#unless @last}}, {{/unless}}{{/each~}}\n{{/inline}}',
-                        '{{#*inline "tags"}}\n    {{~#mergeTags definition group merge}}{{this}}{{/mergeTags~}}\n{{/inline}}'
-                    ]
+                        '{{#*inline "tags"}}\n    {{~#mergeTags definition group merge}}{{this}}{{/mergeTags~}}\n{{/inline}}',
+                    ],
                 ];
 
                 for (const [pattern, replacement] of replacements) {
@@ -278,7 +278,7 @@ export class OptionsUtil {
                 }
 
                 options.anki.fieldTemplates = fieldTemplates;
-            }
+            },
         ];
     }
 
@@ -321,7 +321,7 @@ export class OptionsUtil {
                 showPitchAccentGraph: false,
                 showIframePopupsInRootFrame: false,
                 useSecurePopupFrameUrl: true,
-                usePopupShadowDom: true
+                usePopupShadowDom: true,
             },
 
             audio: {
@@ -330,7 +330,7 @@ export class OptionsUtil {
                 volume: 100,
                 autoPlay: false,
                 customSourceUrl: '',
-                textToSpeechVoice: ''
+                textToSpeechVoice: '',
             },
 
             scanning: {
@@ -348,7 +348,7 @@ export class OptionsUtil {
                 enableOnPopupExpressions: false,
                 enableOnSearchPage: true,
                 enableSearchTags: false,
-                layoutAwareScan: false
+                layoutAwareScan: false,
             },
 
             translation: {
@@ -357,7 +357,7 @@ export class OptionsUtil {
                 convertAlphabeticCharacters: 'false',
                 convertHiraganaToKatakana: 'false',
                 convertKatakanaToHiragana: 'variant',
-                collapseEmphaticSequences: 'false'
+                collapseEmphaticSequences: 'false',
             },
 
             dictionaries: {},
@@ -367,7 +367,7 @@ export class OptionsUtil {
                 enableMecabParser: false,
                 selectedParser: null,
                 termSpacing: true,
-                readingMode: 'hiragana'
+                readingMode: 'hiragana',
             },
 
             anki: {
@@ -379,8 +379,8 @@ export class OptionsUtil {
                 terms: {deck: '', model: '', fields: {}},
                 kanji: {deck: '', model: '', fields: {}},
                 duplicateScope: 'collection',
-                fieldTemplates: null
-            }
+                fieldTemplates: null,
+            },
         };
     }
 
@@ -544,7 +544,7 @@ export class OptionsUtil {
             this._updateVersion34,
             this._updateVersion35,
             this._updateVersion36,
-            this._updateVersion37
+            this._updateVersion37,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -560,8 +560,8 @@ export class OptionsUtil {
     _updateVersion1(options) {
         options.global = {
             database: {
-                prefixWildcardsSupported: false
-            }
+                prefixWildcardsSupported: false,
+            },
         };
     }
 
@@ -618,7 +618,7 @@ export class OptionsUtil {
             scanOnPenHover: true,
             scanOnPenPress: true,
             scanOnPenRelease: false,
-            preventTouchScrolling: true
+            preventTouchScrolling: true,
         });
         for (const {options: profileOptions} of options.profiles) {
             profileOptions.general.usePopupWindow = false;
@@ -628,7 +628,7 @@ export class OptionsUtil {
                 onWebPages: false,
                 onPopupPages: false,
                 onSearchPages: false,
-                onSearchQuery: false
+                onSearchQuery: false,
             };
 
             const {modifier, middleMouse} = profileOptions.scanning;
@@ -651,21 +651,21 @@ export class OptionsUtil {
                 include: modifierInput,
                 exclude: 'mouse0',
                 types: {mouse: true, touch: false, pen: false},
-                options: createInputDefaultOptions()
+                options: createInputDefaultOptions(),
             });
             if (middleMouse) {
                 scanningInputs.push({
                     include: 'mouse2',
                     exclude: '',
                     types: {mouse: true, touch: false, pen: false},
-                    options: createInputDefaultOptions()
+                    options: createInputDefaultOptions(),
                 });
             }
             scanningInputs.push({
                 include: '',
                 exclude: '',
                 types: {mouse: false, touch: true, pen: true},
-                options: createInputDefaultOptions()
+                options: createInputDefaultOptions(),
             });
             profileOptions.scanning.inputs = scanningInputs;
         }
@@ -775,7 +775,7 @@ export class OptionsUtil {
         for (const profile of options.profiles) {
             profile.options.translation.textReplacements = {
                 searchOriginal: true,
-                groups: []
+                groups: [],
             };
             profile.options.sentenceParsing = {
                 scanExtent: profile.options.anki.sentenceExt,
@@ -792,8 +792,8 @@ export class OptionsUtil {
                     {enabled: true, character1: '。', character2: null, includeCharacterAtStart: false, includeCharacterAtEnd: true},
                     {enabled: true, character1: '！', character2: null, includeCharacterAtStart: false, includeCharacterAtEnd: true},
                     {enabled: true, character1: '？', character2: null, includeCharacterAtStart: false, includeCharacterAtEnd: true},
-                    {enabled: true, character1: '…', character2: null, includeCharacterAtStart: false, includeCharacterAtEnd: true}
-                ]
+                    {enabled: true, character1: '…', character2: null, includeCharacterAtStart: false, includeCharacterAtEnd: true},
+                ],
             };
             delete profile.options.anki.sentenceExt;
             profile.options.general.popupActionBarLocation = 'top';
@@ -815,8 +815,8 @@ export class OptionsUtil {
                     {action: 'addNoteTermKana',   key: 'KeyR',      modifiers: ['alt'],  scopes: ['popup', 'search'], enabled: true},
                     {action: 'playAudio',         key: 'KeyP',      modifiers: ['alt'],  scopes: ['popup', 'search'], enabled: true},
                     {action: 'viewNote',          key: 'KeyV',      modifiers: ['alt'],  scopes: ['popup', 'search'], enabled: true},
-                    {action: 'copyHostSelection', key: 'KeyC',      modifiers: ['ctrl'], scopes: ['popup'], enabled: true}
-                ]
+                    {action: 'copyHostSelection', key: 'KeyC',      modifiers: ['ctrl'], scopes: ['popup'], enabled: true},
+                ],
             };
             /* eslint-enable @stylistic/no-multi-spaces */
             profile.options.anki.suspendNewCards = false;
@@ -828,14 +828,14 @@ export class OptionsUtil {
                 useLeft: false,
                 useTop: false,
                 windowType: 'popup',
-                windowState: 'normal'
+                windowState: 'normal',
             };
             profile.options.audio.customSourceType = 'audio';
             profile.options.clipboard = {
                 enableBackgroundMonitor: profile.options.general.enableClipboardPopups,
                 enableSearchPageMonitor: false,
                 autoSearchContent: true,
-                maximumSearchLength: profile.options.general.maximumClipboardSearchLength
+                maximumSearchLength: profile.options.general.maximumClipboardSearchLength,
             };
             delete profile.options.general.enableClipboardPopups;
             delete profile.options.general.enableClipboardMonitor;
@@ -974,7 +974,7 @@ export class OptionsUtil {
     _updateVersion14(options) {
         for (const profile of options.profiles) {
             profile.options.accessibility = {
-                forceGoogleDocsHtmlRendering: false
+                forceGoogleDocsHtmlRendering: false,
             };
         }
     }
@@ -1022,7 +1022,7 @@ export class OptionsUtil {
                     character1: character,
                     character2: null,
                     includeCharacterAtStart: false,
-                    includeCharacterAtEnd: true
+                    includeCharacterAtEnd: true,
                 });
             }
         }
@@ -1190,7 +1190,7 @@ export class OptionsUtil {
             'convertAlphabeticCharacters',
             'convertHiraganaToKatakana',
             'convertKatakanaToHiragana',
-            'collapseEmphaticSequences'
+            'collapseEmphaticSequences',
         ];
 
         for (const {options: profileOptions} of options.profiles) {
@@ -1259,7 +1259,7 @@ export class OptionsUtil {
         for (const profile of options.profiles) {
             profile.options.inputs.hotkeys.push(
                 {action: 'profilePrevious', key: 'Minus', modifiers: ['alt'], scopes: ['popup', 'search'], enabled: true},
-                {action: 'profileNext', key: 'Equal', modifiers: ['alt'], scopes: ['popup', 'search'], enabled: true}
+                {action: 'profileNext', key: 'Equal', modifiers: ['alt'], scopes: ['popup', 'search'], enabled: true},
             );
         }
     }

--- a/ext/js/data/permissions-util.js
+++ b/ext/js/data/permissions-util.js
@@ -131,7 +131,7 @@ export function hasRequiredPermissionsForOptions(permissions, options) {
         }
         const fieldsList = [
             options.anki.terms.fields,
-            options.anki.kanji.fields
+            options.anki.kanji.fields,
         ];
         for (const fields of fieldsList) {
             for (const fieldValue of Object.values(fields)) {

--- a/ext/js/dictionary/dictionary-data-util.js
+++ b/ext/js/dictionary/dictionary-data-util.js
@@ -85,7 +85,7 @@ export function groupTermFrequencies(dictionaryEntry) {
             frequencies.push({
                 term,
                 reading,
-                values: [...values.values()]
+                values: [...values.values()],
             });
         }
         results.push({dictionary, frequencies});
@@ -122,7 +122,7 @@ export function groupKanjiFrequencies(sourceFrequencies) {
         for (const {character, values} of map2.values()) {
             frequencies.push({
                 character,
-                values: [...values.values()]
+                values: [...values.values()],
             });
         }
         results.push({dictionary, frequencies});
@@ -159,7 +159,7 @@ export function getGroupedPronunciations(dictionaryEntry) {
                 groupedPronunciation = {
                     pronunciation,
                     terms: new Set(),
-                    reading
+                    reading,
                 };
                 dictionaryGroupedPronunciationList.push(groupedPronunciation);
             }
@@ -185,7 +185,7 @@ export function getGroupedPronunciations(dictionaryEntry) {
                 terms: [...terms],
                 reading,
                 exclusiveTerms,
-                exclusiveReadings
+                exclusiveReadings,
             });
         }
 

--- a/ext/js/dictionary/dictionary-database.js
+++ b/ext/js/dictionary/dictionary-database.js
@@ -68,67 +68,67 @@ export class DictionaryDatabase {
                     stores: {
                         terms: {
                             primaryKey: {keyPath: 'id', autoIncrement: true},
-                            indices: ['dictionary', 'expression', 'reading']
+                            indices: ['dictionary', 'expression', 'reading'],
                         },
                         kanji: {
                             primaryKey: {autoIncrement: true},
-                            indices: ['dictionary', 'character']
+                            indices: ['dictionary', 'character'],
                         },
                         tagMeta: {
                             primaryKey: {autoIncrement: true},
-                            indices: ['dictionary']
+                            indices: ['dictionary'],
                         },
                         dictionaries: {
                             primaryKey: {autoIncrement: true},
-                            indices: ['title', 'version']
-                        }
-                    }
+                            indices: ['title', 'version'],
+                        },
+                    },
                 }),
                 {
                     version: 30,
                     stores: {
                         termMeta: {
                             primaryKey: {autoIncrement: true},
-                            indices: ['dictionary', 'expression']
+                            indices: ['dictionary', 'expression'],
                         },
                         kanjiMeta: {
                             primaryKey: {autoIncrement: true},
-                            indices: ['dictionary', 'character']
+                            indices: ['dictionary', 'character'],
                         },
                         tagMeta: {
                             primaryKey: {autoIncrement: true},
-                            indices: ['dictionary', 'name']
-                        }
-                    }
+                            indices: ['dictionary', 'name'],
+                        },
+                    },
                 },
                 {
                     version: 40,
                     stores: {
                         terms: {
                             primaryKey: {keyPath: 'id', autoIncrement: true},
-                            indices: ['dictionary', 'expression', 'reading', 'sequence']
-                        }
-                    }
+                            indices: ['dictionary', 'expression', 'reading', 'sequence'],
+                        },
+                    },
                 },
                 {
                     version: 50,
                     stores: {
                         terms: {
                             primaryKey: {keyPath: 'id', autoIncrement: true},
-                            indices: ['dictionary', 'expression', 'reading', 'sequence', 'expressionReverse', 'readingReverse']
-                        }
-                    }
+                            indices: ['dictionary', 'expression', 'reading', 'sequence', 'expressionReverse', 'readingReverse'],
+                        },
+                    },
                 },
                 {
                     version: 60,
                     stores: {
                         media: {
                             primaryKey: {keyPath: 'id', autoIncrement: true},
-                            indices: ['dictionary', 'path']
-                        }
-                    }
-                }
-            ])
+                            indices: ['dictionary', 'path'],
+                        },
+                    },
+                },
+            ]),
         );
     }
 
@@ -179,11 +179,11 @@ export class DictionaryDatabase {
                 ['terms', 'dictionary'],
                 ['termMeta', 'dictionary'],
                 ['tagMeta', 'dictionary'],
-                ['media', 'dictionary']
+                ['media', 'dictionary'],
             ],
             [
-                ['dictionaries', 'title']
-            ]
+                ['dictionaries', 'title'],
+            ],
         ];
 
         let storeCount = 0;
@@ -196,7 +196,7 @@ export class DictionaryDatabase {
             count: 0,
             processed: 0,
             storeCount,
-            storesProcesed: 0
+            storesProcesed: 0,
         };
 
         /**
@@ -370,7 +370,7 @@ export class DictionaryDatabase {
                 ['terms', 'dictionary'],
                 ['termMeta', 'dictionary'],
                 ['tagMeta', 'dictionary'],
-                ['media', 'dictionary']
+                ['media', 'dictionary'],
             ];
             const objectStoreNames = targets.map(([objectStoreName]) => objectStoreName);
             const transaction = this._db.transaction(objectStoreNames, 'readonly');
@@ -596,7 +596,7 @@ export class DictionaryDatabase {
             score: row.score,
             dictionary: row.dictionary,
             id: row.id,
-            sequence: typeof sequence === 'number' ? sequence : -1
+            sequence: typeof sequence === 'number' ? sequence : -1,
         };
     }
 
@@ -615,7 +615,7 @@ export class DictionaryDatabase {
             tags: this._splitField(row.tags),
             definitions: row.meanings,
             stats: typeof stats === 'object' && stats !== null ? stats : {},
-            dictionary: row.dictionary
+            dictionary: row.dictionary,
         };
     }
 

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -22,7 +22,7 @@ import {
     TextWriter as TextWriter0,
     Uint8ArrayReader as Uint8ArrayReader0,
     ZipReader as ZipReader0,
-    configure
+    configure,
 } from '../../lib/zip.js';
 import {ExtensionError} from '../core/extension-error.js';
 import {parseJson} from '../core/json.js';
@@ -69,8 +69,8 @@ export class DictionaryImporter {
         configure({
             workerScripts: {
                 deflate: ['../../lib/z-worker.js'],
-                inflate: ['../../lib/z-worker.js']
-            }
+                inflate: ['../../lib/z-worker.js'],
+            },
         });
 
         // Read archive
@@ -108,7 +108,7 @@ export class DictionaryImporter {
         if (await dictionaryDatabase.dictionaryExists(dictionaryTitle)) {
             return {
                 errors: [new Error(`Dictionary ${dictionaryTitle} is already imported, skipped it.`)],
-                result: null
+                result: null,
             };
         }
 
@@ -123,7 +123,7 @@ export class DictionaryImporter {
             ['termMetaFiles', /^term_meta_bank_(\d+)\.json$/],
             ['kanjiFiles', /^kanji_bank_(\d+)\.json$/],
             ['kanjiMetaFiles', /^kanji_meta_bank_(\d+)\.json$/],
-            ['tagFiles', /^tag_bank_(\d+)\.json$/]
+            ['tagFiles', /^tag_bank_(\d+)\.json$/],
         ];
         const {termFiles, termMetaFiles, kanjiFiles, kanjiMetaFiles, tagFiles} = Object.fromEntries(this._getArchiveFiles(fileMap, queryDetails));
 
@@ -187,7 +187,7 @@ export class DictionaryImporter {
             kanji: {total: kanjiList.length},
             kanjiMeta: this._getMetaCounts(kanjiMetaList),
             tagMeta: {total: tagList.length},
-            media: {total: media.length}
+            media: {total: media.length},
         };
         const summary = this._createSummary(dictionaryTitle, version, index, {prefixWildcardsSupported, counts});
         await dictionaryDatabase.bulkAdd('dictionaries', [summary], 0, 1);
@@ -238,7 +238,7 @@ export class DictionaryImporter {
             stepIndex: 0,
             stepCount: 6,
             index: 0,
-            count: 0
+            count: 0,
         };
     }
 
@@ -282,7 +282,7 @@ export class DictionaryImporter {
             version,
             importDate: Date.now(),
             prefixWildcardsSupported,
-            counts
+            counts,
         };
 
         const {author, url, description, attribution, frequencyMode, sourceLanguage, targetLanguage} = index;
@@ -361,7 +361,7 @@ export class DictionaryImporter {
         /** @type {import('dictionary-data').TermGlossaryImage} */
         const target = {
             type: 'image',
-            path: '' // Will be populated during requirement resolution
+            path: '', // Will be populated during requirement resolution
         };
         requirements.push({type: 'image', target, source: data, entry});
         return target;
@@ -377,7 +377,7 @@ export class DictionaryImporter {
         const content = this._prepareStructuredContent(data.content, entry, requirements);
         return {
             type: 'structured-content',
-            content
+            content,
         };
     }
 
@@ -419,7 +419,7 @@ export class DictionaryImporter {
         /** @type {import('structured-content').ImageElement} */
         const target = {
             tag: 'img',
-            path: '' // Will be populated during requirement resolution
+            path: '', // Will be populated during requirement resolution
         };
         requirements.push({type: 'structured-content-image', target, source: content, entry});
         return target;
@@ -441,7 +441,7 @@ export class DictionaryImporter {
         }
 
         return {
-            media: [...media.values()]
+            media: [...media.values()],
         };
     }
 
@@ -456,7 +456,7 @@ export class DictionaryImporter {
                     context,
                     requirement.target,
                     requirement.source,
-                    requirement.entry
+                    requirement.entry,
                 );
                 break;
             case 'structured-content-image':
@@ -464,7 +464,7 @@ export class DictionaryImporter {
                     context,
                     requirement.target,
                     requirement.source,
-                    requirement.entry
+                    requirement.entry,
                 );
                 break;
             default:
@@ -495,7 +495,7 @@ export class DictionaryImporter {
             verticalAlign,
             border,
             borderRadius,
-            sizeUnits
+            sizeUnits,
         } = source;
         await this._createImageData(context, target, source, entry);
         if (typeof verticalAlign === 'string') { target.verticalAlign = verticalAlign; }
@@ -523,7 +523,7 @@ export class DictionaryImporter {
             appearance,
             background,
             collapsed,
-            collapsible
+            collapsible,
         } = source;
         const {width, height} = await this._getImageMedia(context, path, entry);
         target.path = path;
@@ -601,7 +601,7 @@ export class DictionaryImporter {
             mediaType,
             width,
             height,
-            content
+            content,
         };
         media.set(path, mediaData);
 

--- a/ext/js/dictionary/dictionary-worker-handler.js
+++ b/ext/js/dictionary/dictionary-worker-handler.js
@@ -67,7 +67,7 @@ export class DictionaryWorkerHandler {
         const onProgress = (...args) => {
             self.postMessage({
                 action: 'progress',
-                params: {args}
+                params: {args},
             });
         };
         let response;
@@ -92,7 +92,7 @@ export class DictionaryWorkerHandler {
             const {result, errors} = await dictionaryImporter.importDictionary(dictionaryDatabase, archiveContent, details);
             return {
                 result,
-                errors: errors.map((error) => ExtensionError.serialize(error))
+                errors: errors.map((error) => ExtensionError.serialize(error)),
             };
         } finally {
             void dictionaryDatabase.close();

--- a/ext/js/dictionary/dictionary-worker-media-loader.js
+++ b/ext/js/dictionary/dictionary-worker-media-loader.js
@@ -57,7 +57,7 @@ export class DictionaryWorkerMediaLoader {
             // This is executed in a Worker context, so the self needs to be force cast
             /** @type {Worker} */ (/** @type {unknown} */ (self)).postMessage({
                 action: 'getImageDetails',
-                params: {id, content, mediaType}
+                params: {id, content, mediaType},
             }, [content]);
         });
     }

--- a/ext/js/dictionary/dictionary-worker.js
+++ b/ext/js/dictionary/dictionary-worker.js
@@ -37,7 +37,7 @@ export class DictionaryWorker {
             {details, archiveContent},
             [archiveContent],
             onProgress,
-            this._formatImportDictionaryResult.bind(this)
+            this._formatImportDictionaryResult.bind(this),
         );
     }
 
@@ -82,7 +82,7 @@ export class DictionaryWorker {
                 reject,
                 onMessage: null,
                 onProgress,
-                formatResult
+                formatResult,
             };
             // Ugly typecast below due to not being able to explicitly state the template types
             /** @type {(event: MessageEvent<import('dictionary-worker').MessageData<TResponseRaw>>) => void} */
@@ -200,7 +200,7 @@ export class DictionaryWorker {
         const {result, errors} = response;
         return {
             result,
-            errors: errors.map((error) => ExtensionError.deserialize(error))
+            errors: errors.map((error) => ExtensionError.deserialize(error)),
         };
     }
 }

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -94,7 +94,7 @@ export class DisplayAnki {
         /** @type {Map<import('dictionary').DictionaryEntryType, import('display-anki').CreateMode[]>} */
         this._dictionaryEntryTypeModeMap = new Map([
             ['kanji', ['kanji']],
-            ['term', ['term-kanji', 'term-kana']]
+            ['term', ['term-kanji', 'term-kana']],
         ]);
         /** @type {HTMLElement} */
         this._menuContainer = querySelectorNotNull(document, '#popup-menus');
@@ -118,7 +118,7 @@ export class DisplayAnki {
             ['addNoteKanji',      () => { this._hotkeySaveAnkiNoteForSelectedEntry('kanji'); }],
             ['addNoteTermKanji',  () => { this._hotkeySaveAnkiNoteForSelectedEntry('term-kanji'); }],
             ['addNoteTermKana',   () => { this._hotkeySaveAnkiNoteForSelectedEntry('term-kana'); }],
-            ['viewNotes',         this._viewNotesForSelectedEntry.bind(this)]
+            ['viewNotes',         this._viewNotesForSelectedEntry.bind(this)],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
         this._display.on('optionsUpdated', this._onOptionsUpdated.bind(this));
@@ -146,7 +146,7 @@ export class DisplayAnki {
                 resultOutputMode: this._resultOutputMode,
                 glossaryLayoutMode: this._glossaryLayoutMode,
                 compactTags: this._compactTags,
-                marker: 'test'
+                marker: 'test',
             });
         } catch (e) {
             ankiNoteDataException = e;
@@ -179,7 +179,7 @@ export class DisplayAnki {
         return {
             ankiNoteData,
             ankiNoteDataException: toError(ankiNoteDataException),
-            ankiNotes
+            ankiNotes,
         };
     }
 
@@ -203,9 +203,9 @@ export class DisplayAnki {
                 terms,
                 noteGuiMode,
                 screenshot: {format, quality},
-                downloadTimeout
+                downloadTimeout,
             },
-            scanning: {length: scanLength}
+            scanning: {length: scanLength},
         } = options;
 
         this._checkForDuplicates = checkForDuplicates;
@@ -345,7 +345,7 @@ export class DisplayAnki {
             sentence,
             documentTitle,
             query,
-            fullQuery
+            fullQuery,
         };
     }
 
@@ -762,7 +762,7 @@ export class DisplayAnki {
         const results = [];
         for (let i = 0, ii = dictionaryEntries.length; i < ii; ++i) {
             results.push({
-                modeMap: new Map()
+                modeMap: new Map(),
             });
         }
 
@@ -828,14 +828,14 @@ export class DisplayAnki {
                 screenshot: {
                     format: this._screenshotFormat,
                     quality: this._screenshotQuality,
-                    contentOrigin
+                    contentOrigin,
                 },
                 textParsing: {
                     optionsContext,
-                    scanLength: this._scanLength
-                }
+                    scanLength: this._scanLength,
+                },
             },
-            requirements
+            requirements,
         });
         return {note, errors, requirements: outputRequirements};
     }

--- a/ext/js/display/display-audio.js
+++ b/ext/js/display/display-audio.js
@@ -60,7 +60,7 @@ export class DisplayAudio {
             ['text-to-speech', 'Text-to-speech'],
             ['text-to-speech-reading', 'Text-to-speech (Kana reading)'],
             ['custom', 'Custom URL'],
-            ['custom-json', 'Custom URL (JSON)']
+            ['custom-json', 'Custom URL (JSON)'],
         ]);
         /** @type {(event: MouseEvent) => void} */
         this._onAudioPlayButtonClickBind = this._onAudioPlayButtonClick.bind(this);
@@ -85,10 +85,10 @@ export class DisplayAudio {
         /* eslint-disable @stylistic/no-multi-spaces */
         this._display.hotkeyHandler.registerActions([
             ['playAudio',           this._onHotkeyActionPlayAudio.bind(this)],
-            ['playAudioFromSource', this._onHotkeyActionPlayAudioFromSource.bind(this)]
+            ['playAudioFromSource', this._onHotkeyActionPlayAudioFromSource.bind(this)],
         ]);
         this._display.registerDirectMessageHandlers([
-            ['displayAudioClearAutoPlayTimer', this._onMessageClearAutoPlayTimer.bind(this)]
+            ['displayAudioClearAutoPlayTimer', this._onMessageClearAutoPlayTimer.bind(this)],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
         this._display.on('optionsUpdated', this._onOptionsUpdated.bind(this));
@@ -172,7 +172,7 @@ export class DisplayAudio {
         const requiredAudioSources = new Set([
             'jpod101',
             'jpod101-alternate',
-            'jisho'
+            'jisho',
         ]);
         /** @type {Map<string, import('display-audio').AudioSource[]>} */
         const nameMap = new Map();
@@ -297,7 +297,7 @@ export class DisplayAudio {
             downloadable,
             name,
             nameIndex,
-            nameUnique: (nameIndex === 0)
+            nameUnique: (nameIndex === 0),
         };
 
         entries.push(source);
@@ -369,7 +369,7 @@ export class DisplayAudio {
         if (typeof cacheEntry === 'undefined' && create) {
             cacheEntry = {
                 sourceMap: new Map(),
-                primaryCardAudio: null
+                primaryCardAudio: null,
             };
             this._cache.set(key, cacheEntry);
         }
@@ -389,7 +389,7 @@ export class DisplayAudio {
                 if (indexNumber >= 0 && indexNumber < this._audioSources.length) {
                     return {
                         source: this._audioSources[indexNumber],
-                        subIndex: typeof subIndex === 'string' ? Number.parseInt(subIndex, 10) : null
+                        subIndex: typeof subIndex === 'string' ? Number.parseInt(subIndex, 10) : null,
                     };
                 }
             }
@@ -617,7 +617,7 @@ export class DisplayAudio {
         const result = {
             audio: null,
             index: -1,
-            cacheUpdated: false
+            cacheUpdated: false,
         };
         for (let i = start; i < end; ++i) {
             const item = infoList[i];

--- a/ext/js/display/display-content-manager.js
+++ b/ext/js/display/display-content-manager.js
@@ -174,7 +174,7 @@ export class DisplayContentManager {
             focus: false,
             params,
             state: null,
-            content: null
+            content: null,
         });
     }
 

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -641,7 +641,7 @@ export class DisplayGenerator {
             score: 0,
             content: [],
             dictionaries: [],
-            redundant: false
+            redundant: false,
         };
     }
 

--- a/ext/js/display/display-history.js
+++ b/ext/js/display/display-history.js
@@ -231,7 +231,7 @@ export class DisplayHistory extends EventDispatcher {
             next: null,
             previous,
             state,
-            content
+            content,
         };
         this._historyMap.set(entry.id, entry);
         return entry;

--- a/ext/js/display/display-profile-selection.js
+++ b/ext/js/display/display-profile-selection.js
@@ -132,7 +132,7 @@ export class DisplayProfileSelection {
             path: 'profileCurrent',
             value: index,
             scope: 'global',
-            optionsContext: null
+            optionsContext: null,
         };
         await this._display.application.api.modifySettings([modification], this._source);
         this._setProfilePanelVisible(false);

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -200,7 +200,7 @@ export class Display extends EventDispatcher {
             ['profileNext',       async () => { await this._setProfile(1); }],
             ['copyHostSelection', () => this._copyHostSelection()],
             ['nextEntryDifferentDictionary',     () => { this._focusEntryWithDifferentDictionary(1, true); }],
-            ['previousEntryDifferentDictionary', () => { this._focusEntryWithDifferentDictionary(-1, true); }]
+            ['previousEntryDifferentDictionary', () => { this._focusEntryWithDifferentDictionary(-1, true); }],
         ]);
         this.registerDirectMessageHandlers([
             ['displaySetOptionsContext', this._onMessageSetOptionsContext.bind(this)],
@@ -208,10 +208,10 @@ export class Display extends EventDispatcher {
             ['displaySetCustomCss',      this._onMessageSetCustomCss.bind(this)],
             ['displaySetContentScale',   this._onMessageSetContentScale.bind(this)],
             ['displayConfigure',         this._onMessageConfigure.bind(this)],
-            ['displayVisibilityChanged', this._onMessageVisibilityChanged.bind(this)]
+            ['displayVisibilityChanged', this._onMessageVisibilityChanged.bind(this)],
         ]);
         this.registerWindowMessageHandlers([
-            ['displayExtensionUnloaded', this._onMessageExtensionUnloaded.bind(this)]
+            ['displayExtensionUnloaded', this._onMessageExtensionUnloaded.bind(this)],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
     }
@@ -325,7 +325,7 @@ export class Display extends EventDispatcher {
         this._application.on('extensionUnloaded', this._onExtensionUnloaded.bind(this));
         this._application.crossFrame.registerHandlers([
             ['displayPopupMessage1', this._onDisplayPopupMessage1.bind(this)],
-            ['displayPopupMessage2', this._onDisplayPopupMessage2.bind(this)]
+            ['displayPopupMessage2', this._onDisplayPopupMessage2.bind(this)],
         ]);
         window.addEventListener('message', this._onWindowMessage.bind(this), false);
 
@@ -353,7 +353,7 @@ export class Display extends EventDispatcher {
     getContentOrigin() {
         return {
             tabId: this._contentOriginTabId,
-            frameId: this._contentOriginFrameId
+            frameId: this._contentOriginFrameId,
         };
     }
 
@@ -441,8 +441,8 @@ export class Display extends EventDispatcher {
                 layoutAwareScan: scanningOptions.layoutAwareScan,
                 preventMiddleMouse: scanningOptions.preventMiddleMouse.onSearchQuery,
                 matchTypePrefix: false,
-                sentenceParsingOptions
-            }
+                sentenceParsingOptions,
+            },
         });
 
         void this._updateNestedFrontend(options);
@@ -553,7 +553,7 @@ export class Display extends EventDispatcher {
                 optionsContext: void 0,
                 url: window.location.href,
                 sentence: {text: query, offset: 0},
-                documentTitle: document.title
+                documentTitle: document.title,
             }
         );
         if (!hasState || updateOptionsContext) {
@@ -566,8 +566,8 @@ export class Display extends EventDispatcher {
             params: this._createSearchParams(type, query, false, this._queryOffset),
             state: newState,
             content: {
-                contentOrigin: this.getContentOrigin()
-            }
+                contentOrigin: this.getContentOrigin(),
+            },
         };
         this.setContent(details);
     }
@@ -656,7 +656,7 @@ export class Display extends EventDispatcher {
                 },
                 () => {
                     reject(new Error(`Invalid action: ${action}`));
-                }
+                },
             );
         });
     }
@@ -810,12 +810,12 @@ export class Display extends EventDispatcher {
             state: {
                 sentence,
                 optionsContext,
-                cause: 'queryParser'
+                cause: 'queryParser',
             },
             content: {
                 dictionaryEntries,
-                contentOrigin: this.getContentOrigin()
-            }
+                contentOrigin: this.getContentOrigin(),
+            },
         };
         this.setContent(details);
     }
@@ -832,8 +832,8 @@ export class Display extends EventDispatcher {
             params: {type},
             state: {},
             content: {
-                contentOrigin: {tabId, frameId}
-            }
+                contentOrigin: {tabId, frameId},
+            },
         };
         this.setContent(details);
     }
@@ -911,12 +911,12 @@ export class Display extends EventDispatcher {
                     optionsContext,
                     url,
                     sentence,
-                    documentTitle
+                    documentTitle,
                 },
                 content: {
                     dictionaryEntries,
-                    contentOrigin: this.getContentOrigin()
-                }
+                    contentOrigin: this.getContentOrigin(),
+                },
             };
             this.setContent(details);
         } catch (error) {
@@ -1703,7 +1703,7 @@ export class Display extends EventDispatcher {
 
         const [{PopupFactory}, {Frontend}] = await Promise.all([
             import('../app/popup-factory.js'),
-            import('../app/frontend.js')
+            import('../app/frontend.js'),
         ]);
 
         const popupFactory = new PopupFactory(this._application);
@@ -1720,7 +1720,7 @@ export class Display extends EventDispatcher {
             allowRootFramePopupProxy: true,
             childrenSupported: this._childrenSupported,
             hotkeyHandler: this._hotkeyHandler,
-            canUseWindowPopup: true
+            canUseWindowPopup: true,
         });
         this._frontend = frontend;
         await frontend.prepare();
@@ -1827,7 +1827,7 @@ export class Display extends EventDispatcher {
                 searchKanji: false,
                 searchOnClick: true,
                 searchOnClickOnly: true,
-                textSourceGenerator: this._textSourceGenerator
+                textSourceGenerator: this._textSourceGenerator,
             });
             this._contentTextScanner.includeSelector = '.click-scannable,.click-scannable *';
             this._contentTextScanner.excludeSelector = '.scan-disable,.scan-disable *';
@@ -1857,8 +1857,8 @@ export class Display extends EventDispatcher {
                     scanOnPenPress: false,
                     scanOnPenRelease: false,
                     preventTouchScrolling: false,
-                    preventPenScrolling: false
-                }
+                    preventPenScrolling: false,
+                },
             }],
             deepContentScan: scanningOptions.deepDomScan,
             normalizeCssZoom: scanningOptions.normalizeCssZoom,
@@ -1869,7 +1869,7 @@ export class Display extends EventDispatcher {
             scanLength: scanningOptions.length,
             layoutAwareScan: scanningOptions.layoutAwareScan,
             preventMiddleMouse: false,
-            sentenceParsingOptions
+            sentenceParsingOptions,
         });
 
         this._contentTextScanner.setEnabled(true);
@@ -1894,19 +1894,19 @@ export class Display extends EventDispatcher {
             params: {
                 type,
                 query,
-                wildcards: 'off'
+                wildcards: 'off',
             },
             state: {
                 focusEntry: 0,
                 optionsContext: optionsContext !== null ? optionsContext : void 0,
                 url,
                 sentence: sentence !== null ? sentence : void 0,
-                documentTitle
+                documentTitle,
             },
             content: {
                 dictionaryEntries: dictionaryEntries !== null ? dictionaryEntries : void 0,
-                contentOrigin: this.getContentOrigin()
-            }
+                contentOrigin: this.getContentOrigin(),
+            },
         };
         /** @type {TextScanner} */ (this._contentTextScanner).clearSelection();
         this.setContent(details);
@@ -1928,8 +1928,8 @@ export class Display extends EventDispatcher {
         return {
             optionsContext: this.getOptionsContext(),
             detail: {
-                documentTitle: document.title
-            }
+                documentTitle: document.title,
+            },
         };
     }
 
@@ -2014,7 +2014,7 @@ export class Display extends EventDispatcher {
             path: 'profileCurrent',
             value: newProfile,
             scope: 'global',
-            optionsContext: null
+            optionsContext: null,
         };
         await this.application.api.modifySettings([modification], 'search');
     }

--- a/ext/js/display/option-toggle-hotkey-handler.js
+++ b/ext/js/display/option-toggle-hotkey-handler.js
@@ -49,7 +49,7 @@ export class OptionToggleHotkeyHandler {
     /** */
     prepare() {
         this._display.hotkeyHandler.registerActions([
-            ['toggleOption', this._onHotkeyActionToggleOption.bind(this)]
+            ['toggleOption', this._onHotkeyActionToggleOption.bind(this)],
         ]);
     }
 
@@ -74,7 +74,7 @@ export class OptionToggleHotkeyHandler {
             const getSettingsResponse = (await this._display.application.api.getSettings([{
                 scope: 'profile',
                 path,
-                optionsContext
+                optionsContext,
             }]))[0];
             const {error: getSettingsError} = getSettingsResponse;
             if (typeof getSettingsError !== 'undefined') {
@@ -94,7 +94,7 @@ export class OptionToggleHotkeyHandler {
                 action: 'set',
                 path,
                 value,
-                optionsContext
+                optionsContext,
             };
             const modifySettingsResponse = (await this._display.application.api.modifySettings([modification], this._source))[0];
             const {error: modifySettingsError} = modifySettingsResponse;

--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -67,7 +67,7 @@ export class QueryParser extends EventDispatcher {
             searchTerms: true,
             searchKanji: false,
             searchOnClick: true,
-            textSourceGenerator
+            textSourceGenerator,
         });
         /** @type {?(import('../language/ja/japanese-wanakana.js'))} */
         this._japaneseWanakanaModule = null;
@@ -164,7 +164,7 @@ export class QueryParser extends EventDispatcher {
             inputInfo,
             textSource,
             optionsContext,
-            sentenceOffset: this._getSentenceOffset(textSource)
+            sentenceOffset: this._getSentenceOffset(textSource),
         });
     }
 
@@ -210,7 +210,7 @@ export class QueryParser extends EventDispatcher {
             path: 'parsing.selectedParser',
             value,
             scope: 'profile',
-            optionsContext
+            optionsContext,
         };
         void this._api.modifySettings([modification], 'search');
     }

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -67,7 +67,7 @@ export class SearchDisplayController {
         this._clipboardMonitorEnabled = false;
         /** @type {import('clipboard-monitor').ClipboardReaderLike} */
         this._clipboardReaderLike = {
-            getText: this._display.application.api.clipboardGet.bind(this._display.application.api)
+            getText: this._display.application.api.clipboardGet.bind(this._display.application.api),
         };
         /** @type {ClipboardMonitor} */
         this._clipboardMonitor = new ClipboardMonitor(this._clipboardReaderLike);
@@ -75,7 +75,7 @@ export class SearchDisplayController {
         this._apiMap = createApiMap([
             ['searchDisplayControllerGetMode', this._onMessageGetMode.bind(this)],
             ['searchDisplayControllerSetMode', this._onMessageSetMode.bind(this)],
-            ['searchDisplayControllerUpdateSearchQuery', this._onExternalSearchUpdate.bind(this)]
+            ['searchDisplayControllerUpdateSearchQuery', this._onExternalSearchUpdate.bind(this)],
         ]);
     }
 
@@ -92,7 +92,7 @@ export class SearchDisplayController {
         this._display.on('contentUpdateStart', this._onContentUpdateStart.bind(this));
 
         this._display.hotkeyHandler.registerActions([
-            ['focusSearchBox', this._onActionFocusSearchBox.bind(this)]
+            ['focusSearchBox', this._onActionFocusSearchBox.bind(this)],
         ]);
 
         this._updateClipboardMonitorEnabled();
@@ -317,7 +317,7 @@ export class SearchDisplayController {
             path: 'general.enableWanakana',
             value,
             scope: 'profile',
-            optionsContext: this._display.getOptionsContext()
+            optionsContext: this._display.getOptionsContext(),
         };
         void this._display.application.api.modifySettings([modification], 'search');
     }
@@ -358,7 +358,7 @@ export class SearchDisplayController {
             path: 'profileCurrent',
             value,
             scope: 'global',
-            optionsContext: null
+            optionsContext: null,
         };
         await this._display.application.api.modifySettings([modification], 'search');
     }
@@ -477,7 +477,7 @@ export class SearchDisplayController {
             path: 'clipboard.enableSearchPageMonitor',
             value,
             scope: 'profile',
-            optionsContext: this._display.getOptionsContext()
+            optionsContext: this._display.getOptionsContext(),
         };
         await this._display.application.api.modifySettings([modification], 'search');
     }
@@ -516,7 +516,7 @@ export class SearchDisplayController {
                 (granted) => {
                     const e = chrome.runtime.lastError;
                     resolve(!e && granted);
-                }
+                },
             );
         });
     }
@@ -543,20 +543,20 @@ export class SearchDisplayController {
             focus: false,
             historyMode,
             params: {
-                query
+                query,
             },
             state: {
                 focusEntry: 0,
                 optionsContext,
                 url,
                 sentence: {text: query, offset: 0},
-                documentTitle
+                documentTitle,
             },
             content: {
                 dictionaryEntries: void 0,
                 animate,
-                contentOrigin: {tabId, frameId}
-            }
+                contentOrigin: {tabId, frameId},
+            },
         };
         if (!lookup) { details.params.lookup = 'false'; }
         this._display.setContent(details);

--- a/ext/js/display/structured-content-generator.js
+++ b/ext/js/display/structured-content-generator.js
@@ -74,7 +74,7 @@ export class StructuredContentGenerator {
             verticalAlign,
             border,
             borderRadius,
-            sizeUnits
+            sizeUnits,
         } = data;
 
         const hasPreferredWidth = (typeof preferredWidth === 'number');
@@ -144,7 +144,7 @@ export class StructuredContentGenerator {
                 path,
                 dictionary,
                 (url) => this._setImageData(node, image, imageBackground, url, false),
-                () => this._setImageData(node, image, imageBackground, null, true)
+                () => this._setImageData(node, image, imageBackground, null, true),
             );
         }
 
@@ -379,7 +379,7 @@ export class StructuredContentGenerator {
             wordBreak,
             whiteSpace,
             cursor,
-            listStyleType
+            listStyleType,
         } = contentStyle;
         if (typeof fontStyle === 'string') { style.fontStyle = fontStyle; }
         if (typeof fontWeight === 'string') { style.fontWeight = fontWeight; }

--- a/ext/js/dom/css-style-applier.js
+++ b/ext/js/dom/css-style-applier.js
@@ -63,7 +63,7 @@ export class CssStyleApplier {
             }
             styleData.push({
                 selectors: selectors2,
-                styles: styles2
+                styles: styles2,
             });
         }
     }
@@ -112,7 +112,7 @@ export class CssStyleApplier {
             cache: 'default',
             credentials: 'omit',
             redirect: 'follow',
-            referrerPolicy: 'no-referrer'
+            referrerPolicy: 'no-referrer',
         });
         if (!response.ok) {
             throw new Error(`Failed to fetch ${url}: ${response.status}`);

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -199,7 +199,7 @@ export function addFullscreenChangeEventListener(onFullscreenChanged, eventListe
         'fullscreenchange',
         'MSFullscreenChange',
         'mozfullscreenchange',
-        'webkitfullscreenchange'
+        'webkitfullscreenchange',
     ];
     for (const eventName of fullscreenEventNames) {
         if (eventListenerCollection === null) {

--- a/ext/js/dom/dom-data-binder.js
+++ b/ext/js/dom/dom-data-binder.js
@@ -56,7 +56,7 @@ export class DOMDataBinder {
             onAdded: this._createObserver.bind(this),
             onRemoved: this._removeObserver.bind(this),
             onChildrenUpdated: this._onObserverChildrenUpdated.bind(this),
-            isStale: this._isObserverStale.bind(this)
+            isStale: this._isObserverStale.bind(this),
         });
     }
 
@@ -105,7 +105,7 @@ export class DOMDataBinder {
 
         const args = targets.map(([observer]) => ({
             element: observer.element,
-            metadata: observer.metadata
+            metadata: observer.metadata,
         }));
         const responses = await this._getValues(args);
         this._applyValues(targets, responses, true);
@@ -123,7 +123,7 @@ export class DOMDataBinder {
             args.push({
                 element: observer.element,
                 metadata: observer.metadata,
-                value: task.data.value
+                value: task.data.value,
             });
             targets.push([observer, task]);
         }
@@ -181,7 +181,7 @@ export class DOMDataBinder {
             value: null,
             hasValue: false,
             onChange: null,
-            metadata
+            metadata,
         };
         observer.onChange = this._onElementChange.bind(this, observer);
 

--- a/ext/js/dom/panel-element.js
+++ b/ext/js/dom/panel-element.js
@@ -96,7 +96,7 @@ export class PanelElement extends EventDispatcher {
             this._mutationObserver.observe(this._node, {
                 attributes: true,
                 attributeFilter: ['hidden'],
-                attributeOldValue: true
+                attributeOldValue: true,
             });
         }
         super.on(eventName, callback);

--- a/ext/js/dom/popup-menu.js
+++ b/ext/js/dom/popup-menu.js
@@ -89,7 +89,7 @@ export class PopupMenu extends EventDispatcher {
         this._sourceElement.dispatchEvent(new CustomEvent('menuOpen', {
             bubbles: false,
             cancelable: false,
-            detail
+            detail,
         }));
     }
 
@@ -257,7 +257,7 @@ export class PopupMenu extends EventDispatcher {
             altKey,
             ctrlKey,
             metaKey,
-            shiftKey
+            shiftKey,
         };
         const result = this._sourceElement.dispatchEvent(new CustomEvent('menuClose', {bubbles: false, cancelable, detail}));
         if (cancelable && !result) { return false; }
@@ -280,5 +280,5 @@ Object.defineProperty(PopupMenu, 'openMenus', {
     configurable: false,
     enumerable: true,
     writable: false,
-    value: new Set()
+    value: new Set(),
 });

--- a/ext/js/dom/scroll-element.js
+++ b/ext/js/dom/scroll-element.js
@@ -121,7 +121,7 @@ export class ScrollElement {
         const t = this._easeInOutCubic((time - this._animationStartTime) / (this._animationEndTime - this._animationStartTime));
         this._scroll(
             this._lerp(this._animationStartX, this._animationEndX, t),
-            this._lerp(this._animationStartY, this._animationEndY, t)
+            this._lerp(this._animationStartY, this._animationEndY, t),
         );
 
         this._animationRequestId = window.requestAnimationFrame(this._requestAnimationFrameCallback);

--- a/ext/js/dom/selector-observer.js
+++ b/ext/js/dom/selector-observer.js
@@ -31,7 +31,7 @@ export class SelectorObserver {
         onAdded = null,
         onRemoved = null,
         onChildrenUpdated = null,
-        isStale = null
+        isStale = null,
     }) {
         /** @type {string} */
         this._selector = selector;
@@ -84,7 +84,7 @@ export class SelectorObserver {
         this._mutationObserver.observe(element, {
             attributes: !!attributes,
             childList: true,
-            subtree: true
+            subtree: true,
         });
 
         const {parentNode} = element;
@@ -92,7 +92,7 @@ export class SelectorObserver {
             type: 'childList',
             target: parentNode !== null ? parentNode : element,
             addedNodes: [element],
-            removedNodes: []
+            removedNodes: [],
         }]);
     }
 

--- a/ext/js/dom/simple-dom-parser.js
+++ b/ext/js/dom/simple-dom-parser.js
@@ -33,7 +33,7 @@ export class SimpleDOMParser {
         this._treeAdapter = this._parse5Lib.defaultTreeAdapter;
         /** @type {import('simple-dom-parser').Parse5Document} */
         this._document = this._parse5Lib.parse(content, {
-            treeAdapter: this._treeAdapter
+            treeAdapter: this._treeAdapter,
         });
         /** @type {RegExp} */
         this._patternHtmlWhitespace = /[\t\r\n\f ]+/g;

--- a/ext/js/dom/text-source-generator.js
+++ b/ext/js/dom/text-source-generator.js
@@ -174,7 +174,7 @@ export class TextSourceGenerator {
         // Result
         return {
             text: text.substring(cursorStart, cursorEnd),
-            offset: startLength - cursorStart
+            offset: startLength - cursorStart,
         };
     }
 

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -108,7 +108,7 @@ export class TextSourceRange {
             this._imposterSourceElement,
             this._cachedRects,
             this._cachedSourceRect,
-            this._disallowExpandSelection
+            this._disallowExpandSelection,
         );
     }
 
@@ -307,7 +307,7 @@ export class TextSourceRange {
         return offsetDOMRects(
             this._cachedRects,
             sourceRect.left - this._cachedSourceRect.left,
-            sourceRect.top - this._cachedSourceRect.top
+            sourceRect.top - this._cachedSourceRect.top,
         );
     }
 }

--- a/ext/js/extension/environment.js
+++ b/ext/js/extension/environment.js
@@ -47,7 +47,7 @@ export class Environment {
 
         return {
             browser,
-            platform: {os}
+            platform: {os},
         };
     }
 

--- a/ext/js/input/hotkey-handler.js
+++ b/ext/js/input/hotkey-handler.js
@@ -52,7 +52,7 @@ export class HotkeyHandler extends EventDispatcher {
         this._isPrepared = true;
         this._updateEventHandlers();
         crossFrameApi.registerHandlers([
-            ['hotkeyHandlerForwardHotkey', this._onMessageForwardHotkey.bind(this)]
+            ['hotkeyHandlerForwardHotkey', this._onMessageForwardHotkey.bind(this)],
         ]);
     }
 
@@ -114,7 +114,7 @@ export class HotkeyHandler extends EventDispatcher {
                 key,
                 modifiers: [...modifiers],
                 scopes: [...scopes],
-                enabled
+                enabled,
             });
         }
         this._updateHotkeyRegistrations();

--- a/ext/js/input/hotkey-help-controller.js
+++ b/ext/js/input/hotkey-help-controller.js
@@ -180,7 +180,7 @@ export class HotkeyHelpController {
             global,
             attributes: attributesArray,
             values,
-            defaultAttributeValues
+            defaultAttributeValues,
         };
     }
 

--- a/ext/js/input/hotkey-util.js
+++ b/ext/js/input/hotkey-util.js
@@ -38,7 +38,7 @@ export class HotkeyUtil {
             ['meta', -4],
             ['ctrl', -3],
             ['alt', -2],
-            ['shift', -1]
+            ['shift', -1],
         ]);
         /** @type {Intl.Collator} */
         this._stringComparer = new Intl.Collator('en-US'); // Invariant locale
@@ -243,14 +243,14 @@ export class HotkeyUtil {
                     ['alt', 'Alt'],
                     ['ctrl', 'Ctrl'],
                     ['shift', 'Shift'],
-                    ['meta', 'Windows']
+                    ['meta', 'Windows'],
                 ];
             case 'mac':
                 return [
                     ['alt', 'Opt'],
                     ['ctrl', 'Ctrl'],
                     ['shift', 'Shift'],
-                    ['meta', 'Cmd']
+                    ['meta', 'Cmd'],
                 ];
             case 'linux':
             case 'openbsd':
@@ -260,14 +260,14 @@ export class HotkeyUtil {
                     ['alt', 'Alt'],
                     ['ctrl', 'Ctrl'],
                     ['shift', 'Shift'],
-                    ['meta', 'Super']
+                    ['meta', 'Super'],
                 ];
             default: // 'unknown', etc
                 return [
                     ['alt', 'Alt'],
                     ['ctrl', 'Ctrl'],
                     ['shift', 'Shift'],
-                    ['meta', 'Meta']
+                    ['meta', 'Meta'],
                 ];
         }
     }

--- a/ext/js/language/ar/arabic-text-preprocessors.js
+++ b/ext/js/language/ar/arabic-text-preprocessors.js
@@ -33,7 +33,7 @@ const optionalDiacritics = [
     '\u0654', // Hamza Above
     '\u0655', // Hamza Below
     '\u0656', // Subscript Alef
-    '\u0670' // Dagger Alef
+    '\u0670', // Dagger Alef
 ];
 
 const diacriticsRegex = new RegExp(`[${optionalDiacritics.join('')}]`, 'g');
@@ -45,5 +45,5 @@ export const removeArabicScriptDiacritics = {
     options: basicTextProcessorOptions,
     process: (text, setting) => {
         return setting ? text.replace(diacriticsRegex, '') : text;
-    }
+    },
 };

--- a/ext/js/language/de/german-text-preprocessors.js
+++ b/ext/js/language/de/german-text-preprocessors.js
@@ -30,5 +30,5 @@ export const eszettPreprocessor = {
             case 'inverse':
                 return str.replace(/SS/g, 'ẞ').replace(/ss/g, 'ß');
         }
-    }
+    },
 };

--- a/ext/js/language/de/german-transforms.js
+++ b/ext/js/language/de/german-transforms.js
@@ -36,7 +36,7 @@ function separatedPrefix(prefix, conditionsIn, conditionsOut) {
             return term.replace(regex, '$1 ' + prefix);
         },
         conditionsIn,
-        conditionsOut
+        conditionsOut,
     };
 }
 
@@ -53,16 +53,16 @@ export const germanTransforms = {
     conditions: {
         v: {
             name: 'Verb',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n: {
             name: 'Noun',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         adj: {
             name: 'Adjective',
-            isDictionaryForm: true
-        }
+            isDictionaryForm: true,
+        },
     },
     transforms: [
         {
@@ -70,37 +70,37 @@ export const germanTransforms = {
             description: 'Noun formed from a verb',
             rules: [
                 suffixInflection('ung', 'en', [], []),
-                suffixInflection('lung', 'eln', [], [])
-            ]
+                suffixInflection('lung', 'eln', [], []),
+            ],
         },
         {
             name: '-bar',
             description: '-able adjective from a verb',
             rules: [
                 suffixInflection('bar', 'en', [], ['v']),
-                suffixInflection('bar', 'n', [], ['v']) // Lieferbar
-            ]
+                suffixInflection('bar', 'n', [], ['v']), // Lieferbar
+            ],
         },
         {
             name: 'negative',
             description: 'Negation',
             rules: [
-                prefixInflection('un', '', [], ['adj'])
-            ]
+                prefixInflection('un', '', [], ['adj']),
+            ],
         },
         {
             name: 'separated prefix',
             description: 'Separable prefix',
             rules: [
-                ...separatedPrefixInflections
-            ]
+                ...separatedPrefixInflections,
+            ],
         },
         {
             name: 'zu-infinitive',
             description: 'zu-infinitive',
             rules: [
-                ...zuInfinitiveInflections
-            ]
-        }
-    ]
+                ...zuInfinitiveInflections,
+            ],
+        },
+    ],
 };

--- a/ext/js/language/en/english-transforms.js
+++ b/ext/js/language/en/english-transforms.js
@@ -41,7 +41,7 @@ const pastSuffixInflections = [
 
     suffixInflection('laid', 'lay', ['v'], ['v']),
     suffixInflection('paid', 'pay', ['v'], ['v']),
-    suffixInflection('said', 'say', ['v'], ['v'])
+    suffixInflection('said', 'say', ['v'], ['v']),
 ];
 
 const ingSuffixInflections = [
@@ -49,13 +49,13 @@ const ingSuffixInflections = [
     suffixInflection('ing', 'e', ['v'], ['v']), // 'driving'
     suffixInflection('ying', 'ie', ['v'], ['v']), // 'lying'
     suffixInflection('cking', 'c', ['v'], ['v']), // 'panicking'
-    ...doubledConsonantInflection('bdgklmnprstz', 'ing', ['v'], ['v'])
+    ...doubledConsonantInflection('bdgklmnprstz', 'ing', ['v'], ['v']),
 ];
 
 const thirdPersonSgPresentSuffixInflections = [
     suffixInflection('s', '', ['v'], ['v']), // 'walks'
     suffixInflection('es', '', ['v'], ['v']), // 'teaches'
-    suffixInflection('ies', 'y', ['v'], ['v']) // 'tries'
+    suffixInflection('ies', 'y', ['v'], ['v']), // 'tries'
 ];
 
 const phrasalVerbParticles = ['aboard', 'about', 'above', 'across', 'ahead', 'alongside', 'apart', 'around', 'aside', 'astray', 'away', 'back', 'before', 'behind', 'below', 'beneath', 'besides', 'between', 'beyond', 'by', 'close', 'down', 'east', 'west', 'north', 'south', 'eastward', 'westward', 'northward', 'southward', 'forward', 'backward', 'backwards', 'forwards', 'home', 'in', 'inside', 'instead', 'near', 'off', 'on', 'opposite', 'out', 'outside', 'over', 'overhead', 'past', 'round', 'since', 'through', 'throughout', 'together', 'under', 'underneath', 'up', 'within', 'without'];
@@ -72,7 +72,7 @@ const phrasalVerbInterposedObjectRule = {
         return term.replace(new RegExp(`(?<=\\w) (?:(?!\\b(${phrasalVerbWordDisjunction})\\b).)+ (?=(?:${particlesDisjunction}))`), ' ');
     },
     conditionsIn: [],
-    conditionsOut: ['v_phr']
+    conditionsOut: ['v_phr'],
 };
 
 /**
@@ -88,7 +88,7 @@ function createPhrasalVerbInflection(inflected, deinflected) {
             return term.replace(new RegExp(`(?<=)${inflected}(?= (?:${phrasalVerbWordDisjunction}))`), deinflected);
         },
         conditionsIn: ['v_phr'],
-        conditionsOut: ['v_phr']
+        conditionsOut: ['v_phr'],
     };
 }
 
@@ -112,41 +112,41 @@ export const englishTransforms = {
         v_any: {
             name: 'Verb',
             isDictionaryForm: false,
-            subConditions: ['v', 'v_irr', 'v_phr']
+            subConditions: ['v', 'v_irr', 'v_phr'],
         },
         v: {
             name: 'Regular verb',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         v_irr: {
             name: 'Irregular verb',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         v_phr: {
             name: 'Phrasal verb',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n: {
             name: 'Noun',
             isDictionaryForm: true,
-            subConditions: ['np', 'ns']
+            subConditions: ['np', 'ns'],
         },
         np: {
             name: 'Noun plural',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         ns: {
             name: 'Noun singular',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         adj: {
             name: 'Adjective',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         adv: {
             name: 'Adverb',
-            isDictionaryForm: true
-        }
+            isDictionaryForm: true,
+        },
     },
     transforms: [
         {
@@ -157,54 +157,54 @@ export const englishTransforms = {
                 suffixInflection('es', '', ['np'], ['ns']),
                 suffixInflection('ies', 'y', ['np'], ['ns']),
                 suffixInflection('ves', 'fe', ['np'], ['ns']),
-                suffixInflection('ves', 'f', ['np'], ['ns'])
-            ]
+                suffixInflection('ves', 'f', ['np'], ['ns']),
+            ],
         },
         {
             name: 'possessive',
             description: 'Possessive form of a noun',
             rules: [
                 suffixInflection('\'s', '', ['n'], ['n']),
-                suffixInflection('s\'', 's', ['n'], ['n'])
-            ]
+                suffixInflection('s\'', 's', ['n'], ['n']),
+            ],
         },
         {
             name: 'past',
             description: 'Simple past tense of a verb',
             rules: [
                 ...pastSuffixInflections,
-                ...createPhrasalVerbInflectionsFromSuffixInflections(pastSuffixInflections)
-            ]
+                ...createPhrasalVerbInflectionsFromSuffixInflections(pastSuffixInflections),
+            ],
         },
         {
             name: 'ing',
             description: 'Present participle of a verb',
             rules: [
                 ...ingSuffixInflections,
-                ...createPhrasalVerbInflectionsFromSuffixInflections(ingSuffixInflections)
-            ]
+                ...createPhrasalVerbInflectionsFromSuffixInflections(ingSuffixInflections),
+            ],
         },
         {
             name: '3rd pers. sing. pres',
             description: 'Third person singular present tense of a verb',
             rules: [
                 ...thirdPersonSgPresentSuffixInflections,
-                ...createPhrasalVerbInflectionsFromSuffixInflections(thirdPersonSgPresentSuffixInflections)
-            ]
+                ...createPhrasalVerbInflectionsFromSuffixInflections(thirdPersonSgPresentSuffixInflections),
+            ],
         },
         {
             name: 'interposed object',
             description: 'Phrasal verb with interposed object',
             rules: [
-                phrasalVerbInterposedObjectRule
-            ]
+                phrasalVerbInterposedObjectRule,
+            ],
         },
         {
             name: 'archaic',
             description: 'Archaic form of a word',
             rules: [
-                suffixInflection('\'d', 'ed', ['v'], ['v'])
-            ]
+                suffixInflection('\'d', 'ed', ['v'], ['v']),
+            ],
         },
         {
             name: 'adverb',
@@ -212,8 +212,8 @@ export const englishTransforms = {
             rules: [
                 suffixInflection('ly', '', ['adv'], ['adj']), // 'quickly'
                 suffixInflection('ily', 'y', ['adv'], ['adj']), // 'happily'
-                suffixInflection('ly', 'le', ['adv'], ['adj']) // 'humbly'
-            ]
+                suffixInflection('ly', 'le', ['adv'], ['adj']), // 'humbly'
+            ],
         },
         {
             name: 'comparative',
@@ -222,8 +222,8 @@ export const englishTransforms = {
                 suffixInflection('er', '', ['adj'], ['adj']), // 'faster'
                 suffixInflection('er', 'e', ['adj'], ['adj']), // 'nicer'
                 suffixInflection('ier', 'y', ['adj'], ['adj']), // 'happier'
-                ...doubledConsonantInflection('bdgmnt', 'er', ['adj'], ['adj'])
-            ]
+                ...doubledConsonantInflection('bdgmnt', 'er', ['adj'], ['adj']),
+            ],
         },
         {
             name: 'superlative',
@@ -232,15 +232,15 @@ export const englishTransforms = {
                 suffixInflection('est', '', ['adj'], ['adj']), // 'fastest'
                 suffixInflection('est', 'e', ['adj'], ['adj']), // 'nicest'
                 suffixInflection('iest', 'y', ['adj'], ['adj']), // 'happiest'
-                ...doubledConsonantInflection('bdgmnt', 'est', ['adj'], ['adj'])
-            ]
+                ...doubledConsonantInflection('bdgmnt', 'est', ['adj'], ['adj']),
+            ],
         },
         {
             name: 'dropped g',
             description: 'Dropped g in -ing form of a verb',
             rules: [
-                suffixInflection('in\'', 'ing', ['v'], ['v'])
-            ]
+                suffixInflection('in\'', 'ing', ['v'], ['v']),
+            ],
         },
         {
             name: '-y',
@@ -248,37 +248,37 @@ export const englishTransforms = {
             rules: [
                 suffixInflection('y', '', ['adj'], ['n', 'v']), // 'dirty', 'pushy'
                 suffixInflection('y', 'e', ['adj'], ['n', 'v']), // 'hazy'
-                ...doubledConsonantInflection('glmnprst', 'y', [], ['n', 'v']) // 'baggy', 'saggy'
-            ]
+                ...doubledConsonantInflection('glmnprst', 'y', [], ['n', 'v']), // 'baggy', 'saggy'
+            ],
         },
         {
             name: 'un-',
             description: 'Negative form of an adjective, adverb, or verb',
             rules: [
-                prefixInflection('un', '', ['adj', 'adv', 'v'], ['adj', 'adv', 'v'])
-            ]
+                prefixInflection('un', '', ['adj', 'adv', 'v'], ['adj', 'adv', 'v']),
+            ],
         },
         {
             name: 'going-to future',
             description: 'Going-to future tense of a verb',
             rules: [
-                prefixInflection('going to ', '', ['v'], ['v'])
-            ]
+                prefixInflection('going to ', '', ['v'], ['v']),
+            ],
         },
         {
             name: 'will future',
             description: 'Will-future tense of a verb',
             rules: [
-                prefixInflection('will ', '', ['v'], ['v'])
-            ]
+                prefixInflection('will ', '', ['v'], ['v']),
+            ],
         },
         {
             name: 'imperative negative',
             description: 'Negative imperative form of a verb',
             rules: [
                 prefixInflection('don\'t ', '', ['v'], ['v']),
-                prefixInflection('do not ', '', ['v'], ['v'])
-            ]
-        }
-    ]
+                prefixInflection('do not ', '', ['v'], ['v']),
+            ],
+        },
+    ],
 };

--- a/ext/js/language/es/spanish-transforms.js
+++ b/ext/js/language/es/spanish-transforms.js
@@ -22,7 +22,7 @@ const ACCENTS = new Map([
     ['e', 'é'],
     ['i', 'í'],
     ['o', 'ó'],
-    ['u', 'ú']
+    ['u', 'ú'],
 ]);
 
 
@@ -41,37 +41,37 @@ export const spanishTransforms = {
         v: {
             name: 'Verb',
             isDictionaryForm: true,
-            subConditions: ['v_ar', 'v_er', 'v_ir']
+            subConditions: ['v_ar', 'v_er', 'v_ir'],
         },
         v_ar: {
             name: '-ar verb',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         v_er: {
             name: '-er verb',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         v_ir: {
             name: '-ir verb',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n: {
             name: 'Noun',
             isDictionaryForm: true,
-            subConditions: ['ns', 'np']
+            subConditions: ['ns', 'np'],
         },
         np: {
             name: 'Noun plural',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         ns: {
             name: 'Noun singular',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         adj: {
             name: 'Adjective',
-            isDictionaryForm: true
-        }
+            isDictionaryForm: true,
+        },
     },
     transforms: [
         {
@@ -82,15 +82,15 @@ export const spanishTransforms = {
                 suffixInflection('es', '', ['np'], ['ns']),
                 suffixInflection('ces', 'z', ['np'], ['ns']), // 'lápices' -> lápiz
                 ...[...'aeiou'].map((v) => suffixInflection(`${v}ses`, `${addAccent(v)}s`, ['np'], ['ns'])), // 'autobuses' -> autobús
-                ...[...'aeiou'].map((v) => suffixInflection(`${v}nes`, `${addAccent(v)}n`, ['np'], ['ns'])) // 'canciones' -> canción
-            ]
+                ...[...'aeiou'].map((v) => suffixInflection(`${v}nes`, `${addAccent(v)}n`, ['np'], ['ns'])), // 'canciones' -> canción
+            ],
         },
         {
             name: 'feminine adjective',
             description: 'feminine form of an adjective',
             rules: [
-                suffixInflection('a', 'o', ['adj'], ['adj'])
-            ]
+                suffixInflection('a', 'o', ['adj'], ['adj']),
+            ],
         },
         {
             name: 'present indicative',
@@ -164,8 +164,8 @@ export const spanishTransforms = {
                 wholeWordInflection('ha', 'haber', ['v'], ['v']),
                 wholeWordInflection('hemos', 'haber', ['v'], ['v']),
                 wholeWordInflection('habéis', 'haber', ['v'], ['v']),
-                wholeWordInflection('han', 'haber', ['v'], ['v'])
-            ]
-        }
-    ]
+                wholeWordInflection('han', 'haber', ['v'], ['v']),
+            ],
+        },
+    ],
 };

--- a/ext/js/language/ja/japanese-text-preprocessors.js
+++ b/ext/js/language/ja/japanese-text-preprocessors.js
@@ -23,7 +23,7 @@ import {
     convertFullWidthAlphanumericToNormal,
     convertHalfWidthKanaToFullWidth,
     convertHiraganaToKatakana as convertHiraganaToKatakanaFunction,
-    convertKatakanaToHiragana as convertKatakanaToHiraganaFunction
+    convertKatakanaToHiragana as convertKatakanaToHiraganaFunction,
 } from './japanese.js';
 
 /** @type {import('language').TextProcessor<boolean>} */
@@ -31,7 +31,7 @@ export const convertHalfWidthCharacters = {
     name: 'Convert half width characters to full width',
     description: 'ﾖﾐﾁｬﾝ → ヨミチャン',
     options: basicTextProcessorOptions,
-    process: (str, setting) => (setting ? convertHalfWidthKanaToFullWidth(str) : str)
+    process: (str, setting) => (setting ? convertHalfWidthKanaToFullWidth(str) : str),
 };
 
 
@@ -40,7 +40,7 @@ export const alphabeticToHiragana = {
     name: 'Convert alphabetic characters to hiragana',
     description: 'yomichan → よみちゃん',
     options: basicTextProcessorOptions,
-    process: (str, setting) => (setting ? convertAlphabeticToKana(str) : str)
+    process: (str, setting) => (setting ? convertAlphabeticToKana(str) : str),
 };
 
 /** @type {import('language').BidirectionalConversionPreprocessor} */
@@ -57,7 +57,7 @@ export const alphanumericWidthVariants = {
             case 'inverse':
                 return convertAlphanumericToFullWidth(str);
         }
-    }
+    },
 };
 
 /** @type {import('language').BidirectionalConversionPreprocessor} */
@@ -74,7 +74,7 @@ export const convertHiraganaToKatakana = {
             case 'inverse':
                 return convertKatakanaToHiraganaFunction(str);
         }
-    }
+    },
 };
 
 /** @type {import('language').TextProcessor<[collapseEmphatic: boolean, collapseEmphaticFull: boolean]>} */
@@ -88,5 +88,5 @@ export const collapseEmphaticSequences = {
             str = collapseEmphaticSequencesFunction(str, collapseEmphaticFull);
         }
         return str;
-    }
+    },
 };

--- a/ext/js/language/ja/japanese-transforms.js
+++ b/ext/js/language/ja/japanese-transforms.js
@@ -26,109 +26,109 @@ export const japaneseTransforms = {
             i18n: [
                 {
                     language: 'ja',
-                    name: '動詞'
-                }
+                    name: '動詞',
+                },
             ],
             isDictionaryForm: false,
-            subConditions: ['v1', 'v5', 'vk', 'vs', 'vz']
+            subConditions: ['v1', 'v5', 'vk', 'vs', 'vz'],
         },
         'v1': {
             name: 'Ichidan verb',
             i18n: [
                 {
                     language: 'ja',
-                    name: '一段動詞'
-                }
+                    name: '一段動詞',
+                },
             ],
             isDictionaryForm: true,
-            subConditions: ['v1d', 'v1p']
+            subConditions: ['v1d', 'v1p'],
         },
         'v1d': {
             name: 'Ichidan verb, dictionary form',
             i18n: [
                 {
                     language: 'ja',
-                    name: '一段動詞、辞書形'
-                }
+                    name: '一段動詞、辞書形',
+                },
             ],
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         'v1p': {
             name: 'Ichidan verb, progressive or perfect form',
             i18n: [
                 {
                     language: 'ja',
-                    name: '一段動詞、進行形または完了形'
-                }
+                    name: '一段動詞、進行形または完了形',
+                },
             ],
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         'v5': {
             name: 'Godan verb',
             i18n: [
                 {
                     language: 'ja',
-                    name: '五段動詞'
-                }
+                    name: '五段動詞',
+                },
             ],
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         'vk': {
             name: 'Kuru verb',
             i18n: [
                 {
                     language: 'ja',
-                    name: '来る動詞'
-                }
+                    name: '来る動詞',
+                },
             ],
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         'vs': {
             name: 'Suru verb',
             i18n: [
                 {
                     language: 'ja',
-                    name: 'する動詞'
-                }
+                    name: 'する動詞',
+                },
             ],
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         'vz': {
             name: 'Zuru verb',
             i18n: [
                 {
                     language: 'ja',
-                    name: 'ずる動詞'
-                }
+                    name: 'ずる動詞',
+                },
             ],
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         'adj-i': {
             name: 'Adjective with i ending',
             i18n: [
                 {
                     language: 'ja',
-                    name: '形容詞'
-                }
+                    name: '形容詞',
+                },
             ],
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         '-te': {
             name: 'Intermediate -te endings for progressive or perfect tense',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         '-ba': {
             name: 'Intermediate -ba endings for conditional contraction',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         'adv': {
             name: 'Intermediate -ku endings for adverbs',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         'past': {
             name: '-ta past form ending',
-            isDictionaryForm: false
-        }
+            isDictionaryForm: false,
+        },
     },
     transforms: [
         {
@@ -138,8 +138,8 @@ export const japaneseTransforms = {
                 {
                     language: 'ja',
                     name: 'ば',
-                    description: '仮定形'
-                }
+                    description: '仮定形',
+                },
             ],
             rules: [
                 suffixInflection('ければ', 'い', ['-ba'], ['adj-i']),
@@ -151,8 +151,8 @@ export const japaneseTransforms = {
                 suffixInflection('ねば', 'ぬ', ['-ba'], ['v5']),
                 suffixInflection('べば', 'ぶ', ['-ba'], ['v5']),
                 suffixInflection('めば', 'む', ['-ba'], ['v5']),
-                suffixInflection('れば', 'る', ['-ba'], ['v1', 'v5', 'vk', 'vs', 'vz'])
-            ]
+                suffixInflection('れば', 'る', ['-ba'], ['v1', 'v5', 'vk', 'vs', 'vz']),
+            ],
         },
         {
             name: '-ya',
@@ -161,8 +161,8 @@ export const japaneseTransforms = {
                 {
                     language: 'ja',
                     name: '～ゃ',
-                    description: '仮定形の縮約系'
-                }
+                    description: '仮定形の縮約系',
+                },
             ],
             rules: [
                 suffixInflection('けりゃ', 'ければ', [], ['-ba']),
@@ -175,8 +175,8 @@ export const japaneseTransforms = {
                 suffixInflection('にゃ', 'ねば', [], ['-ba']),
                 suffixInflection('びゃ', 'べば', [], ['-ba']),
                 suffixInflection('みゃ', 'めば', [], ['-ba']),
-                suffixInflection('りゃ', 'れば', [], ['-ba'])
-            ]
+                suffixInflection('りゃ', 'れば', [], ['-ba']),
+            ],
         },
         {
             name: '-cha',
@@ -185,8 +185,8 @@ export const japaneseTransforms = {
                 {
                     language: 'ja',
                     name: '～ちゃ',
-                    description: '「～テハ」の縮約系'
-                }
+                    description: '「～テハ」の縮約系',
+                },
             ],
             rules: [
                 suffixInflection('ちゃ', 'る', ['v5'], ['v1']),
@@ -205,8 +205,8 @@ export const japaneseTransforms = {
                 suffixInflection('為ちゃ', '為る', ['v5'], ['vs']),
                 suffixInflection('きちゃ', 'くる', ['v5'], ['vk']),
                 suffixInflection('来ちゃ', '来る', ['v5'], ['vk']),
-                suffixInflection('來ちゃ', '來る', ['v5'], ['vk'])
-            ]
+                suffixInflection('來ちゃ', '來る', ['v5'], ['vk']),
+            ],
         },
         {
             name: '-chau',
@@ -227,8 +227,8 @@ export const japaneseTransforms = {
                 suffixInflection('為ちゃう', '為る', ['v5'], ['vs']),
                 suffixInflection('きちゃう', 'くる', ['v5'], ['vk']),
                 suffixInflection('来ちゃう', '来る', ['v5'], ['vk']),
-                suffixInflection('來ちゃう', '來る', ['v5'], ['vk'])
-            ]
+                suffixInflection('來ちゃう', '來る', ['v5'], ['vk']),
+            ],
         },
         {
             name: '-chimau',
@@ -249,15 +249,15 @@ export const japaneseTransforms = {
                 suffixInflection('為ちまう', '為る', ['v5'], ['vs']),
                 suffixInflection('きちまう', 'くる', ['v5'], ['vk']),
                 suffixInflection('来ちまう', '来る', ['v5'], ['vk']),
-                suffixInflection('來ちまう', '來る', ['v5'], ['vk'])
-            ]
+                suffixInflection('來ちまう', '來る', ['v5'], ['vk']),
+            ],
         },
         {
             name: '-shimau',
             rules: [
                 suffixInflection('てしまう', 'て', ['v5'], ['-te']),
-                suffixInflection('でしまう', 'で', ['v5'], ['-te'])
-            ]
+                suffixInflection('でしまう', 'で', ['v5'], ['-te']),
+            ],
         },
         {
             name: '-nasai',
@@ -277,8 +277,8 @@ export const japaneseTransforms = {
                 suffixInflection('為なさい', '為る', [], ['vs']),
                 suffixInflection('きなさい', 'くる', [], ['vk']),
                 suffixInflection('来なさい', '来る', [], ['vk']),
-                suffixInflection('來なさい', '來る', [], ['vk'])
-            ]
+                suffixInflection('來なさい', '來る', [], ['vk']),
+            ],
         },
         {
             name: '-sou',
@@ -299,8 +299,8 @@ export const japaneseTransforms = {
                 suffixInflection('為そう', '為る', [], ['vs']),
                 suffixInflection('きそう', 'くる', [], ['vk']),
                 suffixInflection('来そう', '来る', [], ['vk']),
-                suffixInflection('來そう', '來る', [], ['vk'])
-            ]
+                suffixInflection('來そう', '來る', [], ['vk']),
+            ],
         },
         {
             name: '-sugiru',
@@ -321,8 +321,8 @@ export const japaneseTransforms = {
                 suffixInflection('為すぎる', '為る', ['v1'], ['vs']),
                 suffixInflection('きすぎる', 'くる', ['v1'], ['vk']),
                 suffixInflection('来すぎる', '来る', ['v1'], ['vk']),
-                suffixInflection('來すぎる', '來る', ['v1'], ['vk'])
-            ]
+                suffixInflection('來すぎる', '來る', ['v1'], ['vk']),
+            ],
         },
         {
             name: '-tai',
@@ -342,8 +342,8 @@ export const japaneseTransforms = {
                 suffixInflection('為たい', '為る', ['adj-i'], ['vs']),
                 suffixInflection('きたい', 'くる', ['adj-i'], ['vk']),
                 suffixInflection('来たい', '来る', ['adj-i'], ['vk']),
-                suffixInflection('來たい', '來る', ['adj-i'], ['vk'])
-            ]
+                suffixInflection('來たい', '來る', ['adj-i'], ['vk']),
+            ],
         },
         {
             name: '-tara',
@@ -382,8 +382,8 @@ export const japaneseTransforms = {
                 suffixInflection('添うたら', '添う', [], ['v5']),
                 suffixInflection('副うたら', '副う', [], ['v5']),
                 suffixInflection('厭うたら', '厭う', [], ['v5']),
-                suffixInflection('のたもうたら', 'のたまう', [], ['v5'])
-            ]
+                suffixInflection('のたもうたら', 'のたまう', [], ['v5']),
+            ],
         },
         {
             name: '-tari',
@@ -422,8 +422,8 @@ export const japaneseTransforms = {
                 suffixInflection('添うたり', '添う', [], ['v5']),
                 suffixInflection('副うたり', '副う', [], ['v5']),
                 suffixInflection('厭うたり', '厭う', [], ['v5']),
-                suffixInflection('のたもうたり', 'のたまう', [], ['v5'])
-            ]
+                suffixInflection('のたもうたり', 'のたまう', [], ['v5']),
+            ],
         },
         {
             name: '-te',
@@ -463,8 +463,8 @@ export const japaneseTransforms = {
                 suffixInflection('副うて', '副う', ['-te'], ['v5']),
                 suffixInflection('厭うて', '厭う', ['-te'], ['v5']),
                 suffixInflection('のたもうて', 'のたまう', ['-te'], ['v5']),
-                suffixInflection('まして', 'ます', [], ['v'])
-            ]
+                suffixInflection('まして', 'ます', [], ['v']),
+            ],
         },
         {
             name: '-zu',
@@ -484,8 +484,8 @@ export const japaneseTransforms = {
                 suffixInflection('為ず', '為る', [], ['vs']),
                 suffixInflection('こず', 'くる', [], ['vk']),
                 suffixInflection('来ず', '来る', [], ['vk']),
-                suffixInflection('來ず', '來る', [], ['vk'])
-            ]
+                suffixInflection('來ず', '來る', [], ['vk']),
+            ],
         },
         {
             name: '-nu',
@@ -505,8 +505,8 @@ export const japaneseTransforms = {
                 suffixInflection('為ぬ', '為る', [], ['vs']),
                 suffixInflection('こぬ', 'くる', [], ['vk']),
                 suffixInflection('来ぬ', '来る', [], ['vk']),
-                suffixInflection('來ぬ', '來る', [], ['vk'])
-            ]
+                suffixInflection('來ぬ', '來る', [], ['vk']),
+            ],
         },
         {
             name: '-n',
@@ -526,8 +526,8 @@ export const japaneseTransforms = {
                 suffixInflection('為ん', '為る', [], ['vs']),
                 suffixInflection('こん', 'くる', [], ['vk']),
                 suffixInflection('来ん', '来る', [], ['vk']),
-                suffixInflection('來ん', '來る', [], ['vk'])
-            ]
+                suffixInflection('來ん', '來る', [], ['vk']),
+            ],
         },
         {
             name: '-mu',
@@ -547,8 +547,8 @@ export const japaneseTransforms = {
                 suffixInflection('為む', '為る', [], ['vs']),
                 suffixInflection('こむ', 'くる', [], ['vk']),
                 suffixInflection('来む', '来る', [], ['vk']),
-                suffixInflection('來む', '來る', [], ['vk'])
-            ]
+                suffixInflection('來む', '來る', [], ['vk']),
+            ],
         },
         {
             name: '-zaru',
@@ -568,8 +568,8 @@ export const japaneseTransforms = {
                 suffixInflection('為ざる', '為る', [], ['vs']),
                 suffixInflection('こざる', 'くる', [], ['vk']),
                 suffixInflection('来ざる', '来る', [], ['vk']),
-                suffixInflection('來ざる', '來る', [], ['vk'])
-            ]
+                suffixInflection('來ざる', '來る', [], ['vk']),
+            ],
         },
         {
             name: '-neba',
@@ -589,14 +589,14 @@ export const japaneseTransforms = {
                 suffixInflection('為ねば', '為る', [], ['vs']),
                 suffixInflection('こねば', 'くる', [], ['vk']),
                 suffixInflection('来ねば', '来る', [], ['vk']),
-                suffixInflection('來ねば', '來る', [], ['vk'])
-            ]
+                suffixInflection('來ねば', '來る', [], ['vk']),
+            ],
         },
         {
             name: 'adv',
             rules: [
-                suffixInflection('く', 'い', ['adv'], ['adj-i'])
-            ]
+                suffixInflection('く', 'い', ['adv'], ['adj-i']),
+            ],
         },
         {
             name: 'causative',
@@ -619,8 +619,8 @@ export const japaneseTransforms = {
                 suffixInflection('為させる', '為る', ['v1'], ['vs']),
                 suffixInflection('こさせる', 'くる', ['v1'], ['vk']),
                 suffixInflection('来させる', '来る', ['v1'], ['vk']),
-                suffixInflection('來させる', '來る', ['v1'], ['vk'])
-            ]
+                suffixInflection('來させる', '來る', ['v1'], ['vk']),
+            ],
         },
         {
             name: 'imperative',
@@ -644,14 +644,14 @@ export const japaneseTransforms = {
                 suffixInflection('為よ', '為る', [], ['vs']),
                 suffixInflection('こい', 'くる', [], ['vk']),
                 suffixInflection('来い', '来る', [], ['vk']),
-                suffixInflection('來い', '來る', [], ['vk'])
-            ]
+                suffixInflection('來い', '來る', [], ['vk']),
+            ],
         },
         {
             name: 'imperative negative',
             rules: [
-                suffixInflection('な', '', [], ['v'])
-            ]
+                suffixInflection('な', '', [], ['v']),
+            ],
         },
         {
             name: 'masu stem',
@@ -690,8 +690,8 @@ export const japaneseTransforms = {
                 suffixInflection('き', 'くる', [], ['vk']),
                 suffixInflection('し', 'する', [], ['vs']),
                 suffixInflection('来', '来る', [], ['vk']),
-                suffixInflection('來', '來る', [], ['vk'])
-            ]
+                suffixInflection('來', '來る', [], ['vk']),
+            ],
         },
         {
             name: 'negative',
@@ -713,14 +713,14 @@ export const japaneseTransforms = {
                 suffixInflection('こない', 'くる', ['adj-i'], ['vk']),
                 suffixInflection('来ない', '来る', ['adj-i'], ['vk']),
                 suffixInflection('來ない', '來る', ['adj-i'], ['vk']),
-                suffixInflection('ません', 'ます', ['v'], ['v'])
-            ]
+                suffixInflection('ません', 'ます', ['v'], ['v']),
+            ],
         },
         {
             name: 'noun',
             rules: [
-                suffixInflection('さ', 'い', [], ['adj-i'])
-            ]
+                suffixInflection('さ', 'い', [], ['adj-i']),
+            ],
         },
         {
             name: 'passive',
@@ -740,8 +740,8 @@ export const japaneseTransforms = {
                 suffixInflection('為れる', '為る', ['v1'], ['vs']),
                 suffixInflection('こられる', 'くる', ['v1'], ['vk']),
                 suffixInflection('来られる', '来る', ['v1'], ['vk']),
-                suffixInflection('來られる', '來る', ['v1'], ['vk'])
-            ]
+                suffixInflection('來られる', '來る', ['v1'], ['vk']),
+            ],
         },
         {
             name: 'past',
@@ -782,8 +782,8 @@ export const japaneseTransforms = {
                 suffixInflection('厭うた', '厭う', ['past'], ['v5']),
                 suffixInflection('のたもうた', 'のたまう', ['past'], ['v5']),
                 suffixInflection('ました', 'ます', ['past'], ['v']),
-                suffixInflection('ませんでした', 'ません', ['past'], ['v'])
-            ]
+                suffixInflection('ませんでした', 'ません', ['past'], ['v']),
+            ],
         },
         {
             name: 'polite',
@@ -804,8 +804,8 @@ export const japaneseTransforms = {
                 suffixInflection('きます', 'くる', ['vk'], ['vk']),
                 suffixInflection('来ます', '来る', ['vk'], ['vk']),
                 suffixInflection('來ます', '來る', ['vk'], ['vk']),
-                suffixInflection('くあります', 'い', ['v'], ['adj-i'])
-            ]
+                suffixInflection('くあります', 'い', ['v'], ['adj-i']),
+            ],
         },
         {
             name: 'potential',
@@ -823,8 +823,8 @@ export const japaneseTransforms = {
                 suffixInflection('出来る', 'する', ['v1'], ['vs']),
                 suffixInflection('これる', 'くる', ['v1'], ['vk']),
                 suffixInflection('来れる', '来る', ['v1'], ['vk']),
-                suffixInflection('來れる', '來る', ['v1'], ['vk'])
-            ]
+                suffixInflection('來れる', '來る', ['v1'], ['vk']),
+            ],
         },
         {
             name: 'potential or passive',
@@ -836,8 +836,8 @@ export const japaneseTransforms = {
                 suffixInflection('為られる', '為る', ['v1'], ['vs']),
                 suffixInflection('こられる', 'くる', ['v1'], ['vk']),
                 suffixInflection('来られる', '来る', ['v1'], ['vk']),
-                suffixInflection('來られる', '來る', ['v1'], ['vk'])
-            ]
+                suffixInflection('來られる', '來る', ['v1'], ['vk']),
+            ],
         },
         {
             name: 'volitional',
@@ -858,8 +858,8 @@ export const japaneseTransforms = {
                 suffixInflection('こよう', 'くる', [], ['vk']),
                 suffixInflection('来よう', '来る', [], ['vk']),
                 suffixInflection('來よう', '來る', [], ['vk']),
-                suffixInflection('ましょう', 'ます', [], ['v'])
-            ]
+                suffixInflection('ましょう', 'ます', [], ['v']),
+            ],
         },
         {
             name: 'causative passive',
@@ -871,8 +871,8 @@ export const japaneseTransforms = {
                 suffixInflection('ばされる', 'ぶ', ['v1'], ['v5']),
                 suffixInflection('まされる', 'む', ['v1'], ['v5']),
                 suffixInflection('らされる', 'る', ['v1'], ['v5']),
-                suffixInflection('わされる', 'う', ['v1'], ['v5'])
-            ]
+                suffixInflection('わされる', 'う', ['v1'], ['v5']),
+            ],
         },
         {
             name: '-toku',
@@ -892,8 +892,8 @@ export const japaneseTransforms = {
                 suffixInflection('為とく', '為る', ['v5'], ['vs']),
                 suffixInflection('きとく', 'くる', ['v5'], ['vk']),
                 suffixInflection('来とく', '来る', ['v5'], ['vk']),
-                suffixInflection('來とく', '來る', ['v5'], ['vk'])
-            ]
+                suffixInflection('來とく', '來る', ['v5'], ['vk']),
+            ],
         },
         {
             name: 'progressive or perfect',
@@ -905,27 +905,27 @@ export const japaneseTransforms = {
                 suffixInflection('でおる', 'で', ['v5'], ['-te']),
                 suffixInflection('でる', 'で', ['v1p'], ['-te']),
                 suffixInflection('とる', 'て', ['v5'], ['-te']),
-                suffixInflection('ないでいる', 'ない', ['v1'], ['adj-i'])
-            ]
+                suffixInflection('ないでいる', 'ない', ['v1'], ['adj-i']),
+            ],
         },
         {
             name: '-ki',
             rules: [
-                suffixInflection('き', 'い', [], ['adj-i'])
-            ]
+                suffixInflection('き', 'い', [], ['adj-i']),
+            ],
         },
         {
             name: '-ge',
             rules: [
                 suffixInflection('げ', 'い', [], ['adj-i']),
-                suffixInflection('気', 'い', [], ['adj-i'])
-            ]
+                suffixInflection('気', 'い', [], ['adj-i']),
+            ],
         },
         {
             name: '-garu',
             rules: [
-                suffixInflection('がる', 'い', ['v5'], ['adj-i'])
-            ]
+                suffixInflection('がる', 'い', ['v5'], ['adj-i']),
+            ],
         },
         {
             name: '-e',
@@ -971,8 +971,8 @@ export const japaneseTransforms = {
                 suffixInflection('でぇ', 'どい', [], ['adj-i']),
                 suffixInflection('れぇ', 'れい', [], ['adj-i']),
                 suffixInflection('べぇ', 'ばい', [], ['adj-i']),
-                suffixInflection('てぇ', 'たい', [], ['adj-i'])
-            ]
+                suffixInflection('てぇ', 'たい', [], ['adj-i']),
+            ],
         },
         {
             name: 'slang',
@@ -986,8 +986,8 @@ export const japaneseTransforms = {
                 suffixInflection('神ってる', '神がかっている', [], ['v1p']),
                 suffixInflection('じわる', 'じわじわ来る', [], ['vk']),
                 suffixInflection('おさしみ', 'おやすみ', [], []),
-                suffixInflection('おやさい', 'おやすみ', [], [])
-            ]
+                suffixInflection('おやさい', 'おやすみ', [], []),
+            ],
         },
         {
             name: 'kansai-ben',
@@ -998,8 +998,8 @@ export const japaneseTransforms = {
                 suffixInflection('せえへん', 'しない', [], ['adj-i']),
                 suffixInflection('へんかった', 'なかった', ['past'], ['past']),
                 suffixInflection('ひんかった', 'なかった', ['past'], ['past']),
-                suffixInflection('うてへん', 'ってない', [], ['adj-i'])
-            ]
+                suffixInflection('うてへん', 'ってない', [], ['adj-i']),
+            ],
         },
         {
             name: 'kansai-ben',
@@ -1019,8 +1019,8 @@ export const japaneseTransforms = {
                 suffixInflection('もうて', 'まって', ['-te'], ['-te']),
                 suffixInflection('ろうて', 'らって', ['-te'], ['-te']),
                 suffixInflection('ようて', 'やって', ['-te'], ['-te']),
-                suffixInflection('ゆうて', 'いって', ['-te'], ['-te'])
-            ]
+                suffixInflection('ゆうて', 'いって', ['-te'], ['-te']),
+            ],
         },
         {
             name: 'kansai-ben',
@@ -1040,8 +1040,8 @@ export const japaneseTransforms = {
                 suffixInflection('もうた', 'まった', ['past'], ['past']),
                 suffixInflection('ろうた', 'らった', ['past'], ['past']),
                 suffixInflection('ようた', 'やった', ['past'], ['past']),
-                suffixInflection('ゆうた', 'いった', ['past'], ['past'])
-            ]
+                suffixInflection('ゆうた', 'いった', ['past'], ['past']),
+            ],
         },
         {
             name: 'kansai-ben',
@@ -1061,8 +1061,8 @@ export const japaneseTransforms = {
                 suffixInflection('もうたら', 'まったら', [], []),
                 suffixInflection('ろうたら', 'らったら', [], []),
                 suffixInflection('ようたら', 'やったら', [], []),
-                suffixInflection('ゆうたら', 'いったら', [], [])
-            ]
+                suffixInflection('ゆうたら', 'いったら', [], []),
+            ],
         },
         {
             name: 'kansai-ben',
@@ -1078,8 +1078,8 @@ export const japaneseTransforms = {
                 suffixInflection('もう', 'まく', [], ['adv']),
                 suffixInflection('ろう', 'らく', [], ['adv']),
                 suffixInflection('よう', 'よく', [], ['adv']),
-                suffixInflection('しゅう', 'しく', [], ['adv'])
-            ]
+                suffixInflection('しゅう', 'しく', [], ['adv']),
+            ],
         },
         {
             name: 'kansai-ben',
@@ -1095,8 +1095,8 @@ export const japaneseTransforms = {
                 suffixInflection('もうて', 'まくて', ['-te'], ['-te']),
                 suffixInflection('ろうて', 'らくて', ['-te'], ['-te']),
                 suffixInflection('ようて', 'よくて', ['-te'], ['-te']),
-                suffixInflection('しゅうて', 'しくて', ['-te'], ['-te'])
-            ]
+                suffixInflection('しゅうて', 'しくて', ['-te'], ['-te']),
+            ],
         },
         {
             name: 'kansai-ben',
@@ -1112,8 +1112,8 @@ export const japaneseTransforms = {
                 suffixInflection('もうない', 'まくない', ['adj-i'], ['adj-i']),
                 suffixInflection('ろうない', 'らくない', ['adj-i'], ['adj-i']),
                 suffixInflection('ようない', 'よくない', ['adj-i'], ['adj-i']),
-                suffixInflection('しゅうない', 'しくない', ['adj-i'], ['adj-i'])
-            ]
-        }
-    ]
+                suffixInflection('しゅうない', 'しくない', ['adj-i'], ['adj-i']),
+            ],
+        },
+    ],
 };

--- a/ext/js/language/ja/japanese.js
+++ b/ext/js/language/ja/japanese.js
@@ -63,7 +63,7 @@ const CJK_IDEOGRAPH_RANGES = [
     CJK_UNIFIED_IDEOGRAPHS_EXTENSION_E_RANGE,
     CJK_UNIFIED_IDEOGRAPHS_EXTENSION_F_RANGE,
     CJK_COMPATIBILITY_IDEOGRAPHS_RANGE,
-    CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT_RANGE
+    CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT_RANGE,
 ];
 
 /**
@@ -90,7 +90,7 @@ const JAPANESE_RANGES = [
     [0xff1a, 0xff1f], // Fullwidth punctuation 2
     [0xff3b, 0xff3f], // Fullwidth punctuation 3
     [0xff5b, 0xff60], // Fullwidth punctuation 4
-    [0xffe0, 0xffee] // Currency markers
+    [0xffe0, 0xffee], // Currency markers
 ];
 
 const SMALL_KANA_SET = new Set('ぁぃぅぇぉゃゅょゎァィゥェォャュョヮ');
@@ -151,7 +151,7 @@ const HALFWIDTH_KATAKANA_MAPPING = new Map([
     ['ﾚ', 'レ--'],
     ['ﾛ', 'ロ--'],
     ['ﾜ', 'ワ--'],
-    ['ﾝ', 'ン--']
+    ['ﾝ', 'ン--'],
 ]);
 
 const VOWEL_TO_KANA_MAPPING = new Map([
@@ -160,7 +160,7 @@ const VOWEL_TO_KANA_MAPPING = new Map([
     ['u', 'ぅうくぐすずっつづぬふぶぷむゅゆるゥウクグスズッツヅヌフブプムュユルヴ'],
     ['e', 'ぇえけげせぜてでねへべぺめれゑヶェエケゲセゼテデネヘベペメレヱヶヹ'],
     ['o', 'ぉおこごそぞとどのほぼぽもょよろをォオコゴソゾトドノホボポモョヨロヲヺ'],
-    ['', 'のノ']
+    ['', 'のノ'],
 ]);
 
 /** @type {Map<string, string>} */
@@ -255,7 +255,7 @@ function segmentizeFurigana(reading, readingNormalized, groups, groupsStart) {
                 reading.substring(textLength),
                 readingNormalized.substring(textLength),
                 groups,
-                groupsStart + 1
+                groupsStart + 1,
             );
             if (segments !== null) {
                 if (reading.startsWith(text)) {
@@ -274,7 +274,7 @@ function segmentizeFurigana(reading, readingNormalized, groups, groupsStart) {
                 reading.substring(i),
                 readingNormalized.substring(i),
                 groups,
-                groupsStart + 1
+                groupsStart + 1,
             );
             if (segments !== null) {
                 if (result !== null) {

--- a/ext/js/language/ko/korean-text-processors.js
+++ b/ext/js/language/ko/korean-text-processors.js
@@ -24,7 +24,7 @@ export const disassembleHangul = {
     options: [true], // Could probably also be set to [false, true], but this way it is always on
     process: (str) => {
         return Hangul.disassemble(str, false).join('');
-    }
+    },
 };
 
 /** @type {import('language').TextProcessor<boolean>} */
@@ -34,5 +34,5 @@ export const reassembleHangul = {
     options: [true], // Could probably also be set to [false, true], but this way it is always on
     process: (str) => {
         return Hangul.assemble(str);
-    }
+    },
 };

--- a/ext/js/language/ko/korean-transforms.js
+++ b/ext/js/language/ko/korean-transforms.js
@@ -27,9 +27,9 @@ export const koreanTransforms = {
             i18n: [
                 {
                     language: 'ko',
-                    name: '동사 / 보조 동사'
-                }
-            ]
+                    name: '동사 / 보조 동사',
+                },
+            ],
         },
         adj: {
             name: 'Adjective or Auxiliary Adjective',
@@ -37,9 +37,9 @@ export const koreanTransforms = {
             i18n: [
                 {
                     language: 'ko',
-                    name: '형용사 / 보조 형용사'
-                }
-            ]
+                    name: '형용사 / 보조 형용사',
+                },
+            ],
         },
         ida: {
             name: 'Postpositional particle ida',
@@ -47,58 +47,58 @@ export const koreanTransforms = {
             i18n: [
                 {
                     language: 'ko',
-                    name: '조사 이다'
-                }
-            ]
+                    name: '조사 이다',
+                },
+            ],
         },
         p: {
             name: 'Intermediate past tense ending',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         f: {
             name: 'Intermediate future tense ending',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         eusi: {
             name: 'Intermediate formal ending',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         euob: {
             name: 'Intermediate formal ending',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         euo: {
             name: 'Intermediate formal ending',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         sao: {
             name: 'Intermediate formal ending',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         saob: {
             name: 'Intermediate formal ending',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         sab: {
             name: 'Intermediate formal ending',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         jaob: {
             name: 'Intermediate formal ending',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         jao: {
             name: 'Intermediate formal ending',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         jab: {
             name: 'Intermediate formal ending',
-            isDictionaryForm: false
+            isDictionaryForm: false,
         },
         do: {
             name: 'Intermediate ending',
-            isDictionaryForm: false
-        }
+            isDictionaryForm: false,
+        },
     },
     transforms: [
         {
@@ -137,218 +137,218 @@ export const koreanTransforms = {
                 suffixInflection('ㅣ', 'ㅣㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅠ', 'ㅠㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅜ', 'ㅜㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅡ', 'ㅡㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㅡ', 'ㅡㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-거나',
             rules: [
                 suffixInflection('ㄱㅓㄴㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㄴㅏ', '', [], ['p', 'f', 'euob', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㄴㅏ', '', [], ['p', 'f', 'euob', 'eusi']),
+            ],
         },
         {
             name: '-거늘',
             rules: [
                 suffixInflection('ㄱㅓㄴㅡㄹ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㄴㅡㄹ', '', [], ['p', 'f', 'euob', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㄴㅡㄹ', '', [], ['p', 'f', 'euob', 'eusi']),
+            ],
         },
         {
             name: '-거니',
             rules: [
                 suffixInflection('ㄱㅓㄴㅣ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㄴㅣ', '', [], ['p', 'f', 'euob', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㄴㅣ', '', [], ['p', 'f', 'euob', 'eusi']),
+            ],
         },
         {
             name: '-거니와',
             rules: [
                 suffixInflection('ㄱㅓㄴㅣㅇㅗㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㄴㅣㅇㅗㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㄴㅣㅇㅗㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-거던',
             rules: [
                 suffixInflection('ㄱㅓㄷㅓㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㄷㅓㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㄷㅓㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-거드면',
             rules: [
                 suffixInflection('ㄱㅓㄷㅡㅁㅕㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㄷㅡㅁㅕㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㄷㅡㅁㅕㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-거든',
             rules: [
                 suffixInflection('ㄱㅓㄷㅡㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㄷㅡㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㄷㅡㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-거들랑',
             rules: [
                 suffixInflection('ㄱㅓㄷㅡㄹㄹㅏㅇ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㄷㅡㄹㄹㅏㅇ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㄷㅡㄹㄹㅏㅇ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-거라',
             rules: [
-                suffixInflection('ㄱㅓㄹㅏ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄱㅓㄹㅏ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-건',
             rules: [
                 suffixInflection('ㄱㅓㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㄴ', '', [], ['p', 'f', 'euob', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㄴ', '', [], ['p', 'f', 'euob', 'eusi']),
+            ],
         },
         {
             name: '-건대',
             rules: [
                 suffixInflection('ㄱㅓㄴㄷㅐ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄱㅓㄴㄷㅐ', '', [], ['p', 'eusi', 'jaob'])
-            ]
+                suffixInflection('ㄱㅓㄴㄷㅐ', '', [], ['p', 'eusi', 'jaob']),
+            ],
         },
         {
             name: '-건마는',
             rules: [
                 suffixInflection('ㄱㅓㄴㅁㅏㄴㅡㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㄴㅁㅏㄴㅡㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㄴㅁㅏㄴㅡㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-건만',
             rules: [
                 suffixInflection('ㄱㅓㄴㅁㅏㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㄴㅁㅏㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㄴㅁㅏㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-걸랑',
             rules: [
                 suffixInflection('ㄱㅓㄹㄹㅏㅇ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㄹㄹㅏㅇ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㄹㄹㅏㅇ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-것다',
             rules: [
                 suffixInflection('ㄱㅓㅅㄷㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㅅㄷㅏ', '', [], ['p', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㅅㄷㅏ', '', [], ['p', 'eusi']),
+            ],
         },
         {
             name: '-것마는',
             rules: [
                 suffixInflection('ㄱㅓㅅㅁㅏㄴㅡㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅓㅅㅁㅏㄴㅡㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅓㅅㅁㅏㄴㅡㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-게',
             rules: [
                 suffixInflection('ㄱㅔ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅔ', '', [], ['p', 'eusi'])
-            ]
+                suffixInflection('ㄱㅔ', '', [], ['p', 'eusi']),
+            ],
         },
         {
             name: '-게끔',
             rules: [
                 suffixInflection('ㄱㅔㄲㅡㅁ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄱㅔㄲㅡㅁ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄱㅔㄲㅡㅁ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-게나',
             rules: [
                 suffixInflection('ㄱㅔㄴㅏ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄱㅔㄴㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄱㅔㄴㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-게시리',
             rules: [
                 suffixInflection('ㄱㅔㅅㅣㄹㅣ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄱㅔㅅㅣㄹㅣ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄱㅔㅅㅣㄹㅣ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-겠',
             rules: [
                 suffixInflection('ㄱㅔㅆ', 'ㄷㅏ', ['f'], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅔㅆ', '', ['f'], ['p', 'eusi'])
-            ]
+                suffixInflection('ㄱㅔㅆ', '', ['f'], ['p', 'eusi']),
+            ],
         },
         {
             name: '-고',
             rules: [
                 suffixInflection('ㄱㅗ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅗ', '', [], ['p', 'f', 'eusi', 'saob', 'euob', 'euo', 'sab', 'jaob', 'jab'])
-            ]
+                suffixInflection('ㄱㅗ', '', [], ['p', 'f', 'eusi', 'saob', 'euob', 'euo', 'sab', 'jaob', 'jab']),
+            ],
         },
         {
             name: '-고는 하다',
             rules: [
                 suffixInflection('ㄱㅗㄴㅡㄴ ㅎㅏㄷㅏ', 'ㄷㅏ', ['v'], ['v']),
-                suffixInflection('ㄱㅗㄴㅡㄴ ㅎㅏㄷㅏ', '', ['v'], ['eusi'])
-            ]
+                suffixInflection('ㄱㅗㄴㅡㄴ ㅎㅏㄷㅏ', '', ['v'], ['eusi']),
+            ],
         },
         {
             name: '-곤 하다',
             rules: [
                 suffixInflection('ㄱㅗㄴ ㅎㅏㄷㅏ', 'ㄷㅏ', ['v'], ['v']),
-                suffixInflection('ㄱㅗㄴ ㅎㅏㄷㅏ', '', ['v'], ['eusi'])
-            ]
+                suffixInflection('ㄱㅗㄴ ㅎㅏㄷㅏ', '', ['v'], ['eusi']),
+            ],
         },
         {
             name: '-고는',
             rules: [
                 suffixInflection('ㄱㅗㄴㅡㄴ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄱㅗㄴㅡㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄱㅗㄴㅡㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-곤',
             rules: [
                 suffixInflection('ㄱㅗㄴ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄱㅗㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄱㅗㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-고도',
             rules: [
                 suffixInflection('ㄱㅗㄷㅗ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅗㄷㅗ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄱㅗㄷㅗ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-고말고',
             rules: [
                 suffixInflection('ㄱㅗㅁㅏㄹㄱㅗ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅗㅁㅏㄹㄱㅗ', '', [], ['p', 'eusi'])
-            ]
+                suffixInflection('ㄱㅗㅁㅏㄹㄱㅗ', '', [], ['p', 'eusi']),
+            ],
         },
         {
             name: '-고서',
             rules: [
                 suffixInflection('ㄱㅗㅅㅓ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㄱㅗㅅㅓ', '', [], ['eusi']),
-                suffixInflection('ㅇㅏㄴㅣㄱㅗㅅㅓ', 'ㅇㅏㄴㅣㄷㅏ', [], ['adj'])
-            ]
+                suffixInflection('ㅇㅏㄴㅣㄱㅗㅅㅓ', 'ㅇㅏㄴㅣㄷㅏ', [], ['adj']),
+            ],
         },
         {
             name: '-고야',
             rules: [
                 suffixInflection('ㄱㅗㅇㅑ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄱㅗㅇㅑ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄱㅗㅇㅑ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-고자',
@@ -356,8 +356,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄱㅗㅈㅏ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㄱㅗㅈㅏ', '', [], ['eusi']),
                 suffixInflection('ㅇㅣㅆㄱㅗㅈㅏ', '있다', [], []),
-                suffixInflection('ㅇㅓㅂㅅㄱㅗㅈㅏ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄱㅗㅈㅏ', '없다', [], []),
+            ],
         },
         {
             name: '-고저',
@@ -365,118 +365,118 @@ export const koreanTransforms = {
                 suffixInflection('ㄱㅗㅈㅓ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㄱㅗㅈㅓ', '', [], ['eusi']),
                 suffixInflection('ㅇㅣㅆㄱㅗㅈㅓ', '있다', [], []),
-                suffixInflection('ㅇㅓㅂㅅㄱㅗㅈㅓ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄱㅗㅈㅓ', '없다', [], []),
+            ],
         },
         {
             name: '-관데',
             rules: [
                 suffixInflection('ㄱㅗㅏㄴㄷㅔ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅗㅏㄴㄷㅔ', '', [], ['p', 'eusi'])
-            ]
+                suffixInflection('ㄱㅗㅏㄴㄷㅔ', '', [], ['p', 'eusi']),
+            ],
         },
         {
             name: '-구나',
             rules: [
                 suffixInflection('ㄱㅜㄴㅏ', 'ㄷㅏ', [], ['adj', 'ida']),
-                suffixInflection('ㄱㅜㄴㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅜㄴㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-구려',
             rules: [
                 suffixInflection('ㄱㅜㄹㅕ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅜㄹㅕ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅜㄹㅕ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-구료',
             rules: [
                 suffixInflection('ㄱㅜㄹㅛ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅜㄹㅛ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅜㄹㅛ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-구만',
             rules: [
                 suffixInflection('ㄱㅜㅁㅏㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅜㅁㅏㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅜㅁㅏㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-구먼',
             rules: [
                 suffixInflection('ㄱㅜㅁㅓㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅜㅁㅓㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅜㅁㅓㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-구면',
             rules: [
                 suffixInflection('ㄱㅜㅁㅕㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅜㅁㅕㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅜㅁㅕㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-군',
             rules: [
                 suffixInflection('ㄱㅜㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅜㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅜㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-기',
             rules: [
                 suffixInflection('ㄱㅣ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅣ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅣ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-기로',
             rules: [
-                suffixInflection('ㄱㅣㄹㅗ', 'ㄷㅏ', [], ['v', 'adj', 'ida'])
-            ]
+                suffixInflection('ㄱㅣㄹㅗ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
+            ],
         },
         {
             name: '-기로니',
             rules: [
-                suffixInflection('ㄱㅣㄹㅗㄴㅣ', 'ㄷㅏ', [], ['v', 'adj', 'ida'])
-            ]
+                suffixInflection('ㄱㅣㄹㅗㄴㅣ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
+            ],
         },
         {
             name: '-기로서',
             rules: [
                 suffixInflection('ㄱㅣㄹㅗㅅㅓ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅣㄹㅗㅅㅓ', '', [], ['p'])
-            ]
+                suffixInflection('ㄱㅣㄹㅗㅅㅓ', '', [], ['p']),
+            ],
         },
         {
             name: '-기로서니',
             rules: [
                 suffixInflection('ㄱㅣㄹㅗㅅㅓㄴㅣ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅣㄹㅗㅅㅓㄴㅣ', '', [], ['p'])
-            ]
+                suffixInflection('ㄱㅣㄹㅗㅅㅓㄴㅣ', '', [], ['p']),
+            ],
         },
         {
             name: '-기로선들',
             rules: [
                 suffixInflection('ㄱㅣㄹㅗㅅㅓㄴㄷㅡㄹ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅣㄹㅗㅅㅓㄴㄷㅡㄹ', '', [], ['p'])
-            ]
+                suffixInflection('ㄱㅣㄹㅗㅅㅓㄴㄷㅡㄹ', '', [], ['p']),
+            ],
         },
         {
             name: '-기에',
             rules: [
                 suffixInflection('ㄱㅣㅇㅔ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅣㅇㅔ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄱㅣㅇㅔ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-길래',
             rules: [
                 suffixInflection('ㄱㅣㄹㄹㅐ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄱㅣㄹㄹㅐ', '', [], ['p', 'eusi'])
-            ]
+                suffixInflection('ㄱㅣㄹㄹㅐ', '', [], ['p', 'eusi']),
+            ],
         },
         {
             name: '-(으)ㄹ',
@@ -489,8 +489,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ거나',
@@ -503,8 +503,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄱㅓㄴㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄱㅓㄴㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄱㅓㄴㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄱㅓㄴㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㄹㄱㅓㄴㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)ㄹ걸',
@@ -517,8 +517,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄱㅓㄹ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄱㅓㄹ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄱㅓㄹ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄱㅓㄹ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄱㅓㄹ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ게',
@@ -528,8 +528,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㄱㅔ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅜㄹㄱㅔ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㄹㄱㅔ', 'ㅅㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅇㅡㄹㄱㅔ', 'ㄷㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄹㅇㅡㄹㄱㅔ', 'ㄷㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-(으)ㄹ 거야',
@@ -540,8 +540,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹ ㄱㅓㅇㅑ', 'ㅂㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅡㄹ ㄱㅓㅇㅑ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹ ㄱㅓㅇㅑ', 'ㅎㄷㅏ', [], ['adj']),
-                suffixInflection('ㄹㅇㅡㄹ ㄱㅓㅇㅑ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㄹ ㄱㅓㅇㅑ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-(으)ㄹ 거예요',
@@ -552,8 +552,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹ ㄱㅓㅇㅖㅇㅛ', 'ㅂㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅡㄹ ㄱㅓㅇㅖㅇㅛ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹ ㄱㅓㅇㅖㅇㅛ', 'ㅎㄷㅏ', [], ['adj']),
-                suffixInflection('ㄹㅇㅡㄹ ㄱㅓㅇㅖㅇㅛ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㄹ ㄱㅓㅇㅖㅇㅛ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-(으)ㄹ 것이다',
@@ -564,8 +564,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹ ㄱㅓㅅㅇㅣㄷㅏ', 'ㅂㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅡㄹ ㄱㅓㅅㅇㅣㄷㅏ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹ ㄱㅓㅅㅇㅣㄷㅏ', 'ㅎㄷㅏ', [], ['adj']),
-                suffixInflection('ㄹㅇㅡㄹ ㄱㅓㅅㅇㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㄹ ㄱㅓㅅㅇㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-(으)ㄹ 것입니다',
@@ -576,8 +576,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹ ㄱㅓㅅㅇㅣㅂㄴㅣㄷㅏ', 'ㅂㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅡㄹ ㄱㅓㅅㅇㅣㅂㄴㅣㄷㅏ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹ ㄱㅓㅅㅇㅣㅂㄴㅣㄷㅏ', 'ㅎㄷㅏ', [], ['adj']),
-                suffixInflection('ㄹㅇㅡㄹ ㄱㅓㅅㅇㅣㅂㄴㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㄹ ㄱㅓㅅㅇㅣㅂㄴㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-(으)ㄹ 거다',
@@ -588,8 +588,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹ ㄱㅓㄷㅏ', 'ㅂㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅡㄹ ㄱㅓㄷㅏ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹ ㄱㅓㄷㅏ', 'ㅎㄷㅏ', [], ['adj']),
-                suffixInflection('ㄹㅇㅡㄹ ㄱㅓㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㄹ ㄱㅓㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-(으)ㄹ 겁니다',
@@ -600,8 +600,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹ ㄱㅓㅂㄴㅣㄷㅏ', 'ㅂㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅡㄹ ㄱㅓㅂㄴㅣㄷㅏ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹ ㄱㅓㅂㄴㅣㄷㅏ', 'ㅎㄷㅏ', [], ['adj']),
-                suffixInflection('ㄹㅇㅡㄹ ㄱㅓㅂㄴㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㄹ ㄱㅓㅂㄴㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-(으)ㄹ께',
@@ -612,8 +612,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹㄲㅔ', 'ㅂㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅡㄹㄲㅔ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄲㅔ', 'ㅎㄷㅏ', [], ['adj']),
-                suffixInflection('ㄹㅇㅡㄹㄲㅔ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㄹㄲㅔ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-(으)나',
@@ -626,15 +626,15 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄴㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅡㄴㅏ', '', [], ['p', 'f']),
-                suffixInflection('ㄴㅏ', '', [], ['p', 'f', 'eusi', 'sao'])
-            ]
+                suffixInflection('ㄴㅏ', '', [], ['p', 'f', 'eusi', 'sao']),
+            ],
         },
         {
             name: '-나니',
             rules: [
                 suffixInflection('ㄴㅏㄴㅣ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅏㄴㅣ', '', [], ['p', 'f', 'eusi', 'sab', 'euob'])
-            ]
+                suffixInflection('ㄴㅏㄴㅣ', '', [], ['p', 'f', 'eusi', 'sab', 'euob']),
+            ],
         },
         {
             name: '-(으)나마',
@@ -647,29 +647,29 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅏㅁㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄴㅏㅁㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄴㅏㅁㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄴㅏㅁㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㄴㅏㅁㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-나이까',
             rules: [
                 suffixInflection('ㄴㅏㅇㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄴㅏㅇㅣㄲㅏ', '', [], ['p', 'f', 'eusi', 'saob', 'euob'])
-            ]
+                suffixInflection('ㄴㅏㅇㅣㄲㅏ', '', [], ['p', 'f', 'eusi', 'saob', 'euob']),
+            ],
         },
         {
             name: '-나이다',
             rules: [
                 suffixInflection('ㄴㅏㅇㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄴㅏㅇㅣㄷㅏ', '', [], ['p', 'f', 'eusi', 'saob', 'jaob', 'jab', 'euob'])
-            ]
+                suffixInflection('ㄴㅏㅇㅣㄷㅏ', '', [], ['p', 'f', 'eusi', 'saob', 'jaob', 'jab', 'euob']),
+            ],
         },
         {
             name: '-남',
             rules: [
                 suffixInflection('ㄴㅏㅁ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅏㅁ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄴㅏㅁ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-(으)냐',
@@ -682,8 +682,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅑ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄴㅑ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄴㅑ', '', [], ['p', 'f', 'eusi']),
-                suffixInflection('ㅇㅡㄴㅑ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㅇㅡㄴㅑ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-(으)냐고',
@@ -696,54 +696,54 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅑㄱㅗ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄴㅑㄱㅗ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄴㅑㄱㅗ', '', [], ['p', 'f', 'eusi']),
-                suffixInflection('ㅇㅡㄴㅑㄱㅗ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㅇㅡㄴㅑㄱㅗ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-너라',
             rules: [
-                suffixInflection('ㄴㅓㄹㅏ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄴㅓㄹㅏ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-네',
             rules: [
                 suffixInflection('ㄴㅔ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
                 suffixInflection('ㄴㅔ', 'ㄹㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄴㅔ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄴㅔ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-노니',
             rules: [
                 suffixInflection('ㄴㅗㄴㅣ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅗㄴㅣ', '', [], ['p', 'f', 'eusi', 'sab', 'euob'])
-            ]
+                suffixInflection('ㄴㅗㄴㅣ', '', [], ['p', 'f', 'eusi', 'sab', 'euob']),
+            ],
         },
         {
             name: '-노라',
             rules: [
                 suffixInflection('ㄴㅗㄹㅏ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅗㄹㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㄴㅗㄹㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-노라고',
             rules: [
-                suffixInflection('ㄴㅗㄹㅏㄱㅗ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄴㅗㄹㅏㄱㅗ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-노라니',
             rules: [
-                suffixInflection('ㄴㅗㄹㅏㄴㅣ', 'ㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄴㅗㄹㅏㄴㅣ', 'ㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-노라니까',
             rules: [
-                suffixInflection('ㄴㅗㄹㅏㄴㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄴㅗㄹㅏㄴㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-노라면',
@@ -751,8 +751,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅗㄹㅏㅁㅕㄴ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㅗㄹㅏㅁㅕㄴ', '', [], ['eusi']),
                 suffixInflection('ㅇㅣㅆㄴㅗㄹㅏㅁㅕㄴ', '있다', [], []),
-                suffixInflection('ㅇㅓㅂㅅㄴㅗㄹㅏㅁㅕㄴ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅗㄹㅏㅁㅕㄴ', '없다', [], []),
+            ],
         },
         {
             name: '-(으)뇨',
@@ -764,84 +764,84 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅛ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄴㅛ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄴㅛ', 'ㄷㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄴㅛ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㅛ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-누',
             rules: [
                 suffixInflection('ㄴㅜ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄴㅜ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㄴㅜ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-누나',
             rules: [
                 suffixInflection('ㄴㅜㄴㅏ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅜㄴㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㅜㄴㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-누만',
             rules: [
                 suffixInflection('ㄴㅜㅁㅏㄴ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅜㅁㅏㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㅜㅁㅏㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-누먼',
             rules: [
                 suffixInflection('ㄴㅜㅁㅓㄴ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅜㅁㅓㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㅜㅁㅓㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-느냐',
             rules: [
                 suffixInflection('ㄴㅡㄴㅑ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄴㅡㄴㅑ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄴㅡㄴㅑ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-느냐고',
             rules: [
                 suffixInflection('ㄴㅡㄴㅑㄱㅗ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄴㅡㄴㅑㄱㅗ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄴㅡㄴㅑㄱㅗ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-느뇨',
             rules: [
                 suffixInflection('ㄴㅡㄴㅛ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄴㅡㄴㅛ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄴㅡㄴㅛ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-느니',
             rules: [
                 suffixInflection('ㄴㅡㄴㅣ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄴㅡㄴㅣ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄴㅡㄴㅣ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-느니만',
             rules: [
-                suffixInflection('ㄴㅡㄴㅣㅁㅏㄴ ㅁㅗㅅㅎㅏㄷㅏ', 'ㄷㅏ', ['v'], ['v', 'adj'])
-            ]
+                suffixInflection('ㄴㅡㄴㅣㅁㅏㄴ ㅁㅗㅅㅎㅏㄷㅏ', 'ㄷㅏ', ['v'], ['v', 'adj']),
+            ],
         },
         {
             name: '-느라',
             rules: [
                 suffixInflection('ㄴㅡㄹㅏ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅡㄹㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㅡㄹㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-느라고',
             rules: [
                 suffixInflection('ㄴㅡㄹㅏㄱㅗ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅡㄹㅏㄱㅗ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㅡㄹㅏㄱㅗ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-는',
@@ -849,8 +849,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅡㄴ', 'ㄷㅏ', [], ['v', 'ida']),
                 suffixInflection('ㄴㅡㄴ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㅡㄴ', '', [], ['eusi', 'f']),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴ', '없다', [], ['adj'])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴ', '없다', [], ['adj']),
+            ],
         },
         {
             name: '-(으)ㄴ',
@@ -858,8 +858,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄴ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅡㄴ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄴ', '', [], ['eusi', 'f'])
-            ]
+                suffixInflection('ㄴ', '', [], ['eusi', 'f']),
+            ],
         },
         {
             name: '-(으/느)ㄴ가',
@@ -871,8 +871,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄴㄱㅏ', 'ㄹㄷㅏ', [], ['adj']),
                 suffixInflection('ㄴㄱㅏ', '', [], ['eusi']),
                 suffixInflection('ㄴㅡㄴㄱㅏ', '', [], ['p', 'f', 'eusi']),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄱㅏ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄱㅏ', '없다', [], []),
+            ],
         },
         {
             name: '-(으/느)ㄴ감',
@@ -884,8 +884,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄴㄱㅏㅁ', 'ㄹㄷㅏ', [], ['adj']),
                 suffixInflection('ㄴㄱㅏㅁ', '', [], ['eusi']),
                 suffixInflection('ㄴㅡㄴㄱㅏㅁ', '', [], ['p', 'f', 'eusi']),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄱㅏㅁ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄱㅏㅁ', '없다', [], []),
+            ],
         },
         {
             name: '-(으/느)ㄴ걸',
@@ -897,8 +897,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄴㄱㅓㄹ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄴㄱㅓㄹ', '', [], ['eusi']),
                 suffixInflection('ㄴㅡㄴㄱㅓㄹ', '', [], ['p', 'f', 'eusi']),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄱㅓㄹ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄱㅓㄹ', '없다', [], []),
+            ],
         },
         {
             name: '-(으/느)ㄴ고',
@@ -910,57 +910,57 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄴㄱㅗ', 'ㄹㄷㅏ', [], ['adj']),
                 suffixInflection('ㄴㄱㅗ', '', [], ['eusi']),
                 suffixInflection('ㄴㅡㄴㄱㅗ', '', [], ['p', 'f', 'eusi']),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄱㅗ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄱㅗ', '없다', [], []),
+            ],
         },
         {
             name: '-는구나',
             rules: [
                 suffixInflection('ㄴㅡㄴㄱㅜㄴㅏ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅡㄴㄱㅜㄴㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㅡㄴㄱㅜㄴㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-는구려',
             rules: [
                 suffixInflection('ㄴㅡㄴㄱㅜㄹㅕ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅡㄴㄱㅜㄹㅕ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㅡㄴㄱㅜㄹㅕ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-는구료',
             rules: [
                 suffixInflection('ㄴㅡㄴㄱㅜㄹㅛ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅡㄴㄱㅜㄹㅛ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㅡㄴㄱㅜㄹㅛ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-는구만',
             rules: [
                 suffixInflection('ㄴㅡㄴㄱㅜㅁㅏㄴ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅡㄴㄱㅜㅁㅏㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㅡㄴㄱㅜㅁㅏㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-는구먼',
             rules: [
                 suffixInflection('ㄴㅡㄴㄱㅜㅁㅓㄴ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅡㄴㄱㅜㅁㅓㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㅡㄴㄱㅜㅁㅓㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-는구면',
             rules: [
                 suffixInflection('ㄴㅡㄴㄱㅜㅁㅕㄴ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅡㄴㄱㅜㅁㅕㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㅡㄴㄱㅜㅁㅕㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-는군',
             rules: [
                 suffixInflection('ㄴㅡㄴㄱㅜㄴ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㅡㄴㄱㅜㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㅡㄴㄱㅜㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-는궈니',
@@ -968,8 +968,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅡㄴㄱㅜㅓㄴㅣ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㅡㄴㄱㅜㅓㄴㅣ', '', [], ['p', 'f', 'eusi']),
                 suffixInflection('ㅇㅣㅆㄴㅡㄴㄱㅜㅓㄴㅣ', '있다', [], []),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄱㅜㅓㄴㅣ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄱㅜㅓㄴㅣ', '없다', [], []),
+            ],
         },
         {
             name: '-는과니',
@@ -977,8 +977,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅡㄴㄱㅗㅏㄴㅣ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㅡㄴㄱㅗㅏㄴㅣ', '', [], ['p', 'f', 'eusi']),
                 suffixInflection('ㅇㅣㅆㄴㅡㄴㄱㅗㅏㄴㅣ', '있다', [], []),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄱㅗㅏㄴㅣ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄱㅗㅏㄴㅣ', '없다', [], []),
+            ],
         },
         {
             name: '-(느)ㄴ다',
@@ -986,8 +986,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㅡㄴㄷㅏ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏ', 'ㄹㄷㅏ', [], ['v']),
-                suffixInflection('ㄴㄷㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㄷㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다고',
@@ -997,8 +997,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㄱㅗ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㄱㅗ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㄱㅗ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㄱㅗ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㄱㅗ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다나',
@@ -1008,8 +1008,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㄴㅏ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㄴㅏ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㄴㅏ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㄴㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㄴㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다네',
@@ -1019,8 +1019,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㄴㅔ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㄴㅔ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㄴㅔ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㄴㅔ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㄴㅔ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다느니',
@@ -1030,8 +1030,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㄴㅡㄴㅣ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㄴㅡㄴㅣ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㄴㅡㄴㅣ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㄴㅡㄴㅣ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㄴㅡㄴㅣ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다니',
@@ -1041,8 +1041,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㄴㅣ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㄴㅣ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㄴㅣ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄷㅏㄴㅣ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㄴㅣ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다니까',
@@ -1052,8 +1052,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㄴㅣㄲㅏ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㄴㅣㄲㅏ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㄴㅣㄲㅏ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㄴㅣㄲㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㄴㅣㄲㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다더라',
@@ -1063,8 +1063,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㄷㅓㄹㅏ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㄷㅓㄹㅏ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㄷㅓㄹㅏ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㄷㅓㄹㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㄷㅓㄹㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다마는',
@@ -1074,8 +1074,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㅁㅏㄴㅡㄴ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㅁㅏㄴㅡㄴ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㅁㅏㄴㅡㄴ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㅁㅏㄴㅡㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㅁㅏㄴㅡㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다만',
@@ -1085,8 +1085,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㅁㅏㄴ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㅁㅏㄴ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㅁㅏㄴ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㅁㅏㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㅁㅏㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다며',
@@ -1096,8 +1096,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㅁㅕ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㅁㅕ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㅁㅕ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㅁㅕ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㅁㅕ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다면',
@@ -1107,8 +1107,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㅁㅕㄴ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㅁㅕㄴ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㅁㅕㄴ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㅁㅕㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㅁㅕㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다면서',
@@ -1118,8 +1118,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㅁㅕㄴㅅㅓ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㅁㅕㄴㅅㅓ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㅁㅕㄴㅅㅓ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㅁㅕㄴㅅㅓ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㅁㅕㄴㅅㅓ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다손',
@@ -1129,8 +1129,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㅅㅗㄴ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㅅㅗㄴ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㅁㅕㄴㅅㅗㄴ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㅁㅕㄴㅅㅗㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㅁㅕㄴㅅㅗㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다오',
@@ -1140,8 +1140,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㅇㅗ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㅇㅗ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㅇㅗ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄷㅏㅇㅗ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㅇㅗ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)다지',
@@ -1151,8 +1151,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㅈㅣ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㅈㅣ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㅈㅣ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㅈㅣ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㅈㅣ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)단다',
@@ -1162,8 +1162,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㄴㄷㅏ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㄴㄷㅏ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㄴㄷㅏ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㄴㄷㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㄴㄷㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)담',
@@ -1173,8 +1173,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㅁ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㅁ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㅁ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㄷㅏㅁ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㅁ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)답니까',
@@ -1184,8 +1184,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㅂㄴㅣㄲㅏ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㅂㄴㅣㄲㅏ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㅂㄴㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄷㅏㅂㄴㅣㄲㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㅂㄴㅣㄲㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)답니다',
@@ -1195,8 +1195,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㅂㄴㅣㄷㅏ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅏㅂㄴㅣㄷㅏ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㅂㄴㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄷㅏㅂㄴㅣㄷㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㅂㄴㅣㄷㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)답시고',
@@ -1206,8 +1206,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅏㅂㅅㅣㄱㅗ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㅡㄴㄷㅏㅂㅅㅣㄱㅗ', '', [], ['eusi']),
                 suffixInflection('ㄷㅏㅂㅅㅣㄱㅗ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄷㅏㅂㅅㅣㄱㅗ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㅂㅅㅣㄱㅗ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)대',
@@ -1217,8 +1217,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅐ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅐ', '', [], ['eusi']),
                 suffixInflection('ㄷㅐ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄷㅐ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅐ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-((느)ㄴ)대요',
@@ -1230,8 +1230,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄷㅐㅇㅛ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄷㅐㅇㅛ', '', [], ['p', 'f', 'eusi']),
                 suffixInflection('ㅇㅣㅆㄴㅡㄴㄷㅐㅇㅛ', '있다', [], []),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄷㅐㅇㅛ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄷㅐㅇㅛ', '없다', [], []),
+            ],
         },
         {
             name: '-((느)ㄴ)댄다',
@@ -1241,8 +1241,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅐㄴㄷㅏ', 'ㄹㄷㅏ', [], ['v']),
                 suffixInflection('ㄴㄷㅐㄴㄷㅏ', '', [], ['eusi']),
                 suffixInflection('ㄷㅐㄴㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄷㅐㄴㄷㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅐㄴㄷㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-(으/느)ㄴ데',
@@ -1254,8 +1254,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅔ', '', [], ['eusi', 'sao']),
                 suffixInflection('ㄴㅡㄴㄷㅔ', '', [], ['p', 'f', 'eusi']),
                 suffixInflection('ㅇㅣㅆㄴㅡㄴㄷㅔ', '있다', [], []),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄷㅔ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄷㅔ', '없다', [], []),
+            ],
         },
         {
             name: '-(으/느)ㄴ뎁쇼',
@@ -1267,14 +1267,14 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅔㅂㅅㅛ', '', [], ['eusi']),
                 suffixInflection('ㄴㅡㄴㄷㅔㅂㅅㅛ', '', [], ['p', 'f', 'eusi']),
                 suffixInflection('ㅇㅣㅆㄴㅡㄴㄷㅔㅂㅅㅛ', '', [], []),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄷㅔㅂㅅㅛ', '', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㄷㅔㅂㅅㅛ', '', [], []),
+            ],
         },
         {
             name: '-는도다',
             rules: [
-                suffixInflection('ㄴㅡㄴㄷㅗㄷㅏ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄴㅡㄴㄷㅗㄷㅏ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-(으/느)ㄴ바',
@@ -1287,8 +1287,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅡㄴㅂㅏ', '', [], ['p', 'f', 'eusi']),
                 suffixInflection('ㅇㅡㄴㅂㅏ', '', [], ['eusi']),
                 suffixInflection('ㅇㅣㅆㄴㅡㄴㅂㅏ', '있다', [], []),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㅂㅏ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㅂㅏ', '없다', [], []),
+            ],
         },
         {
             name: '-(으/느)ㄴ지',
@@ -1300,8 +1300,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅈㅣ', '', [], ['eusi']),
                 suffixInflection('ㄴㅡㄴㅈㅣ', '', [], ['p', 'f', 'eusi']),
                 suffixInflection('ㅇㅣㅆㄴㅡㄴㅈㅣ', '있다', [], []),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㅈㅣ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㅈㅣ', '없다', [], []),
+            ],
         },
         {
             name: '-(으/느)ㄴ지고',
@@ -1313,8 +1313,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅈㅣㄱㅗ', '', [], ['eusi']),
                 suffixInflection('ㄴㅡㄴㅈㅣㄱㅗ', '', [], ['p', 'f', 'eusi']),
                 suffixInflection('ㅇㅣㅆㄴㅡㄴㅈㅣㄱㅗ', '있다', [], []),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㅈㅣㄱㅗ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㅈㅣㄱㅗ', '없다', [], []),
+            ],
         },
         {
             name: '-(으/느)ㄴ지라',
@@ -1326,8 +1326,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅈㅣㄹㅏ', '', [], ['eusi']),
                 suffixInflection('ㄴㅡㄴㅈㅣㄹㅏ', '', [], ['p', 'f', 'eusi']),
                 suffixInflection('ㅇㅣㅆㄴㅡㄴㅈㅣㄹㅏ', '있다', [], []),
-                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㅈㅣㄹㅏ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄴㅡㄴㅈㅣㄹㅏ', '없다', [], []),
+            ],
         },
         {
             name: '-(으)니',
@@ -1339,8 +1339,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅣ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄴㅣ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄴㅣ', 'ㄷㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅡㄴㅣ', '', [], ['p', 'f', 'eusi', 'euo', 'sao', 'jao'])
-            ]
+                suffixInflection('ㅇㅡㄴㅣ', '', [], ['p', 'f', 'eusi', 'euo', 'sao', 'jao']),
+            ],
         },
         {
             name: '-(으)니까',
@@ -1353,8 +1353,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅣㄲㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄴㅣㄲㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄴㅣㄲㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄴㅣㄲㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㄴㅣㄲㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)니까느루',
@@ -1367,8 +1367,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅣㄲㅏㄴㅡㄹㅜ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄴㅣㄲㅏㄴㅡㄹㅜ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄴㅣㄲㅏㄴㅡㄹㅜ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄴㅣㄲㅏㄴㅡㄹㅜ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㄴㅣㄲㅏㄴㅡㄹㅜ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)니까는',
@@ -1381,8 +1381,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅣㄲㅏㄴㅡㄴ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄴㅣㄲㅏㄴㅡㄴ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄴㅣㄲㅏㄴㅡㄴ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄴㅣㄲㅏㄴㅡㄴ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㄴㅣㄲㅏㄴㅡㄴ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)니깐',
@@ -1395,8 +1395,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅣㄲㅏㄴ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄴㅣㄲㅏㄴ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄴㅣㄲㅏㄴ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄴㅣㄲㅏㄴ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㄴㅣㄲㅏㄴ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으/느)니라',
@@ -1406,8 +1406,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅡㄴㅣㄹㅏ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅡㄴㅣㄹㅏ', 'ㄷㅏ', [], ['adj']),
                 suffixInflection('ㄴㅣㄹㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄴㅣㄹㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㅇㅡㄴㅣㄹㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-(으/느)니만치',
@@ -1418,8 +1418,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄴㅣㅁㅏㄴㅊㅣ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄴㅣㅁㅏㄴㅊㅣ', '', [], ['eusi']),
                 suffixInflection('ㄴㅡㄴㅣㅁㅏㄴㅊㅣ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄴㅣㅁㅏㄴㅊㅣ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㄴㅣㅁㅏㄴㅊㅣ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으/느)니만큼',
@@ -1430,42 +1430,42 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄴㅣㅁㅏㄴㅋㅡㅁ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄴㅣㅁㅏㄴㅋㅡㅁ', '', [], ['eusi']),
                 suffixInflection('ㄴㅡㄴㅣㅁㅏㄴㅋㅡㅁ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄴㅣㅁㅏㄴㅋㅡㅁ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㄴㅣㅁㅏㄴㅋㅡㅁ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-다',
             rules: [
-                suffixInflection('ㄷㅏ', '', [], ['p', 'f', 'eusi', 'ida'])
-            ]
+                suffixInflection('ㄷㅏ', '', [], ['p', 'f', 'eusi', 'ida']),
+            ],
         },
         {
             name: '-다가',
             rules: [
                 suffixInflection('ㄷㅏㄱㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄷㅏㄱㅏ', '', [], ['p', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㄱㅏ', '', [], ['p', 'eusi']),
+            ],
         },
         {
             name: '-다가는',
             rules: [
                 suffixInflection('ㄷㅏㄱㅏㄴㅡㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅏㄱㅏㄴㅡㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㄱㅏㄴㅡㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-다간',
             rules: [
                 suffixInflection('ㄷㅏㄱㅏㄴ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄷㅏㄱㅏㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㄱㅏㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-다마다',
             rules: [
                 suffixInflection('ㄷㅏㅁㅏㄷㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅏㅁㅏㄷㅏ', '', [], ['p', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㅁㅏㄷㅏ', '', [], ['p', 'eusi']),
+            ],
         },
         {
             name: '-다시피',
@@ -1473,238 +1473,238 @@ export const koreanTransforms = {
                 suffixInflection('ㄷㅏㅅㅣㅍㅣ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄷㅏㅅㅣㅍㅣ', '', [], ['p', 'f']),
                 suffixInflection('ㅇㅣㅆㄷㅏㅅㅣㅍㅣ', '있다', [], []),
-                suffixInflection('ㅇㅓㅂㅅㄷㅏㅅㅣㅍㅣ', '없다', [], [])
-            ]
+                suffixInflection('ㅇㅓㅂㅅㄷㅏㅅㅣㅍㅣ', '없다', [], []),
+            ],
         },
         {
             name: '-단',
             rules: [
                 suffixInflection('ㄷㅏㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅏㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅏㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더',
             rules: [
                 suffixInflection('ㄷㅓ', 'ㄷㅏ', ['do'], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓ', '', ['do'], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓ', '', ['do'], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더구나',
             rules: [
                 suffixInflection('ㄷㅓㄱㅜㄴㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄱㅜㄴㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄱㅜㄴㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더구려',
             rules: [
                 suffixInflection('ㄷㅓㄱㅜㄹㅕ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄱㅜㄹㅕ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄱㅜㄹㅕ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더구료',
             rules: [
                 suffixInflection('ㄷㅓㄱㅜㄹㅛ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄱㅜㄹㅛ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄱㅜㄹㅛ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더구만',
             rules: [
                 suffixInflection('ㄷㅓㄱㅜㅁㅏㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄱㅜㅁㅏㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄱㅜㅁㅏㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더구먼',
             rules: [
                 suffixInflection('ㄷㅓㄱㅜㅁㅓㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄱㅜㅁㅓㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄱㅜㅁㅓㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더구면',
             rules: [
                 suffixInflection('ㄷㅓㄱㅜㅁㅕㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄱㅜㅁㅕㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄱㅜㅁㅕㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더군',
             rules: [
                 suffixInflection('ㄷㅓㄱㅜㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄱㅜㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄱㅜㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더냐',
             rules: [
                 suffixInflection('ㄷㅓㄴㅑ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㅑ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㅑ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더뇨',
             rules: [
                 suffixInflection('ㄷㅓㄴㅛ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㅛ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㅛ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더니',
             rules: [
                 suffixInflection('ㄷㅓㄴㅣ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㅣ', '', [], ['p', 'f', 'eusi', 'euob', 'euo', 'sab'])
-            ]
+                suffixInflection('ㄷㅓㄴㅣ', '', [], ['p', 'f', 'eusi', 'euob', 'euo', 'sab']),
+            ],
         },
         {
             name: '-더니라',
             rules: [
                 suffixInflection('ㄷㅓㄴㅣㄹㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㅣㄹㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㅣㄹㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더니마는',
             rules: [
                 suffixInflection('ㄷㅓㄴㅣㅁㅏㄴㅡㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㅣㅁㅏㄴㅡㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㅣㅁㅏㄴㅡㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더니만',
             rules: [
                 suffixInflection('ㄷㅓㄴㅣㅁㅏㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㅣㅁㅏㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㅣㅁㅏㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더니이까',
             rules: [
                 suffixInflection('ㄷㅓㄴㅣㅇㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㅣㅇㅣㄲㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㅣㅇㅣㄲㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더니이다',
             rules: [
                 suffixInflection('ㄷㅓㄴㅣㅇㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㅣㅇㅣㄷㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㅣㅇㅣㄷㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더라도',
             rules: [
                 suffixInflection('ㄷㅓㄹㅏㄷㅗ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄹㅏㄷㅗ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄹㅏㄷㅗ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더이까',
             rules: [
                 suffixInflection('ㄷㅓㅇㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㅇㅣㄲㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㅇㅣㄲㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-더이다',
             rules: [
                 suffixInflection('ㄷㅓㅇㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㅇㅣㄷㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㅇㅣㄷㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-던',
             rules: [
                 suffixInflection('ㄷㅓㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-던가',
             rules: [
                 suffixInflection('ㄷㅓㄴㄱㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㄱㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㄱㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-던감',
             rules: [
                 suffixInflection('ㄷㅓㄴㄱㅏㅁ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㄱㅏㅁ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㄱㅏㅁ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-던걸',
             rules: [
                 suffixInflection('ㄷㅓㄴㄱㅓㄹ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㄱㅓㄹ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㄱㅓㄹ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-던고',
             rules: [
                 suffixInflection('ㄷㅓㄴㄱㅗ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㄱㅗ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㄱㅗ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-던데',
             rules: [
                 suffixInflection('ㄷㅓㄴㄷㅔ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㄷㅔ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㄷㅔ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-던들',
             rules: [
-                suffixInflection('ㄷㅓㄴㄷㅡㄹ', '', [], ['p'])
-            ]
+                suffixInflection('ㄷㅓㄴㄷㅡㄹ', '', [], ['p']),
+            ],
         },
         {
             name: '-던바',
             rules: [
                 suffixInflection('ㄷㅓㄴㅂㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㅂㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㅂㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-던지',
             rules: [
                 suffixInflection('ㄷㅓㄴㅈㅣ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅓㄴㅈㅣ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅓㄴㅈㅣ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-데',
             rules: [
                 suffixInflection('ㄷㅔ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅔ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅔ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-데요',
             rules: [
                 suffixInflection('ㄷㅔㅇㅛ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅔㅇㅛ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅔㅇㅛ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-도다',
             rules: [
                 suffixInflection('ㄷㅗㄷㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅗㄷㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅗㄷㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-도록',
             rules: [
                 suffixInflection('ㄷㅗㄹㅗㄱ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄷㅗㄹㅗㄱ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄷㅗㄹㅗㄱ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)되',
@@ -1712,153 +1712,153 @@ export const koreanTransforms = {
                 suffixInflection('ㄷㅗㅣ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
                 suffixInflection('ㅇㅡㄷㅗㅣ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄷㅗㅣ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄷㅗㅣ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㄷㅗㅣ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-드구나',
             rules: [
                 suffixInflection('ㄷㅡㄱㅜㄴㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄱㅜㄴㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄱㅜㄴㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-드구료',
             rules: [
                 suffixInflection('ㄷㅡㄱㅜㄹㅛ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄱㅜㄹㅛ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄱㅜㄹㅛ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-드구면',
             rules: [
                 suffixInflection('ㄷㅡㄱㅜㅁㅕㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄱㅜㅁㅕㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄱㅜㅁㅕㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-드군',
             rules: [
                 suffixInflection('ㄷㅡㄱㅜㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄱㅜㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄱㅜㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-드냐',
             rules: [
                 suffixInflection('ㄷㅡㄴㅑ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄴㅑ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄴㅑ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-드니',
             rules: [
                 suffixInflection('ㄷㅡㄴㅣ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄴㅣ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄴㅣ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-드니라',
             rules: [
                 suffixInflection('ㄷㅡㄴㅣㄹㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄴㅣㄹㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄴㅣㄹㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-드라',
             rules: [
                 suffixInflection('ㄷㅡㄹㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄹㅏ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄹㅏ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-드라도',
             rules: [
                 suffixInflection('ㄷㅡㄹㅏㄷㅗ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄹㅏㄷㅗ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄹㅏㄷㅗ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-드라면',
             rules: [
-                suffixInflection('ㄷㅡㄹㅏㅁㅕㄴ', '', [], ['p'])
-            ]
+                suffixInflection('ㄷㅡㄹㅏㅁㅕㄴ', '', [], ['p']),
+            ],
         },
         {
             name: '-드래도',
             rules: [
                 suffixInflection('ㄷㅡㄹㅐㄷㅗ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄹㅐㄷㅗ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄹㅐㄷㅗ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-든',
             rules: [
                 suffixInflection('ㄷㅡㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄴ', '', [], ['p', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄴ', '', [], ['p', 'eusi']),
+            ],
         },
         {
             name: '-든가',
             rules: [
                 suffixInflection('ㄷㅡㄴㄱㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄴㄱㅏ', '', [], ['p', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄴㄱㅏ', '', [], ['p', 'eusi']),
+            ],
         },
         {
             name: '-든걸',
             rules: [
                 suffixInflection('ㄷㅡㄴㄱㅓㄹ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄴㄱㅓㄹ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄴㄱㅓㄹ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-든고',
             rules: [
                 suffixInflection('ㄷㅡㄴㄱㅗ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄴㄱㅗ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄴㄱㅗ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-든데',
             rules: [
                 suffixInflection('ㄷㅡㄴㄷㅔ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄴㄷㅔ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄴㄷㅔ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-든들',
             rules: [
-                suffixInflection('ㄷㅡㄴㄷㅡㄹ', '', [], ['p'])
-            ]
+                suffixInflection('ㄷㅡㄴㄷㅡㄹ', '', [], ['p']),
+            ],
         },
         {
             name: '-든지',
             rules: [
                 suffixInflection('ㄷㅡㄴㅈㅣ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㄴㅈㅣ', '', [], ['p', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㄴㅈㅣ', '', [], ['p', 'eusi']),
+            ],
         },
         {
             name: '-듯',
             rules: [
                 suffixInflection('ㄷㅡㅅ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㅅ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㅅ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-듯이',
             rules: [
                 suffixInflection('ㄷㅡㅅㅇㅣ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅡㅅㅇㅣ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅡㅅㅇㅣ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-디',
             rules: [
                 suffixInflection('ㄷㅣ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㄷㅣ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㄷㅣ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-(으)라',
@@ -1870,8 +1870,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)라고',
@@ -1883,8 +1883,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㄱㅗ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㄱㅗ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㄱㅗ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㄱㅗ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㄱㅗ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)라구',
@@ -1896,8 +1896,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㄱㅜ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㄱㅜ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㄱㅜ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㄱㅜ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㄱㅜ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)라나',
@@ -1909,8 +1909,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㄴㅏ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㄴㅏ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㄴㅏ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㄴㅏ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㄴㅏ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)라네',
@@ -1922,8 +1922,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㄴㅔ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㄴㅔ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㄴㅔ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㄴㅔ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㄴㅔ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)라느니',
@@ -1935,8 +1935,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㄴㅡㄴㅣ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㄴㅡㄴㅣ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㄴㅡㄴㅣ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㄴㅡㄴㅣ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㄴㅡㄴㅣ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)라니',
@@ -1948,8 +1948,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㄴㅣ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㄴㅣ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㄴㅣ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㄴㅣ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㄴㅣ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)라니까',
@@ -1961,15 +1961,15 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㄴㅣㄲㅏ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㄴㅣㄲㅏ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㄴㅣㄲㅏ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㄴㅣㄲㅏ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㄴㅣㄲㅏ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-라도',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㄷㅗ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㄷㅗ', 'ㄷㅏ', [], ['ida'])
-            ]
+                suffixInflection('ㄹㅏㄷㅗ', 'ㄷㅏ', [], ['ida']),
+            ],
         },
         {
             name: '-(으)라며',
@@ -1981,8 +1981,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㅁㅕ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㅁㅕ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㅁㅕ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㅁㅕ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㅁㅕ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)라면',
@@ -1994,8 +1994,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㅁㅕㄴ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㅁㅕㄴ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㅁㅕㄴ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㅁㅕㄴ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㅁㅕㄴ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)라면서',
@@ -2007,16 +2007,16 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㅁㅕㄴㅅㅓ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㅁㅕㄴㅅㅓ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㅁㅕㄴㅅㅓ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㅁㅕㄴㅅㅓ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㅁㅕㄴㅅㅓ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-라서',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㅅㅓ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅏㅅㅓ', '다', [], ['ida']),
-                suffixInflection('ㄹㅏㅅㅓ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅏㅅㅓ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)라손',
@@ -2028,24 +2028,24 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㅅㅗㄴ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㅅㅗㄴ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㅅㅗㄴ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㅅㅗㄴ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㅅㅗㄴ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-라야',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㅇㅑ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅏㅇㅑ', '다', [], ['ida']),
-                suffixInflection('ㄹㅏㅇㅑ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅏㅇㅑ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-라야만',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㅇㅑㅁㅏㄴ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅏㅇㅑㅁㅏㄴ', '다', [], ['ida']),
-                suffixInflection('ㄹㅏㅇㅑㅁㅏㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅏㅇㅑㅁㅏㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)라오',
@@ -2057,8 +2057,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㅇㅗ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㅇㅗ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㅇㅗ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㅇㅗ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㅇㅗ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)라지',
@@ -2070,8 +2070,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㅈㅣ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㅈㅣ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㅈㅣ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㅈㅣ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㅈㅣ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)락',
@@ -2082,8 +2082,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹㅏㄱ', 'ㅂㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅡㄹㅏㄱ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅏㄱ', 'ㅎㄷㅏ', [], ['adj']),
-                suffixInflection('ㄹㅇㅡㄹㅏㄱ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㄹㅏㄱ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-(으)란',
@@ -2095,8 +2095,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㄴ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㄴ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㄴ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㄴ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㄴ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)란다',
@@ -2108,8 +2108,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㄴㄷㅏ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㄴㄷㅏ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㄴㄷㅏ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㄴㄷㅏ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㄴㄷㅏ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)람',
@@ -2121,8 +2121,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㅁ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㅁ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㅁ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㅁ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)랍니까',
@@ -2134,8 +2134,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㅂㄴㅣㄲㅏ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㅂㄴㅣㄲㅏ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㅂㄴㅣㄲㅏ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㅂㄴㅣㄲㅏ', '', [], ['eusi', 'do'])
-            ]
+                suffixInflection('ㄹㅏㅂㄴㅣㄲㅏ', '', [], ['eusi', 'do']),
+            ],
         },
         {
             name: '-(으)랍니다',
@@ -2147,16 +2147,16 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅏㅂㄴㅣㄷㅏ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅏㅂㄴㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㅂㄴㅣㄷㅏ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅏㅂㄴㅣㄷㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅏㅂㄴㅣㄷㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-랍시고',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅏㅂㅅㅣㄱㅗ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅏㅂㅅㅣㄱㅗ', '다', [], ['ida']),
-                suffixInflection('ㄹㅏㅂㅅㅣㄱㅗ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅏㅂㅅㅣㄱㅗ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)래',
@@ -2168,8 +2168,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅐ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅐ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅐ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅐ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅐ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)래요',
@@ -2181,8 +2181,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅐㅇㅛ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅐㅇㅛ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅏㄴㅣㄹㅐㅇㅛ', '아니다', [], ['adj']),
-                suffixInflection('ㄹㅐㅇㅛ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅐㅇㅛ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)랴',
@@ -2193,8 +2193,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹㅑ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㄹㅑ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅑ', 'ㄷㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅑ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅑ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)러',
@@ -2205,80 +2205,80 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹㅓ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㄹㅓ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅓ', 'ㄷㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅓ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅓ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-러니',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅓㄴㅣ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅓㄴㅣ', '다', [], ['ida']),
-                suffixInflection('ㄹㅓㄴㅣ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅓㄴㅣ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-러니라',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅓㄴㅣㄹㅏ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅓㄴㅣㄹㅏ', '다', [], ['ida']),
-                suffixInflection('ㄹㅓㄴㅣㄹㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅓㄴㅣㄹㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-러니이까',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅓㄴㅣㅇㅣㄲㅏ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅓㄴㅣㅇㅣㄲㅏ', '다', [], ['ida']),
-                suffixInflection('ㄹㅓㄴㅣㅇㅣㄲㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅓㄴㅣㅇㅣㄲㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-러니이다',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅓㄴㅣㅇㅣㄷㅏ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅓㄴㅣㅇㅣㄷㅏ', '다', [], ['ida']),
-                suffixInflection('ㄹㅓㄴㅣㅇㅣㄷㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅓㄴㅣㅇㅣㄷㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-러라',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅓㄹㅏ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅓㄹㅏ', '다', [], ['ida']),
-                suffixInflection('ㄹㅓㄹㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅓㄹㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-러이까',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅓㅇㅣㄲㅏ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅓㅇㅣㄲㅏ', '다', [], ['ida']),
-                suffixInflection('ㄹㅓㅇㅣㄲㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅓㅇㅣㄲㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-러이다',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅓㅇㅣㄷㅏ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅓㅇㅣㄷㅏ', '다', [], ['ida']),
-                suffixInflection('ㄹㅓㅇㅣㄷㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅓㅇㅣㄷㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-런가',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅓㄴㄱㅏ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅓㄴㄱㅏ', '다', [], ['ida']),
-                suffixInflection('ㄹㅓㄴㄱㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅓㄴㄱㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-런들',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅓㄴㄷㅡㄹ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅓㄴㄷㅡㄹ', '다', [], ['ida']),
-                suffixInflection('ㄹㅓㄴㄷㅡㄹ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅓㄴㄷㅡㄹ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)려',
@@ -2290,8 +2290,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅕ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅕ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅕ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)려거든',
@@ -2303,8 +2303,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅕㄱㅓㄷㅡㄴ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅕㄱㅓㄷㅡㄴ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅕㄱㅓㄷㅡㄴ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㄱㅓㄷㅡㄴ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㄱㅓㄷㅡㄴ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)려고',
@@ -2316,8 +2316,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅕㄱㅗ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄹㅕㄱㅗ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅕㄱㅗ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㄱㅗ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㄱㅗ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)려나',
@@ -2330,8 +2330,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅕㄴㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅕㄴㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅕㄴㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㄴㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㄴㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)려니',
@@ -2344,8 +2344,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅕㄴㅣ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅕㄴㅣ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅕㄴㅣ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㄴㅣ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㄴㅣ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)려니와',
@@ -2358,8 +2358,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅕㄴㅣㅇㅗㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅕㄴㅣㅇㅗㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅕㄴㅣㅇㅗㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㄴㅣㅇㅗㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㄴㅣㅇㅗㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)려든',
@@ -2371,8 +2371,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅕㄷㅡㄴ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅕㄷㅡㄴ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅕㄷㅡㄴ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㄷㅡㄴ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㄷㅡㄴ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)려마',
@@ -2384,8 +2384,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅕㅁㅏ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅕㅁㅏ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅕㅁㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㅁㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㅁㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)려면',
@@ -2398,8 +2398,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅕㅁㅕㄴ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅕㅁㅕㄴ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅕㅁㅕㄴ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㅁㅕㄴ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㅁㅕㄴ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)려무나',
@@ -2411,8 +2411,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅕㅁㅜㄴㅏ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅕㅁㅜㄴㅏ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅕㅁㅜㄴㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㅁㅜㄴㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㅁㅜㄴㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)련',
@@ -2424,8 +2424,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅕㄴ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅕㄴ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅕㄴ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㄴ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㄴ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)련마는',
@@ -2438,8 +2438,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅕㄴㅁㅏㄴㅡㄴ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅕㄴㅁㅏㄴㅡㄴ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅕㄴㅁㅏㄴㅡㄴ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㄴㅁㅏㄴㅡㄴ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㄴㅁㅏㄴㅡㄴ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)련만',
@@ -2452,8 +2452,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅕㄴㅁㅏㄴ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅕㄴㅁㅏㄴ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅕㄴㅁㅏㄴ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㄴㅁㅏㄴ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㄴㅁㅏㄴ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)렴',
@@ -2465,8 +2465,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅕㅁ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅕㅁ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅕㅁ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㅁ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㅁ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)렵니까',
@@ -2478,8 +2478,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅕㅂㄴㅣㄲㅏ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅕㅂㄴㅣㄲㅏ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅕㅂㄴㅣㄲㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㅂㄴㅣㄲㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㅂㄴㅣㄲㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)렵니다',
@@ -2491,8 +2491,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㅕㅂㄴㅣㄷㅏ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅕㅂㄴㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅕㅂㄴㅣㄷㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㅂㄴㅣㄷㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㅂㄴㅣㄷㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)렷다',
@@ -2505,120 +2505,120 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅕㅅㄷㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅕㅅㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅕㅅㄷㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅕㅅㄷㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅕㅅㄷㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-로고',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㄱㅗ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㄱㅗ', '다', [], ['ida']),
-                suffixInflection('ㄹㅗㄱㅗ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅗㄱㅗ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-로고나',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㄱㅗㄴㅏ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㄱㅗㄴㅏ', '다', [], ['ida']),
-                suffixInflection('ㄹㅗㄱㅗㄴㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅗㄱㅗㄴㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-로구나',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㄱㅜㄴㅏ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㄱㅜㄴㅏ', '다', [], ['ida']),
-                suffixInflection('ㄹㅗㄱㅜㄴㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅗㄱㅜㄴㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-로구려',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㄱㅜㄹㅕ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㄱㅜㄹㅕ', '다', [], ['ida']),
-                suffixInflection('ㄹㅗㄱㅜㄹㅕ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅗㄱㅜㄹㅕ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-로구료',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㄱㅜㄹㅛ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㄱㅜㄹㅛ', '다', [], ['ida']),
-                suffixInflection('ㄹㅗㄱㅜㄹㅛ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅗㄱㅜㄹㅛ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-로구만',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㄱㅜㅁㅏㄴ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㄱㅜㅁㅏㄴ', '다', [], ['ida']),
-                suffixInflection('ㄹㅗㄱㅜㅁㅏㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅗㄱㅜㅁㅏㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-로구먼',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㄱㅜㅁㅓㄴ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㄱㅜㅁㅓㄴ', '다', [], ['ida']),
-                suffixInflection('ㄹㅗㄱㅜㅁㅓㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅗㄱㅜㅁㅓㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-로구면',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㄱㅜㅁㅕㄴ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㄱㅜㅁㅕㄴ', '다', [], ['ida']),
-                suffixInflection('ㄹㅗㄱㅜㅁㅕㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅗㄱㅜㅁㅕㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-로군',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㄱㅜㄴ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㄱㅜㄴ', '다', [], ['ida']),
-                suffixInflection('ㄹㅗㄱㅜㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅗㄱㅜㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-로다',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㄷㅏ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㄷㅏ', '다', [], ['ida']),
-                suffixInflection('ㄹㅗㄷㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅗㄷㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-로되',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㄷㅗㅣ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㄷㅗㅣ', '다', [], ['ida']),
-                suffixInflection('ㄹㅗㄷㅗㅣ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅗㄷㅗㅣ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-로라',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㄹㅏ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㄹㅏ', '다', [], ['ida']),
-                suffixInflection('', '다', [], ['ida'])
-            ]
+                suffixInflection('', '다', [], ['ida']),
+            ],
         },
         {
             name: '-로서니',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㅅㅓㄴㅣ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㅅㅓㄴㅣ', '다', [], ['ida']),
-                suffixInflection('ㄹㅗㅅㅓㄴㅣ', '다', [], ['ida'])
-            ]
+                suffixInflection('ㄹㅗㅅㅓㄴㅣ', '다', [], ['ida']),
+            ],
         },
         {
             name: '-로세',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㄹㅗㅅㅔ', '아니다', [], ['adj']),
                 suffixInflection('ㄹㅗㅅㅔ', '다', [], ['ida']),
-                suffixInflection('ㄹㅗㅅㅔ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅗㅅㅔ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)리',
@@ -2631,8 +2631,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅣ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅣ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅣ', '', [], ['eusi', 'euo']),
-                suffixInflection('ㅇㅡㄹㅣ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅣ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)리까',
@@ -2645,8 +2645,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅣㄲㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅣㄲㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅣㄲㅏ', '', [], ['eusi', 'euo']),
-                suffixInflection('ㅇㅡㄹㅣㄲㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅣㄲㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)리니',
@@ -2659,8 +2659,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅣㄴㅣ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅣㄴㅣ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅣㄴㅣ', '', [], ['eusi', 'euo']),
-                suffixInflection('ㅇㅡㄹㅣㄴㅣ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅣㄴㅣ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)리니라',
@@ -2673,8 +2673,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅣㄴㅣㄹㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅣㄴㅣㄹㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅣㄴㅣㄹㅏ', '', [], ['eusi', 'euo']),
-                suffixInflection('ㅇㅡㄹㅣㄴㅣㄹㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅣㄴㅣㄹㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)리다',
@@ -2687,8 +2687,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅣㄷㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅣㄷㅏ', '', [], ['eusi', 'euo']),
-                suffixInflection('ㅇㅡㄹㅣㄷㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅣㄷㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)리라',
@@ -2701,8 +2701,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅣㄹㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅣㄹㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅣㄹㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅣㄹㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅣㄹㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)리로다',
@@ -2715,8 +2715,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅣㄹㅗㄷㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅣㄹㅗㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅣㄹㅗㄷㅏ', '', [], ['eusi', 'euo']),
-                suffixInflection('ㅇㅡㄹㅣㄹㅗㄷㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅣㄹㅗㄷㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)리만치',
@@ -2729,8 +2729,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅣㅁㅏㄴㅊㅣ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅣㅁㅏㄴㅊㅣ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅣㅁㅏㄴㅊㅣ', '', [], ['eusi', 'euo']),
-                suffixInflection('ㅇㅡㄹㅣㅁㅏㄴㅊㅣ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅣㅁㅏㄴㅊㅣ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)리만큼',
@@ -2743,8 +2743,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅣㅁㅏㄴㅋㅡㅁ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅣㅁㅏㄴㅋㅡㅁ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅣㅁㅏㄴㅋㅡㅁ', '', [], ['eusi', 'euo']),
-                suffixInflection('ㅇㅡㄹㅣㅁㅏㄴㅋㅡㅁ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅣㅁㅏㄴㅋㅡㅁ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)리오',
@@ -2757,8 +2757,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅣㅇㅗ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅣㅇㅗ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅣㅇㅗ', '', [], ['eusi', 'euo']),
-                suffixInflection('ㅇㅡㄹㅣㅇㅗ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅣㅇㅗ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)마',
@@ -2768,8 +2768,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㅁㅏ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅜㅁㅏ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㅁㅏ', 'ㅅㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅇㅡㅁㅏ', 'ㄷㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄹㅇㅡㅁㅏ', 'ㄷㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-(으)매',
@@ -2782,8 +2782,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅁㅐ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㅁㅐ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅁㅐ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅁㅐ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅁㅐ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)며',
@@ -2796,8 +2796,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅁㅕ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅁㅕ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅁㅕ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅁㅕ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)면',
@@ -2810,8 +2810,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅁㅕㄴ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅁㅕㄴ', '', [], ['eusi', 'euo', 'jao']),
-                suffixInflection('ㅇㅡㅁㅕㄴ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅁㅕㄴ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)면서',
@@ -2824,8 +2824,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅁㅕㄴㅅㅓ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅁㅕㄴㅅㅓ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅁㅕㄴㅅㅓ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅁㅕㄴㅅㅓ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)므로',
@@ -2838,8 +2838,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅁㅡㄹㅗ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅁㅡㄹㅗ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅁㅡㄹㅗ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅁㅡㄹㅗ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)사',
@@ -2850,106 +2850,106 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㅅㅏ', 'ㅂㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅡㅅㅏ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅏ', 'ㅎㄷㅏ', [], ['adj']),
-                suffixInflection('ㄹㅇㅡ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-사오-',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗ', 'ㄷㅏ', ['sao'], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗ', '', ['sao'], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗ', '', ['sao'], ['p', 'f']),
+            ],
         },
         {
             name: '-사오니까',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗㄴㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗㄴㅣㄲㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗㄴㅣㄲㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-사오리까',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗㄹㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗㄹㅣㄲㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗㄹㅣㄲㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-사오리다',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗㄹㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗㄹㅣㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗㄹㅣㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-사오리이까',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗㄹㅣㅇㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗㄹㅣㅇㅣㄲㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗㄹㅣㅇㅣㄲㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-사오리이다',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗㄹㅣㅇㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗㄹㅣㅇㅣㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗㄹㅣㅇㅣㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-사오이다',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗㅇㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗㅇㅣㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗㅇㅣㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-사옵-',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗㅂ', 'ㄷㅏ', ['saob'], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗㅂ', '', ['saob'], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗㅂ', '', ['saob'], ['p', 'f']),
+            ],
         },
         {
             name: '-사옵니까',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗㅂㄴㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗㅂㄴㅣㄲㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗㅂㄴㅣㄲㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-사옵니다',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗㅂㄴㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗㅂㄴㅣㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗㅂㄴㅣㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-사옵디까',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗㅂㄷㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗㅂㄷㅣㄲㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗㅂㄷㅣㄲㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-사옵디다',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗㅂㄷㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗㅂㄷㅣㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗㅂㄷㅣㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-사와',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-사외다',
             rules: [
                 suffixInflection('ㅅㅏㅇㅗㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅇㅗㅣㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅇㅗㅣㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)사이다',
@@ -2960,15 +2960,15 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㅅㅏㅇㅣㄷㅏ', 'ㅂㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅡㅅㅏㅇㅣㄷㅏ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅏㅇㅣㄷㅏ', 'ㅎㄷㅏ', [], ['adj']),
-                suffixInflection('ㄹㅇㅡㅅㅏㅇㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㅅㅏㅇㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-삽-',
             rules: [
                 suffixInflection('ㅅㅏㅂ', 'ㄷㅏ', ['sab'], ['v', 'adj']),
-                suffixInflection('ㅅㅏㅂ', '', ['sab'], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅏㅂ', '', ['sab'], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)세',
@@ -2978,14 +2978,14 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㅅㅔ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㅅㅔ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㅅㅔ', 'ㄹㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅇㅡㅅㅔ', 'ㄷㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄹㅇㅡㅅㅔ', 'ㄷㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-세나',
             rules: [
-                suffixInflection('ㅅㅔㄴㅏ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㅅㅔㄴㅏ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-(으)세요',
@@ -2996,8 +2996,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㅅㅔㅇㅛ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅔㅇㅛ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㅅㅔㅇㅛ', 'ㄹㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄹㅇㅡㅅㅔㅇㅛ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㅅㅔㅇㅛ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-(으)셔요',
@@ -3008,22 +3008,22 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㅅㅕㅇㅛ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅕㅇㅛ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㅅㅕㅇㅛ', 'ㄹㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄹㅇㅡㅅㅕㅇㅛ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㅅㅕㅇㅛ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-소',
             rules: [
                 suffixInflection('ㅅㅗ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅗ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅗ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-소다',
             rules: [
                 suffixInflection('ㅅㅗㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅗㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅗㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)소서',
@@ -3034,29 +3034,29 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㅅㅗㅅㅓ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅗㅅㅓ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㅅㅗㅅㅓ', 'ㄹㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄹㅇㅡㅅㅗㅅㅓ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㅅㅗㅅㅓ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-소이까',
             rules: [
                 suffixInflection('ㅅㅗㅇㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㅅㅗㅇㅣㄲㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅗㅇㅣㄲㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-소이다',
             rules: [
                 suffixInflection('ㅅㅗㅇㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅗㅇㅣㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅗㅇㅣㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-쇠다',
             rules: [
                 suffixInflection('ㅅㅗㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅗㅣㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅅㅗㅣㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(스)ㅂ네',
@@ -3065,8 +3065,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅂㄴㅔ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄴㅔ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄴㅔ', '', [], ['p', 'f']),
-                suffixInflection('ㅂㄴㅔ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅂㄴㅔ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(스)ㅂ늰다',
@@ -3075,8 +3075,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅂㄴㅡㅣㄴㄷㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄴㅡㅣㄴㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄴㅡㅣㄴㄷㅏ', '', [], ['p', 'f']),
-                suffixInflection('ㅂㄴㅡㅣㄴㄷㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅂㄴㅡㅣㄴㄷㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(스)ㅂ니까',
@@ -3085,8 +3085,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅂㄴㅣㄲㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄴㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄴㅣㄲㅏ', '', [], ['p', 'f']),
-                suffixInflection('ㅂㄴㅣㄲㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅂㄴㅣㄲㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(스)ㅂ니다',
@@ -3095,8 +3095,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅂㄴㅣㄷㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄴㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄴㅣㄷㅏ', '', [], ['p', 'f']),
-                suffixInflection('ㅂㄴㅣㄷㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅂㄴㅣㄷㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(스)ㅂ디까',
@@ -3105,8 +3105,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅂㄷㅣㄲㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄷㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄷㅣㄲㅏ', '', [], ['p', 'f']),
-                suffixInflection('ㅂㄷㅣㄲㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅂㄷㅣㄲㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(스)ㅂ디다',
@@ -3115,8 +3115,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅂㄷㅣㄷㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄷㅣㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄷㅣㄷㅏ', '', [], ['p', 'f']),
-                suffixInflection('ㅂㄷㅣㄷㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅂㄷㅣㄷㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(스)ㅂ딘다',
@@ -3125,8 +3125,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅂㄷㅣㄴㄷㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄷㅣㄴㄷㅏ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㄷㅣㄴㄷㅏ', '', [], ['p', 'f']),
-                suffixInflection('ㅂㄷㅣㄴㄷㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅂㄷㅣㄴㄷㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(스)ㅂ죠',
@@ -3135,8 +3135,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅂㅈㅛ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㅈㅛ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㅈㅛ', '', [], ['p', 'f']),
-                suffixInflection('ㅂㅈㅛ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅂㅈㅛ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(스)ㅂ지요',
@@ -3145,8 +3145,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅂㅈㅣㅇㅛ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㅈㅣㅇㅛ', 'ㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅡㅂㅈㅣㅇㅛ', '', [], ['p', 'f']),
-                suffixInflection('ㅂㅈㅣㅇㅛ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅂㅈㅣㅇㅛ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)시-',
@@ -3158,8 +3158,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅅㅣ', 'ㅎㄷㅏ', ['eusi'], ['adj']),
                 suffixInflection('ㅅㅣ', 'ㄹㄷㅏ', ['eusi'], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅅㅣ', 'ㄷㄷㅏ', ['eusi'], ['v', 'adj']),
-                suffixInflection('ㅅㅣ', '', ['eusi'], ['saob', 'euob', 'jaob'])
-            ]
+                suffixInflection('ㅅㅣ', '', ['eusi'], ['saob', 'euob', 'jaob']),
+            ],
         },
         {
             name: '-(으)시압',
@@ -3169,8 +3169,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㅅㅣㅇㅏㅂ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅜㅅㅣㅇㅏㅂ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㅅㅣㅇㅏㅂ', 'ㅅㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅇㅡㅅㅣㅇㅏㅂ', 'ㄷㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄹㅇㅡㅅㅣㅇㅏㅂ', 'ㄷㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-(으)시어요',
@@ -3181,8 +3181,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㅅㅣㅇㅓㅇㅛ', 'ㅅㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅅㅣㅇㅓㅇㅛ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㅅㅣㅇㅓㅇㅛ', 'ㄹㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄹㅇㅡㅅㅣㅇㅓㅇㅛ', 'ㄷㄷㅏ', [], ['v', 'adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㅅㅣㅇㅓㅇㅛ', 'ㄷㄷㅏ', [], ['v', 'adj']),
+            ],
         },
         {
             name: '-(으)십사',
@@ -3192,8 +3192,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㅅㅣㅂㅅㅏ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅜㅅㅣㅂㅅㅏ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㅅㅣㅂㅅㅏ', 'ㅅㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅇㅡㅅㅣㅂㅅㅏ', 'ㄷㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄹㅇㅡㅅㅣㅂㅅㅏ', 'ㄷㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-(으)십시다',
@@ -3203,8 +3203,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㅅㅣㅂㅅㅣㄷㅏ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅜㅅㅣㅂㅅㅣㄷㅏ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㅅㅣㅂㅅㅣㄷㅏ', 'ㅅㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅇㅡㅅㅣㅂㅅㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄹㅇㅡㅅㅣㅂㅅㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-(으)십시오',
@@ -3214,8 +3214,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㅅㅣㅂㅅㅣㅇㅗ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅜㅅㅣㅂㅅㅣㅇㅗ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㅅㅣㅂㅅㅣㅇㅗ', 'ㅅㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅇㅡㅅㅣㅂㅅㅣㅇㅗ', 'ㄷㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄹㅇㅡㅅㅣㅂㅅㅣㅇㅗ', 'ㄷㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-아/어',
@@ -3245,8 +3245,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅓ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅓ', 'ㅡㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅓ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅓ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-아/어다',
@@ -3276,8 +3276,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅓㄷㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅏㄷㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅓㄷㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅓㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅓㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-아/어다가',
@@ -3310,8 +3310,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅓㄷㅏㄱㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅏㄷㅏㄱㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅓㄷㅏㄱㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅓㄷㅏㄱㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅓㄷㅏㄱㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-아/어도',
@@ -3344,8 +3344,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅓㄷㅗ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅏㄷㅗ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅓㄷㅗ', 'ㅡㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅓㄷㅗ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅓㄷㅗ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-아/어라',
@@ -3378,8 +3378,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅓㄹㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅏㄹㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅓㄹㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅓㄹㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅓㄹㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-아/아서',
@@ -3412,8 +3412,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅓㅅㅓ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅏㅅㅓ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅓㅅㅓ', 'ㅡㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅓㅅㅓ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅓㅅㅓ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-아/어야',
@@ -3446,8 +3446,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅓㅇㅑ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅏㅇㅑ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅓㅇㅑ', 'ㅡㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅓㅇㅑ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅓㅇㅑ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-아/어야겠',
@@ -3479,8 +3479,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅏㅇㅑㄱㅔㅆ', 'ㅡㄷㅏ', ['f'], ['v', 'adj']),
                 suffixInflection('ㅓㅇㅑㄱㅔㅆ', 'ㅡㄷㅏ', ['f'], ['v', 'adj']),
                 suffixInflection('ㅏㅇㅑㄱㅔㅆ', 'ㅡㄷㅏ', ['f'], ['v', 'adj']),
-                suffixInflection('ㅓㅇㅑㄱㅔㅆ', 'ㅡㄷㅏ', ['f'], ['v', 'adj'])
-            ]
+                suffixInflection('ㅓㅇㅑㄱㅔㅆ', 'ㅡㄷㅏ', ['f'], ['v', 'adj']),
+            ],
         },
         {
             name: '-아/어야만',
@@ -3513,8 +3513,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅓㅇㅑㅁㅏㄴ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅏㅇㅑㅁㅏㄴ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅓㅇㅑㅁㅏㄴ', 'ㅡㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅓㅇㅑㅁㅏㄴ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅓㅇㅑㅁㅏㄴ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-아/어야지',
@@ -3547,8 +3547,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅓㅇㅑㅈㅣ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅏㅇㅑㅈㅣ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅓㅇㅑㅈㅣ', 'ㅡㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅓㅇㅑㅈㅣ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅓㅇㅑㅈㅣ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-아/어요',
@@ -3582,8 +3582,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅏㅇㅛ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅓㅇㅛ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅔㅇㅛ', 'ㄷㅏ', [], ['adj', 'ida']),
-                suffixInflection('ㅇㅓㅇㅛ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅓㅇㅛ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-아/어지이다',
@@ -3615,8 +3615,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅓㅈㅣㅇㅣㄷㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅏㅈㅣㅇㅣㄷㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅓㅈㅣㅇㅣㄷㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅓㅈㅣㅇㅣㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅓㅈㅣㅇㅣㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-았/었',
@@ -3650,8 +3650,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅏㅆ', 'ㅡㄷㅏ', ['p'], ['v', 'adj']),
                 suffixInflection('ㅓㅆ', 'ㅡㄷㅏ', ['p'], ['v', 'adj']),
                 suffixInflection('ㅅㅕㅆ', 'ㅅㅣ', ['p'], ['eusi']),
-                suffixInflection('ㅅㅣㅇㅓㅆ', 'ㅅㅣ', ['p'], ['eusi'])
-            ]
+                suffixInflection('ㅅㅣㅇㅓㅆ', 'ㅅㅣ', ['p'], ['eusi']),
+            ],
         },
         {
             name: '-았/었었',
@@ -3683,8 +3683,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅏㅆㅇㅓㅆ', 'ㅡㄷㅏ', ['p'], ['v', 'adj']),
                 suffixInflection('ㅓㅆㅇㅓㅆ', 'ㅡㄷㅏ', ['p'], ['v', 'adj']),
                 suffixInflection('ㅏㅆㅇㅓㅆ', 'ㅡㄷㅏ', ['p'], ['v', 'adj']),
-                suffixInflection('ㅓㅆㅇㅓㅆ', 'ㅡㄷㅏ', ['p'], ['v', 'adj'])
-            ]
+                suffixInflection('ㅓㅆㅇㅓㅆ', 'ㅡㄷㅏ', ['p'], ['v', 'adj']),
+            ],
         },
         {
             name: '-았/었자',
@@ -3717,44 +3717,44 @@ export const koreanTransforms = {
                 suffixInflection('ㅓㅆㅈㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅏㅆㅈㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅓㅆㅈㅏ', 'ㅡㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅅㅕㅆㅈㅏ', 'ㅅㅣ', [], ['eusi'])
-            ]
+                suffixInflection('ㅅㅕㅆㅈㅏ', 'ㅅㅣ', [], ['eusi']),
+            ],
         },
         {
             name: '-야',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㅇㅑ', '아니다', [], ['adj']),
-                suffixInflection('ㅇㅣㅇㅑ', '이다', [], ['ida'])
-            ]
+                suffixInflection('ㅇㅣㅇㅑ', '이다', [], ['ida']),
+            ],
         },
         {
             name: '-언마는',
             rules: [
                 suffixInflection('ㅇㅓㄴㅁㅏㄴㅡㄴ', '아니다', [], ['adj']),
                 suffixInflection('ㅇㅓㄴㅁㅏㄴㅡㄴ', '이다', [], ['ida']),
-                suffixInflection('ㅇㅓㄴㅁㅏㄴㅡㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅇㅓㄴㅁㅏㄴㅡㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-언만',
             rules: [
                 suffixInflection('ㅇㅓㄴㅁㅏㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㅇㅓㄴㅁㅏㄴ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㅇㅓㄴㅁㅏㄴ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-언정',
             rules: [
                 suffixInflection('ㅇㅓㄴㅈㅓㅇ', '아니다', [], ['adj']),
                 suffixInflection('ㅇㅓㄴㅈㅓㅇ', '이다', [], ['ida']),
-                suffixInflection('ㅇㅓㄴㅈㅓㅇ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅇㅓㄴㅈㅓㅇ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-에라',
             rules: [
-                suffixInflection('ㅇㅔㄹㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅔㄹㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)오-',
@@ -3767,8 +3767,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅗ', 'ㄹㄷㅏ', ['euo'], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅗ', 'ㄷㄷㅏ', ['euo'], ['v', 'adj']),
                 suffixInflection('ㅇㅗ', '', ['euo'], ['eusi']),
-                suffixInflection('ㅇㅡㅇㅗ', '', ['euo'], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅇㅗ', '', ['euo'], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)오니까',
@@ -3781,8 +3781,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅗㄴㅣㄲㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅗㄴㅣㄲㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅗㄴㅣㄲㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅇㅗㄴㅣㄲㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅇㅗㄴㅣㄲㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)오리이까',
@@ -3794,8 +3794,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅗㄹㅣㅇㅣㄲㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㅇㅗㄹㅣㅇㅣㄲㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅗㄹㅣㅇㅣㄲㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅗㄹㅣㅇㅣㄲㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅇㅗㄹㅣㅇㅣㄲㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)오리이다',
@@ -3807,16 +3807,16 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅗㄹㅣㅇㅣㄷㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㅇㅗㄹㅣㅇㅣㄷㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅗㄹㅣㅇㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅗㄹㅣㅇㅣㄷㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅇㅗㄹㅣㅇㅣㄷㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-오이까',
             rules: [
                 suffixInflection('ㅇㅗㅇㅣㄲㅏ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
                 suffixInflection('ㅇㅗㅇㅣㄲㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㅇㅗㅇㅣㄲㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅇㅗㅇㅣㄲㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)오이다',
@@ -3829,22 +3829,22 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅗㅇㅣㄷㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅗㅇㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅗㅇㅣㄷㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅇㅗㅇㅣㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅇㅗㅇㅣㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-올습니다',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㅇㅗㄹㅅㅡㅂㄴㅣㄷㅏ', '아니다', [], ['adj']),
-                suffixInflection('ㅇㅣㅇㅗㄹㅅㅡㅂㄴㅣㄷㅏ', '이다', [], ['ida'])
-            ]
+                suffixInflection('ㅇㅣㅇㅗㄹㅅㅡㅂㄴㅣㄷㅏ', '이다', [], ['ida']),
+            ],
         },
         {
             name: '-올시다',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㅇㅗㄹㅅㅣㄷㅏ', '아니다', [], ['adj']),
-                suffixInflection('ㅇㅣㅇㅗㄹㅅㅣㄷㅏ', '이다', [], ['ida'])
-            ]
+                suffixInflection('ㅇㅣㅇㅗㄹㅅㅣㄷㅏ', '이다', [], ['ida']),
+            ],
         },
         {
             name: '-(으)옵-',
@@ -3857,8 +3857,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅗㅂ', 'ㄹㄷㅏ', ['euob'], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅗㅂ', 'ㄷㄷㅏ', ['euob'], ['v', 'adj']),
                 suffixInflection('ㅇㅗㅂ', '', ['euob'], ['eusi']),
-                suffixInflection('ㅇㅡㅇㅗㅂ', '', ['euob'], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅇㅗㅂ', '', ['euob'], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)옵니까',
@@ -3871,8 +3871,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅗㅂㄴㅣㄲㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅗㅂㄴㅣㄲㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅗㅂㄴㅣㄲㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅇㅗㅂㄴㅣㄲㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅇㅗㅂㄴㅣㄲㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)옵니다',
@@ -3885,8 +3885,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅗㅂㄴㅣㄷㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅗㅂㄴㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅗㅂㄴㅣㄷㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅇㅗㅂㄴㅣㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅇㅗㅂㄴㅣㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)옵디까',
@@ -3899,8 +3899,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅗㅂㄷㅣㄲㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅗㅂㄷㅣㄲㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅗㅂㄷㅣㄲㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅇㅗㅂㄷㅣㄲㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅇㅗㅂㄷㅣㄲㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)옵디다',
@@ -3913,8 +3913,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅗㅂㄷㅣㄷㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅗㅂㄷㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅗㅂㄷㅣㄷㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅇㅗㅂㄷㅣㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅇㅗㅂㄷㅣㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)옵소서',
@@ -3927,8 +3927,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅗㅂㅅㅗㅅㅓ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅗㅂㅅㅗㅅㅓ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅗㅂㅅㅗㅅㅓ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅇㅗㅂㅅㅗㅅㅓ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅇㅗㅂㅅㅗㅅㅓ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)와',
@@ -3941,8 +3941,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅗㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅗㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅗㅏ', '', [], ['eusi', 'euo', 'jao']),
-                suffixInflection('ㅇㅡㅇㅗㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅇㅗㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)외다',
@@ -3955,15 +3955,15 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅗㅣㄷㅏ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅗㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅗㅣㄷㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅇㅗㅣㄷㅏ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅇㅗㅣㄷㅏ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-요',
             rules: [
                 suffixInflection('ㅇㅏㄴㅣㅇㅛ', '아니다', [], ['ida']),
-                suffixInflection('ㅇㅛ', 'ㄷㅏ', [], ['ida'])
-            ]
+                suffixInflection('ㅇㅛ', 'ㄷㅏ', [], ['ida']),
+            ],
         },
         {
             name: '-(으)우',
@@ -3976,8 +3976,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㅇㅜ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅇㅜ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅇㅜ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅇㅜ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)이',
@@ -3985,8 +3985,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅣ', 'ㄷㅏ', [], ['adj']),
                 suffixInflection('ㅇㅣ', 'ㄹㄷㅏ', [], ['adj']),
                 suffixInflection('ㅇㅡㅇㅣ', 'ㄷㅏ', [], ['adj']),
-                suffixInflection('ㅇㅡㅣ', 'ㄷㅏ', [], ['adj'])
-            ]
+                suffixInflection('ㅇㅡㅣ', 'ㄷㅏ', [], ['adj']),
+            ],
         },
         {
             name: '-(으)ㄴ들',
@@ -3998,8 +3998,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㄷㅡㄹ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄴㄷㅡㄹ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄴㄷㅡㄹ', 'ㄷㄷㅏ', [], ['v', 'adj']),
-                suffixInflection('ㄴㄷㅡㄹ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄴㄷㅡㄹ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)ㄴ즉',
@@ -4012,8 +4012,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅈㅡㄱ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄴㅈㅡㄱ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄴㅈㅡㄱ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄴㅈㅡㄱ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄴㅈㅡㄱ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄴ즉슨',
@@ -4026,8 +4026,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄴㅈㅡㄱㅅㅡㄴ', 'ㄹㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅡㄴㅈㅡㄱㅅㅡㄴ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄴㅈㅡㄱㅅㅡㄴ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄴㅈㅡㄱㅅㅡㄴ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄴㅈㅡㄱㅅㅡㄴ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ까',
@@ -4040,8 +4040,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄲㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄲㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄲㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄲㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄲㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ깝쇼',
@@ -4054,8 +4054,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄲㅏㅂㅅㅛ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄲㅏㅂㅅㅛ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄲㅏㅂㅅㅛ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄲㅏㅂㅅㅛ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄲㅏㅂㅅㅛ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ꼬',
@@ -4068,8 +4068,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄲㅗ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄲㅗ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄲㅗ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄲㅗ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄲㅗ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ는지',
@@ -4082,8 +4082,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄴㅡㄴㅈㅣ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄴㅡㄴㅈㅣ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄴㅡㄴㅈㅣ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄴㅡㄴㅈㅣ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄴㅡㄴㅈㅣ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ데라니',
@@ -4095,8 +4095,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㄷㅔㄹㅏㄴㅣ', 'ㅅㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㄷㅔㄹㅏㄴㅣ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄷㅔㄹㅏㄴㅣ', 'ㄷㄷㅏ', [], ['adj']),
-                suffixInflection('ㄹㄷㅔㄹㅏㄴㅣ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㄷㅔㄹㅏㄴㅣ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)ㄹ라',
@@ -4109,8 +4109,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄹㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄹㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄹㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄹㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄹㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ라고',
@@ -4123,8 +4123,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄹㅏㄱㅗ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄹㅏㄱㅗ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄹㅏㄱㅗ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄹㅏㄱㅗ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄹㅏㄱㅗ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ라치면',
@@ -4135,8 +4135,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹㄹㅏㅊㅣㅁㅕㄴ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㄹㄹㅏㅊㅣㅁㅕㄴ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㄹㅏㅊㅣㅁㅕㄴ', 'ㄷㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㄹㅏㅊㅣㅁㅕㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㄹㅏㅊㅣㅁㅕㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)ㄹ락',
@@ -4148,8 +4148,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㄹㄹㅏㄱ ㅁㅏㄹㄹㅏㄱ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㄹㅏㄱ ㅁㅏㄹㄹㅏㄱ', 'ㄷㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㄹㅏㄱ ㅁㅏㄹㄹㅏㄱ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄹㅏㄱ ㅁㅏㄹㄹㅏㄱ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄹㅏㄱ ㅁㅏㄹㄹㅏㄱ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ래',
@@ -4160,8 +4160,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹㄹㅐ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㄹㄹㅐ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㄹㅐ', 'ㄷㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㄹㅐ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㄹㅐ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)ㄹ러니',
@@ -4174,8 +4174,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄹㅓㄴㅣ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄹㅓㄴㅣ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄹㅓㄴㅣ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄹㅓㄴㅣ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄹㅓㄴㅣ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ러라',
@@ -4188,8 +4188,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄹㅓㄹㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄹㅓㄹㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄹㅓㄹㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄹㅓㄹㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄹㅓㄹㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ런가',
@@ -4202,8 +4202,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄹㅓㄴㄱㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄹㅓㄴㄱㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄹㅓㄴㄱㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄹㅓㄴㄱㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄹㅓㄴㄱㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ런고',
@@ -4216,8 +4216,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄹㅓㄴㄱㅗ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄹㅓㄴㄱㅗ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄹㅓㄴㄱㅗ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄹㅓㄴㄱㅗ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄹㅓㄴㄱㅗ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ런지',
@@ -4230,8 +4230,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄹㅓㄴㅈㅣ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄹㅓㄴㅈㅣ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄹㅓㄴㅈㅣ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄹㅓㄴㅈㅣ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄹㅓㄴㅈㅣ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ레',
@@ -4244,8 +4244,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄹㅔ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄹㅔ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄹㅔ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄹㅔ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄹㅔ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ레라',
@@ -4258,8 +4258,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㄹㅔㄹㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㄹㅔㄹㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㄹㅔㄹㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㄹㅔㄹㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㄹㅔㄹㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ려고',
@@ -4270,8 +4270,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹㄹㅕㄱㅗ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㄹㄹㅕㄱㅗ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㄹㅕㄱㅗ', 'ㄷㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㄹㅕㄱㅗ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㄹㅕㄱㅗ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)ㄹ망정',
@@ -4284,8 +4284,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅁㅏㅇㅈㅓㅇ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅁㅏㅇㅈㅓㅇ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅁㅏㅇㅈㅓㅇ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅁㅏㅇㅈㅓㅇ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅁㅏㅇㅈㅓㅇ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ밖에',
@@ -4298,8 +4298,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅂㅏㄲㅇㅔ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅂㅏㄲㅇㅔ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅂㅏㄲㅇㅔ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅂㅏㄲㅇㅔ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅂㅏㄲㅇㅔ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ뿐더러',
@@ -4312,8 +4312,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅃㅜㄴㄷㅓㄹㅓ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅃㅜㄴㄷㅓㄹㅓ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅃㅜㄴㄷㅓㄹㅓ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅃㅜㄴㄷㅓㄹㅓ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅃㅜㄴㄷㅓㄹㅓ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ사',
@@ -4324,8 +4324,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹㅅㅏ', 'ㅂㄷㅏ', [], ['adj']),
                 suffixInflection('ㅇㅡㄹㅅㅏ', 'ㅅㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅅㅏ', 'ㅎㄷㅏ', [], ['adj']),
-                suffixInflection('ㄹㅇㅡㄹㅅㅏ', 'ㄷㄷㅏ', [], ['adj'])
-            ]
+                suffixInflection('ㄹㅇㅡㄹㅅㅏ', 'ㄷㄷㅏ', [], ['adj']),
+            ],
         },
         {
             name: '-(으)ㄹ새',
@@ -4338,8 +4338,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅅㅐ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅅㅐ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅅㅐ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅅㅐ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅅㅐ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ세',
@@ -4352,8 +4352,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅅㅔ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅅㅔ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅅㅔ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅅㅔ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅅㅔ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ세라',
@@ -4366,8 +4366,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅅㅔㄹㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅅㅔㄹㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅅㅔㄹㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅅㅔㄹㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅅㅔㄹㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ세말이지',
@@ -4380,8 +4380,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅅㅔㅁㅏㄹㅇㅣㅈㅣ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅅㅔㅁㅏㄹㅇㅣㅈㅣ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅅㅔㅁㅏㄹㅇㅣㅈㅣ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅅㅔㅁㅏㄹㅇㅣㅈㅣ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅅㅔㅁㅏㄹㅇㅣㅈㅣ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ소냐',
@@ -4394,8 +4394,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅅㅗㄴㅑ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅅㅗㄴㅑ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅅㅗㄴㅑ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅅㅗㄴㅑ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅅㅗㄴㅑ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ손가',
@@ -4408,8 +4408,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅅㅗㄴㄱㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅅㅗㄴㄱㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅅㅗㄴㄱㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅅㅗㄴㄱㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅅㅗㄴㄱㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ수록',
@@ -4422,8 +4422,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅅㅜㄹㅗㄱ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅅㅜㄹㅗㄱ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅅㅜㄹㅗㄱ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅅㅜㄹㅗㄱ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅅㅜㄹㅗㄱ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ시',
@@ -4436,8 +4436,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅅㅣ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅅㅣ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅅㅣ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅅㅣ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅅㅣ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ시고',
@@ -4450,8 +4450,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅅㅣㄱㅗ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅅㅣㄱㅗ', 'ㄷㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅅㅣㄱㅗ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅅㅣㄱㅗ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅅㅣㄱㅗ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ싸록',
@@ -4464,8 +4464,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅆㅏㄹㅗㄱ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅆㅏㄹㅗㄱ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅆㅏㄹㅗㄱ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅆㅏㄹㅗㄱ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅆㅏㄹㅗㄱ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ쏘냐',
@@ -4478,8 +4478,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅆㅗㄴㅑ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅆㅗㄴㅑ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅆㅗㄴㅑ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅆㅗㄴㅑ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅆㅗㄴㅑ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ쏜가',
@@ -4492,8 +4492,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅆㅗㄴㄱㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅆㅗㄴㄱㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅆㅗㄴㄱㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅆㅗㄴㄱㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅆㅗㄴㄱㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ이만큼',
@@ -4506,8 +4506,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅇㅣㅁㅏㄴㅋㅡㅁ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅇㅣㅁㅏㄴㅋㅡㅁ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅇㅣㅁㅏㄴㅋㅡㅁ', '', [], ['eusi', 'euo']),
-                suffixInflection('ㅇㅡㄹㅇㅣㅁㅏㄴㅋㅡㅁ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅇㅣㅁㅏㄴㅋㅡㅁ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ작시면',
@@ -4518,8 +4518,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹㅈㅏㄱㅅㅣㅁㅕㄴ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㄹㅈㅏㄱㅅㅣㅁㅕㄴ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅏㄱㅅㅣㅁㅕㄴ', 'ㄷㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅈㅏㄱㅅㅣㅁㅕㄴ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅈㅏㄱㅅㅣㅁㅕㄴ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)ㄹ지',
@@ -4532,8 +4532,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅈㅣ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅈㅣ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅈㅣ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅈㅣ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ지나',
@@ -4546,8 +4546,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅈㅣㄴㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣㄴㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅈㅣㄴㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅈㅣㄴㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅈㅣㄴㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ지니',
@@ -4560,8 +4560,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅈㅣㄴㅣ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣㄴㅣ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅈㅣㄴㅣ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅈㅣㄴㅣ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅈㅣㄴㅣ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ지니라',
@@ -4574,8 +4574,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅈㅣㄴㅣㄹㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣㄴㅣㄹㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅈㅣㄴㅣㄹㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅈㅣㄴㅣㄹㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅈㅣㄴㅣㄹㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ지라',
@@ -4588,8 +4588,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅈㅣㄹㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣㄹㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅈㅣㄹㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅈㅣㄹㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅈㅣㄹㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ지라도',
@@ -4602,8 +4602,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅈㅣㄹㅏㄷㅗ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣㄹㅏㄷㅗ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅈㅣㄹㅏㄷㅗ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅈㅣㄹㅏㄷㅗ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅈㅣㄹㅏㄷㅗ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ지로다',
@@ -4616,8 +4616,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅈㅣㄹㅗㄷㅏ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣㄹㅗㄷㅏ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅈㅣㄹㅗㄷㅏ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅈㅣㄹㅗㄷㅏ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅈㅣㄹㅗㄷㅏ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ지며',
@@ -4630,8 +4630,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅈㅣㅁㅕ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣㅁㅕ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅈㅣㅁㅕ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅈㅣㅁㅕ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅈㅣㅁㅕ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ지어다',
@@ -4642,8 +4642,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㄹㅈㅣㅇㅓㄷㅏ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㄹㅈㅣㅇㅓㄷㅏ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣㅇㅓㄷㅏ', 'ㄷㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅈㅣㅇㅓㄷㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㄹㅈㅣㅇㅓㄷㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)ㄹ지언정',
@@ -4656,8 +4656,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅈㅣㅇㅓㄴㅈㅓㅇ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣㅇㅓㄴㅈㅓㅇ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅈㅣㅇㅓㄴㅈㅓㅇ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅈㅣㅇㅓㄴㅈㅓㅇ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅈㅣㅇㅓㄴㅈㅓㅇ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ진대',
@@ -4670,8 +4670,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅈㅣㄴㄷㅐ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣㄴㄷㅐ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅈㅣㄴㄷㅐ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅈㅣㄴㄷㅐ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅈㅣㄴㄷㅐ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ진대는',
@@ -4684,8 +4684,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅈㅣㄴㄷㅐㄴㅡㄴ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣㄴㄷㅐㄴㅡㄴ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅈㅣㄴㄷㅐㄴㅡㄴ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅈㅣㄴㄷㅐㄴㅡㄴ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅈㅣㄴㄷㅐㄴㅡㄴ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ진댄',
@@ -4698,8 +4698,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅈㅣㄴㄷㅐㄴ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣㄴㄷㅐㄴ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅈㅣㄴㄷㅐㄴ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅈㅣㄴㄷㅐㄴ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅈㅣㄴㄷㅐㄴ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㄹ진저',
@@ -4712,8 +4712,8 @@ export const koreanTransforms = {
                 suffixInflection('ㄹㅈㅣㄴㅈㅓ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㄹㅈㅣㄴㅈㅓ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㄹㅈㅣㄴㅈㅓ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㄹㅈㅣㄴㅈㅓ', '', [], ['p'])
-            ]
+                suffixInflection('ㅇㅡㄹㅈㅣㄴㅈㅓ', '', [], ['p']),
+            ],
         },
         {
             name: '-(으)ㅁ',
@@ -4726,8 +4726,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅁ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㅁ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅁ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅁ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅁ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)ㅁ세',
@@ -4737,8 +4737,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㅁㅅㅔ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅜㅁㅅㅔ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㅁㅅㅔ', 'ㅅㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅇㅡㅁㅅㅔ', 'ㄷㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄹㅇㅡㅁㅅㅔ', 'ㄷㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-(으)ㅁ도',
@@ -4751,8 +4751,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅁㄷㅗ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㅁㄷㅗ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅁㄷㅗ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅁㄷㅗ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅁㄷㅗ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)ㅁ에랴',
@@ -4765,8 +4765,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅁㅇㅔㄹㅑ', 'ㅎㄷㅏ', [], ['adj']),
                 suffixInflection('ㄹㅇㅡㅁㅇㅔㄹㅑ', 'ㄷㄷㅏ', [], ['v', 'adj']),
                 suffixInflection('ㅁㅇㅔㄹㅑ', '', [], ['eusi']),
-                suffixInflection('ㅇㅡㅁㅇㅔㄹㅑ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅇㅡㅁㅇㅔㄹㅑ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-(으)ㅂ쇼',
@@ -4776,8 +4776,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㅂㅅㅛ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅜㅂㅅㅛ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㅂㅅㅛ', 'ㅅㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅇㅡㅂㅅㅛ', 'ㄷㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄹㅇㅡㅂㅅㅛ', 'ㄷㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-(으)ㅂ시다',
@@ -4787,8 +4787,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㅂㅅㅣㄷㅏ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅜㅂㅅㅣㄷㅏ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㅂㅅㅣㄷㅏ', 'ㅅㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅇㅡㅂㅅㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄹㅇㅡㅂㅅㅣㄷㅏ', 'ㄷㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-(으)ㅂ시다',
@@ -4799,8 +4799,8 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅜㅂㅅㅣㅅㅏ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㅂㅅㅣㅅㅏ', 'ㅅㄷㅏ', [], ['v']),
                 suffixInflection('ㄹㅇㅡㅂㅅㅣㅅㅏ', 'ㄷㄷㅏ', [], ['v']),
-                suffixInflection('ㅂㅅㅣㅅㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅂㅅㅣㅅㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-(으)ㅂ시오',
@@ -4810,135 +4810,135 @@ export const koreanTransforms = {
                 suffixInflection('ㅇㅡㅂㅅㅣㅇㅗ', 'ㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅜㅂㅅㅣㅇㅗ', 'ㅂㄷㅏ', [], ['v']),
                 suffixInflection('ㅇㅡㅂㅅㅣㅇㅗ', 'ㅅㄷㅏ', [], ['v']),
-                suffixInflection('ㄹㅇㅡㅂㅅㅣㅇㅗ', 'ㄷㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㄹㅇㅡㅂㅅㅣㅇㅗ', 'ㄷㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-자',
             rules: [
-                suffixInflection('ㅈㅏ', 'ㄷㅏ', [], ['v', 'ida'])
-            ]
+                suffixInflection('ㅈㅏ', 'ㄷㅏ', [], ['v', 'ida']),
+            ],
         },
         {
             name: '-자고',
             rules: [
-                suffixInflection('ㅈㅏㄱㅗ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㅈㅏㄱㅗ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-자구',
             rules: [
-                suffixInflection('ㅈㅏㄱㅜ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㅈㅏㄱㅜ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-자꾸나',
             rules: [
-                suffixInflection('ㅈㅏㄲㅜㄴㅏ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㅈㅏㄲㅜㄴㅏ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-자느니',
             rules: [
-                suffixInflection('ㅈㅏㄴㅡㄴㅣ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㅈㅏㄴㅡㄴㅣ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-자니까',
             rules: [
-                suffixInflection('ㅈㅏㄴㅣㄲㅏ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㅈㅏㄴㅣㄲㅏ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-자마자',
             rules: [
                 suffixInflection('ㅈㅏㅁㅏㅈㅏ', 'ㄷㅏ', [], ['v']),
-                suffixInflection('ㅈㅏㅁㅏㅈㅏ', '', [], ['eusi'])
-            ]
+                suffixInflection('ㅈㅏㅁㅏㅈㅏ', '', [], ['eusi']),
+            ],
         },
         {
             name: '-자며',
             rules: [
-                suffixInflection('ㅈㅏㅁㅕ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㅈㅏㅁㅕ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-자면',
             rules: [
-                suffixInflection('ㅈㅏㅁㅕㄴ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㅈㅏㅁㅕㄴ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-자면서',
             rules: [
-                suffixInflection('ㅈㅏㅁㅕㄴㅅㅓ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㅈㅏㅁㅕㄴㅅㅓ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-자손',
             rules: [
-                suffixInflection('ㅈㅏㅅㅗㄴ', 'ㄷㅏ', [], ['v'])
-            ]
+                suffixInflection('ㅈㅏㅅㅗㄴ', 'ㄷㅏ', [], ['v']),
+            ],
         },
         {
             name: '-자오-',
             rules: [
-                suffixInflection('ㅈㅏㅇㅗ', 'ㄷㅏ', ['jao'], ['v'])
-            ]
+                suffixInflection('ㅈㅏㅇㅗ', 'ㄷㅏ', ['jao'], ['v']),
+            ],
         },
         {
             name: '-자옵-',
             rules: [
-                suffixInflection('ㅈㅏㅇㅗㅂ', 'ㄷㅏ', ['jaob'], ['v'])
-            ]
+                suffixInflection('ㅈㅏㅇㅗㅂ', 'ㄷㅏ', ['jaob'], ['v']),
+            ],
         },
         {
             name: '-잡-',
             rules: [
-                suffixInflection('ㅈㅏㅂ', 'ㄷㅏ', ['jab'], ['v'])
-            ]
+                suffixInflection('ㅈㅏㅂ', 'ㄷㅏ', ['jab'], ['v']),
+            ],
         },
         {
             name: '-죠',
             rules: [
                 suffixInflection('ㅈㅛ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㅈㅛ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㅈㅛ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-지',
             rules: [
                 suffixInflection('ㅈㅣ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㅈㅣ', '', [], ['p', 'f', 'eusi'])
-            ]
+                suffixInflection('ㅈㅣ', '', [], ['p', 'f', 'eusi']),
+            ],
         },
         {
             name: '-지마는',
             rules: [
                 suffixInflection('ㅈㅣㅁㅏㄴㅡㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㅈㅣㅁㅏㄴㅡㄴ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅈㅣㅁㅏㄴㅡㄴ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-지만',
             rules: [
                 suffixInflection('ㅈㅣㅁㅏㄴ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㅈㅣㅁㅏㄴ', '', [], ['p', 'f', 'euo', 'euob'])
-            ]
+                suffixInflection('ㅈㅣㅁㅏㄴ', '', [], ['p', 'f', 'euo', 'euob']),
+            ],
         },
         {
             name: '-지만서도',
             rules: [
                 suffixInflection('ㅈㅣㅁㅏㄴㅅㅓㄷㅗ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㅈㅣㅁㅏㄴㅅㅓㄷㅗ', '', [], ['p', 'f'])
-            ]
+                suffixInflection('ㅈㅣㅁㅏㄴㅅㅓㄷㅗ', '', [], ['p', 'f']),
+            ],
         },
         {
             name: '-지요',
             rules: [
                 suffixInflection('ㅈㅣㅇㅛ', 'ㄷㅏ', [], ['v', 'adj', 'ida']),
-                suffixInflection('ㅈㅣㅇㅛ', '', [], ['p', 'f', 'eusi'])
-            ]
-        }
-    ]
+                suffixInflection('ㅈㅣㅇㅛ', '', [], ['p', 'f', 'eusi']),
+            ],
+        },
+    ],
 };

--- a/ext/js/language/la/latin-transforms.js
+++ b/ext/js/language/la/latin-transforms.js
@@ -25,105 +25,105 @@ export const latinTransforms = {
     conditions: {
         v: {
             name: 'Verb',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n: {
             name: 'Noun',
             isDictionaryForm: true,
-            subConditions: ['ns', 'np']
+            subConditions: ['ns', 'np'],
         },
         ns: {
             name: 'Noun, singular',
             isDictionaryForm: true,
-            subConditions: ['n1s', 'n2s', 'n3s', 'n4s', 'n5s']
+            subConditions: ['n1s', 'n2s', 'n3s', 'n4s', 'n5s'],
         },
         np: {
             name: 'Noun, plural',
             isDictionaryForm: true,
-            subConditions: ['n1p', 'n2p', 'n3p', 'n4p', 'n5p']
+            subConditions: ['n1p', 'n2p', 'n3p', 'n4p', 'n5p'],
         },
         n1: {
             name: 'Noun, 1st declension',
             isDictionaryForm: true,
-            subConditions: ['n1s', 'n1p']
+            subConditions: ['n1s', 'n1p'],
         },
         n1p: {
             name: 'Noun, 1st declension, plural',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n1s: {
             name: 'Noun, 1st declension, singular',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n2: {
             name: 'Noun, 2nd declension',
             isDictionaryForm: true,
-            subConditions: ['n2s', 'n2p']
+            subConditions: ['n2s', 'n2p'],
         },
         n2p: {
             name: 'Noun, 2nd declension, plural',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n2s: {
             name: 'Noun, 2nd declension, singular',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n3: {
             name: 'Noun, 3rd declension',
             isDictionaryForm: true,
-            subConditions: ['n3s', 'n3p']
+            subConditions: ['n3s', 'n3p'],
         },
         n3p: {
             name: 'Noun, 3rd declension, plural',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n3s: {
             name: 'Noun, 3rd declension, singular',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n4: {
             name: 'Noun, 4th declension',
             isDictionaryForm: true,
-            subConditions: ['n4s', 'n4p']
+            subConditions: ['n4s', 'n4p'],
         },
         n4p: {
             name: 'Noun, 4th declension, plural',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n4s: {
             name: 'Noun, 4th declension, singular',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n5: {
             name: 'Noun, 5th declension',
             isDictionaryForm: true,
-            subConditions: ['n5s', 'n5p']
+            subConditions: ['n5s', 'n5p'],
         },
         n5p: {
             name: 'Noun, 5th declension, plural',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n5s: {
             name: 'Noun, 5th declension, singular',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         adj: {
             name: 'Adjective',
             isDictionaryForm: true,
-            subConditions: ['adj3', 'adj12']
+            subConditions: ['adj3', 'adj12'],
         },
         adj12: {
             name: 'Adjective, 1st-2nd declension',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         adj3: {
             name: 'Adjective, 3rd declension',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         adv: {
             name: 'Adverb',
-            isDictionaryForm: true
-        }
+            isDictionaryForm: true,
+        },
     },
     transforms: [
         {
@@ -134,29 +134,29 @@ export const latinTransforms = {
                 suffixInflection('i', 'us', ['adj12'], ['adj12']),
                 suffixInflection('e', '', ['n1p'], ['n1s']),
                 suffixInflection('ae', 'a', ['adj12'], ['adj12']),
-                suffixInflection('a', 'um', ['adj12'], ['adj12'])
-            ]
+                suffixInflection('a', 'um', ['adj12'], ['adj12']),
+            ],
         },
         {
             name: 'feminine',
             description: 'Adjective form',
             rules: [
-                suffixInflection('a', 'us', ['adj12'], ['adj12'])
-            ]
+                suffixInflection('a', 'us', ['adj12'], ['adj12']),
+            ],
         },
         {
             name: 'neuter',
             description: 'Adjective form',
             rules: [
-                suffixInflection('um', 'us', ['adj12'], ['adj12'])
-            ]
+                suffixInflection('um', 'us', ['adj12'], ['adj12']),
+            ],
         },
         {
             name: 'ablative',
             description: 'Ablative case',
             rules: [
-                suffixInflection('o', 'um', ['n2s'], ['n2s'])
-            ]
-        }
-    ]
+                suffixInflection('o', 'um', ['n2s'], ['n2s']),
+            ],
+        },
+    ],
 };

--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -25,7 +25,7 @@ import {
     alphanumericWidthVariants,
     collapseEmphaticSequences,
     convertHalfWidthCharacters,
-    convertHiraganaToKatakana
+    convertHiraganaToKatakana,
 } from './ja/japanese-text-preprocessors.js';
 import {japaneseTransforms} from './ja/japanese-transforms.js';
 import {isStringPartiallyJapanese} from './ja/japanese.js';
@@ -39,7 +39,7 @@ import {capitalizeFirstLetter, decapitalize, removeAlphabeticDiacritics} from '.
 
 const capitalizationPreprocessors = {
     decapitalize,
-    capitalizeFirstLetter
+    capitalizeFirstLetter,
 };
 
 /** @type {import('language-descriptors').LanguageDescriptorAny[]} */
@@ -49,8 +49,8 @@ const languageDescriptors = [
         name: 'Arabic',
         exampleText: 'قَرَأَ',
         textPreprocessors: {
-            removeArabicScriptDiacritics
-        }
+            removeArabicScriptDiacritics,
+        },
     },
     {
         iso: 'de',
@@ -58,49 +58,49 @@ const languageDescriptors = [
         exampleText: 'gelesen',
         textPreprocessors: {
             ...capitalizationPreprocessors,
-            eszettPreprocessor
+            eszettPreprocessor,
         },
-        languageTransforms: germanTransforms
+        languageTransforms: germanTransforms,
     },
     {
         iso: 'el',
         name: 'Greek',
         exampleText: 'διαβάζω',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'en',
         name: 'English',
         exampleText: 'read',
         textPreprocessors: capitalizationPreprocessors,
-        languageTransforms: englishTransforms
+        languageTransforms: englishTransforms,
     },
     {
         iso: 'es',
         name: 'Spanish',
         exampleText: 'acabar de',
         textPreprocessors: capitalizationPreprocessors,
-        languageTransforms: spanishTransforms
+        languageTransforms: spanishTransforms,
     },
     {
         iso: 'fa',
         name: 'Persian',
         exampleText: 'خواندن',
         textPreprocessors: {
-            removeArabicScriptDiacritics
-        }
+            removeArabicScriptDiacritics,
+        },
     },
     {
         iso: 'fi',
         name: 'Finnish',
         exampleText: 'lukea',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'fr',
         name: 'French',
         exampleText: 'lire',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'grc',
@@ -108,26 +108,26 @@ const languageDescriptors = [
         exampleText: 'γράφω',
         textPreprocessors: {
             ...capitalizationPreprocessors,
-            removeAlphabeticDiacritics
-        }
+            removeAlphabeticDiacritics,
+        },
     },
     {
         iso: 'hu',
         name: 'Hungarian',
         exampleText: 'olvasni',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'id',
         name: 'Indonesian',
         exampleText: 'membaca',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'it',
         name: 'Italian',
         exampleText: 'leggere',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'la',
@@ -135,14 +135,14 @@ const languageDescriptors = [
         exampleText: 'legere',
         textPreprocessors: {
             ...capitalizationPreprocessors,
-            removeAlphabeticDiacritics
+            removeAlphabeticDiacritics,
         },
-        languageTransforms: latinTransforms
+        languageTransforms: latinTransforms,
     },
     {
         iso: 'lo',
         name: 'Lao',
-        exampleText: 'ອ່ານ'
+        exampleText: 'ອ່ານ',
     },
     {
         iso: 'ja',
@@ -154,50 +154,50 @@ const languageDescriptors = [
             alphabeticToHiragana,
             alphanumericWidthVariants,
             convertHiraganaToKatakana,
-            collapseEmphaticSequences
+            collapseEmphaticSequences,
         },
-        languageTransforms: japaneseTransforms
+        languageTransforms: japaneseTransforms,
     },
     {
         iso: 'km',
         name: 'Khmer',
-        exampleText: 'អាន'
+        exampleText: 'អាន',
     },
     {
         iso: 'ko',
         name: 'Korean',
         exampleText: '읽어',
         textPreprocessors: {
-            disassembleHangul
+            disassembleHangul,
         },
         textPostprocessors: {
-            reassembleHangul
+            reassembleHangul,
         },
-        languageTransforms: koreanTransforms
+        languageTransforms: koreanTransforms,
     },
     {
         iso: 'nl',
         name: 'Dutch',
         exampleText: 'lezen',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'pl',
         name: 'Polish',
         exampleText: 'czytacie',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'pt',
         name: 'Portuguese',
         exampleText: 'ler',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'ro',
         name: 'Romanian',
         exampleText: 'citit',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'ru',
@@ -206,8 +206,8 @@ const languageDescriptors = [
         textPreprocessors: {
             ...capitalizationPreprocessors,
             yoToE,
-            removeRussianDiacritics
-        }
+            removeRussianDiacritics,
+        },
     },
     {
         iso: 'sga',
@@ -215,56 +215,56 @@ const languageDescriptors = [
         exampleText: 'légaid',
         textPreprocessors: {
             ...capitalizationPreprocessors,
-            removeAlphabeticDiacritics
+            removeAlphabeticDiacritics,
         },
-        languageTransforms: oldIrishTransforms
+        languageTransforms: oldIrishTransforms,
     },
     {
         iso: 'sh',
         name: 'Serbo-Croatian',
         exampleText: 'čitaše',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'sq',
         name: 'Albanian',
         exampleText: 'ndihmojme',
         textPreprocessors: capitalizationPreprocessors,
-        languageTransforms: albanianTransforms
+        languageTransforms: albanianTransforms,
     },
     {
         iso: 'sv',
         name: 'Swedish',
         exampleText: 'läsa',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'th',
         name: 'Thai',
-        exampleText: 'อ่าน'
+        exampleText: 'อ่าน',
     },
     {
         iso: 'tr',
         name: 'Turkish',
         exampleText: 'okuyor',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'vi',
         name: 'Vietnamese',
         exampleText: 'đọc',
-        textPreprocessors: capitalizationPreprocessors
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'yue',
         name: 'Cantonese',
-        exampleText: '讀'
+        exampleText: '讀',
     },
     {
         iso: 'zh',
         name: 'Chinese',
-        exampleText: '读'
-    }
+        exampleText: '读',
+    },
 ];
 
 /** @type {Map<string, import('language-descriptors').LanguageDescriptorAny>} */

--- a/ext/js/language/language-transformer.js
+++ b/ext/js/language/language-transformer.js
@@ -65,7 +65,7 @@ export class LanguageTransformer {
                     isInflected,
                     deinflect,
                     conditionsIn: conditionFlagsIn,
-                    conditionsOut: conditionFlagsOut
+                    conditionsOut: conditionFlagsOut,
                 });
             }
             const isInflectedTests = rules.map((rule) => rule.isInflected);
@@ -139,7 +139,7 @@ export class LanguageTransformer {
                     results.push(LanguageTransformer.createTransformedText(
                         deinflect(text),
                         rule.conditionsOut,
-                        this._extendTrace(trace, {transform: name, ruleIndex: j, text})
+                        this._extendTrace(trace, {transform: name, ruleIndex: j, text}),
                     ));
                 }
             }

--- a/ext/js/language/language-transforms.js
+++ b/ext/js/language/language-transforms.js
@@ -31,7 +31,7 @@ export function suffixInflection(inflectedSuffix, deinflectedSuffix, conditionsI
         deinflected: deinflectedSuffix,
         deinflect: (text) => text.slice(0, -inflectedSuffix.length) + deinflectedSuffix,
         conditionsIn,
-        conditionsOut
+        conditionsOut,
     };
 }
 
@@ -49,7 +49,7 @@ export function prefixInflection(inflectedPrefix, deinflectedPrefix, conditionsI
         isInflected: prefixRegExp,
         deinflect: (text) => deinflectedPrefix + text.slice(inflectedPrefix.length),
         conditionsIn,
-        conditionsOut
+        conditionsOut,
     };
 }
 
@@ -67,6 +67,6 @@ export function wholeWordInflection(inflectedWord, deinflectedWord, conditionsIn
         isInflected: regex,
         deinflect: () => deinflectedWord,
         conditionsIn,
-        conditionsOut
+        conditionsOut,
     };
 }

--- a/ext/js/language/languages.js
+++ b/ext/js/language/languages.js
@@ -40,7 +40,7 @@ export function getAllLanguageTextProcessors() {
         for (const [id, textPreprocessor] of Object.entries(textPreprocessors)) {
             textPreprocessorsArray.push({
                 id,
-                textProcessor: /** @type {import('language').TextProcessor<unknown>} */ (textPreprocessor)
+                textProcessor: /** @type {import('language').TextProcessor<unknown>} */ (textPreprocessor),
             });
         }
         /** @type {import('language').TextProcessorWithId<unknown>[]} */
@@ -48,7 +48,7 @@ export function getAllLanguageTextProcessors() {
         for (const [id, textPostprocessor] of Object.entries(textPostprocessors)) {
             textPostprocessorsArray.push({
                 id,
-                textProcessor: /** @type {import('language').TextProcessor<unknown>} */ (textPostprocessor)
+                textProcessor: /** @type {import('language').TextProcessor<unknown>} */ (textPostprocessor),
             });
         }
         results.push({iso, textPreprocessors: textPreprocessorsArray, textPostprocessors: textPostprocessorsArray});

--- a/ext/js/language/ru/russian-text-preprocessors.js
+++ b/ext/js/language/ru/russian-text-preprocessors.js
@@ -24,7 +24,7 @@ export const removeRussianDiacritics = {
     options: basicTextProcessorOptions,
     process: (str, setting) => {
         return setting ? str.replace(/\u0301/g, '') : str;
-    }
+    },
 };
 
 /** @type {import('language').TextProcessor<boolean>} */
@@ -34,5 +34,5 @@ export const yoToE = {
     options: basicTextProcessorOptions,
     process: (str, setting) => {
         return setting ? str.replace(/ё/g, 'е').replace(/Ё/g, 'Е') : str;
-    }
+    },
 };

--- a/ext/js/language/sga/old-irish-transforms.js
+++ b/ext/js/language/sga/old-irish-transforms.js
@@ -32,7 +32,7 @@ function tryAlternateOrthography(notBeginning, originalOrthography, alternateOrt
         isInflected: orthographyRegExp,
         deinflect: (text) => text.replace(orthographyRegExp, alternateOrthography),
         conditionsIn,
-        conditionsOut
+        conditionsOut,
     };
 }
 
@@ -45,37 +45,37 @@ export const oldIrishTransforms = {
             name: 'nd for nn',
             description: 'nd for nn',
             rules: [
-                suffixInflection('nd', 'nn', [], [])
-            ]
+                suffixInflection('nd', 'nn', [], []),
+            ],
         },
         {
             name: 'cg for c',
             description: 'cg for c',
             rules: [
-                tryAlternateOrthography(false, 'cg', 'c', [], [])
-            ]
+                tryAlternateOrthography(false, 'cg', 'c', [], []),
+            ],
         },
         {
             name: 'td for t',
             description: 'td for t',
             rules: [
-                tryAlternateOrthography(false, 'td', 't', [], [])
-            ]
+                tryAlternateOrthography(false, 'td', 't', [], []),
+            ],
         },
         {
             name: 'pb for p',
             description: 'pb for p',
             rules: [
-                tryAlternateOrthography(false, 'pb', 'p', [], [])
-            ]
+                tryAlternateOrthography(false, 'pb', 'p', [], []),
+            ],
         },
         {
             name: 'ǽ/æ for é',
             description: 'ǽ/æ for é',
             rules: [
                 tryAlternateOrthography(false, 'ǽ', 'é', [], []),
-                tryAlternateOrthography(false, 'æ', 'é', [], [])
-            ]
+                tryAlternateOrthography(false, 'æ', 'é', [], []),
+            ],
         },
         {
             name: 'doubled vowel',
@@ -85,8 +85,8 @@ export const oldIrishTransforms = {
                 tryAlternateOrthography(true, 'ee', 'é', [], []),
                 tryAlternateOrthography(true, 'ii', 'í', [], []),
                 tryAlternateOrthography(true, 'oo', 'ó', [], []),
-                tryAlternateOrthography(true, 'uu', 'ú', [], [])
-            ]
+                tryAlternateOrthography(true, 'uu', 'ú', [], []),
+            ],
         },
         {
             name: 'doubled consonant',
@@ -102,8 +102,8 @@ export const oldIrishTransforms = {
                 tryAlternateOrthography(true, 'll', 'l', [], []),
                 tryAlternateOrthography(true, 'nn', 'n', [], []),
                 tryAlternateOrthography(true, 'mm', 'm', [], []),
-                tryAlternateOrthography(true, 'ss', 's', [], [])
-            ]
+                tryAlternateOrthography(true, 'ss', 's', [], []),
+            ],
         },
         {
             name: 'lenited',
@@ -111,8 +111,8 @@ export const oldIrishTransforms = {
             rules: [
                 tryAlternateOrthography(true, 'ch', 'c', [], []),
                 tryAlternateOrthography(true, 'ph', 'p', [], []),
-                tryAlternateOrthography(true, 'th', 't', [], [])
-            ]
+                tryAlternateOrthography(true, 'th', 't', [], []),
+            ],
         },
         {
             name: 'lenited (Middle Irish)',
@@ -120,8 +120,8 @@ export const oldIrishTransforms = {
             rules: [
                 tryAlternateOrthography(true, 'gh', 'g', [], []),
                 tryAlternateOrthography(true, 'bh', 'b', [], []),
-                tryAlternateOrthography(true, 'dh', 'd', [], [])
-            ]
+                tryAlternateOrthography(true, 'dh', 'd', [], []),
+            ],
         },
         {
             name: '[IM] nasalized',
@@ -131,8 +131,8 @@ export const oldIrishTransforms = {
                 prefixInflection('mb', 'b', [], []),
                 prefixInflection('nd', 'd', [], []),
                 prefixInflection('n-', '', [], []),
-                prefixInflection('m-', '', [], [])
-            ]
+                prefixInflection('m-', '', [], []),
+            ],
         },
         {
             name: '[IM] nasalized (Middle Irish)',
@@ -140,8 +140,8 @@ export const oldIrishTransforms = {
             rules: [
                 prefixInflection('gc', 'c', [], []),
                 prefixInflection('bp', 'p', [], []),
-                prefixInflection('dt', 'd', [], [])
-            ]
+                prefixInflection('dt', 'd', [], []),
+            ],
         },
         {
             name: '[IM] lenited',
@@ -149,8 +149,8 @@ export const oldIrishTransforms = {
             rules: [
                 prefixInflection('ch', 'c', [], []),
                 prefixInflection('ph', 'p', [], []),
-                prefixInflection('th', 't', [], [])
-            ]
+                prefixInflection('th', 't', [], []),
+            ],
         },
         {
             name: '[IM] lenited (Middle Irish)',
@@ -158,8 +158,8 @@ export const oldIrishTransforms = {
             rules: [
                 prefixInflection('gh', 'g', [], []),
                 prefixInflection('bh', 'b', [], []),
-                prefixInflection('dh', 'd', [], [])
-            ]
+                prefixInflection('dh', 'd', [], []),
+            ],
         },
         {
             name: '[IM] aspirated',
@@ -170,8 +170,8 @@ export const oldIrishTransforms = {
                 prefixInflection('hi', 'i', [], []),
                 prefixInflection('ho', 'o', [], []),
                 prefixInflection('hu', 'u', [], []),
-                prefixInflection('h-', '', [], [])
-            ]
+                prefixInflection('h-', '', [], []),
+            ],
         },
         {
             name: '[IM] geminated',
@@ -198,8 +198,8 @@ export const oldIrishTransforms = {
                 prefixInflection('l-l', 'l', [], []),
                 prefixInflection('n-n', 'n', [], []),
                 prefixInflection('m-m', 'm', [], []),
-                prefixInflection('s-s', 's', [], [])
-            ]
-        }
-    ]
+                prefixInflection('s-s', 's', [], []),
+            ],
+        },
+    ],
 };

--- a/ext/js/language/sq/albanian-transforms.js
+++ b/ext/js/language/sq/albanian-transforms.js
@@ -28,7 +28,7 @@ function conjugationIISuffixInflection(inflectedSuffix, deinflectedSuffix, condi
     return {
         ...suffixInflection(inflectedSuffix, deinflectedSuffix, conditionsIn, conditionsOut),
         type: 'other',
-        isInflected: new RegExp('.*[^j]' + inflectedSuffix + '$')
+        isInflected: new RegExp('.*[^j]' + inflectedSuffix + '$'),
     };
 }
 
@@ -38,29 +38,29 @@ export const albanianTransforms = {
     conditions: {
         v: {
             name: 'Verb',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         n: {
             name: 'Noun',
             isDictionaryForm: true,
-            subConditions: ['np', 'ns']
+            subConditions: ['np', 'ns'],
         },
         np: {
             name: 'Noun plural',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         ns: {
             name: 'Noun singular',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         adj: {
             name: 'Adjective',
-            isDictionaryForm: true
+            isDictionaryForm: true,
         },
         adv: {
             name: 'Adverb',
-            isDictionaryForm: true
-        }
+            isDictionaryForm: true,
+        },
     },
     transforms: [
         // Nouns
@@ -82,23 +82,23 @@ export const albanianTransforms = {
                 // Feminine
                 suffixInflection('a', 'ë', [], ['n']),
                 suffixInflection('a', '', [], ['n']),
-                suffixInflection('ja', 'e', [], ['n'])
-            ]
+                suffixInflection('ja', 'e', [], ['n']),
+            ],
         },
         {
             name: 'singular definite accusative',
             description: 'Singular definite accusative form of a noun',
             rules: [
-                suffixInflection('n', '', [], ['n'])
-            ]
+                suffixInflection('n', '', [], ['n']),
+            ],
         },
         {
             name: 'plural',
             description: 'Plural form of a noun',
             rules: [
                 suffixInflection('e', '', ['np'], ['ns']),
-                suffixInflection('t', '', ['np'], ['ns'])
-            ]
+                suffixInflection('t', '', ['np'], ['ns']),
+            ],
         },
         // Verbs
         {
@@ -108,8 +108,8 @@ export const albanianTransforms = {
                 suffixInflection('on', 'oj', [], ['v']),
                 suffixInflection('uan', 'uaj', [], ['v']),
                 suffixInflection('n', 'j', [], ['v']),
-                suffixInflection('hesh', 'hem', [], ['v'])
-            ]
+                suffixInflection('hesh', 'hem', [], ['v']),
+            ],
         },
         {
             name: 'present indicative third-person singular',
@@ -118,8 +118,8 @@ export const albanianTransforms = {
                 suffixInflection('on', 'oj', [], ['v']),
                 suffixInflection('uan', 'uaj', [], ['v']),
                 suffixInflection('n', 'j', [], ['v']),
-                suffixInflection('het', 'hem', [], ['v'])
-            ]
+                suffixInflection('het', 'hem', [], ['v']),
+            ],
         },
         {
             name: 'present indicative first-person plural',
@@ -127,8 +127,8 @@ export const albanianTransforms = {
             rules: [
                 suffixInflection('më', '', [], ['v']),
                 suffixInflection('im', '', [], ['v']),
-                suffixInflection('hemi', 'hem', [], ['v'])
-            ]
+                suffixInflection('hemi', 'hem', [], ['v']),
+            ],
         },
         {
             name: 'present indicative second-person plural',
@@ -136,8 +136,8 @@ export const albanianTransforms = {
             rules: [
                 suffixInflection('ni', 'j', [], ['v']),
                 suffixInflection('ni', '', [], ['v']),
-                suffixInflection('heni', 'hem', [], ['v'])
-            ]
+                suffixInflection('heni', 'hem', [], ['v']),
+            ],
         },
         {
             name: 'present indicative third-person plural',
@@ -145,8 +145,8 @@ export const albanianTransforms = {
             rules: [
                 suffixInflection('në', '', [], ['v']),
                 suffixInflection('in', '', [], ['v']),
-                suffixInflection('hen', 'hem', [], ['v'])
-            ]
+                suffixInflection('hen', 'hem', [], ['v']),
+            ],
         },
         {
             name: 'imperfect first-person singular indicative',
@@ -154,8 +154,8 @@ export const albanianTransforms = {
             rules: [
                 suffixInflection('ja', 'j', [], ['v']),
                 suffixInflection('ja', '', [], ['v']),
-                suffixInflection('hesha', 'hem', [], ['v'])
-            ]
+                suffixInflection('hesha', 'hem', [], ['v']),
+            ],
         },
         {
             name: 'imperfect second-person singular indicative',
@@ -163,8 +163,8 @@ export const albanianTransforms = {
             rules: [
                 suffixInflection('je', 'j', [], ['v']),
                 suffixInflection('je', '', [], ['v']),
-                suffixInflection('heshe', 'hem', [], ['v'])
-            ]
+                suffixInflection('heshe', 'hem', [], ['v']),
+            ],
         },
         {
             name: 'imperfect third-person singular indicative',
@@ -172,8 +172,8 @@ export const albanianTransforms = {
             rules: [
                 suffixInflection('nte', 'j', [], ['v']),
                 suffixInflection('te', '', [], ['v']),
-                suffixInflection('hej', 'hem', [], ['v'])
-            ]
+                suffixInflection('hej', 'hem', [], ['v']),
+            ],
         },
         {
             name: 'imperfect first-person plural indicative',
@@ -181,8 +181,8 @@ export const albanianTransforms = {
             rules: [
                 suffixInflection('nim', 'j', [], ['v']),
                 suffixInflection('nim', '', [], ['v']),
-                suffixInflection('heshim', 'hem', [], ['v'])
-            ]
+                suffixInflection('heshim', 'hem', [], ['v']),
+            ],
         },
         {
             name: 'imperfect second-person plural indicative',
@@ -190,8 +190,8 @@ export const albanianTransforms = {
             rules: [
                 suffixInflection('nit', 'j', [], ['v']),
                 suffixInflection('nit', '', [], ['v']),
-                suffixInflection('heshit', 'hem', [], ['v'])
-            ]
+                suffixInflection('heshit', 'hem', [], ['v']),
+            ],
         },
         {
             name: 'imperfect third-person plural indicative',
@@ -199,8 +199,8 @@ export const albanianTransforms = {
             rules: [
                 suffixInflection('nin', 'j', [], ['v']),
                 suffixInflection('nin', '', [], ['v']),
-                suffixInflection('heshin', 'hem', [], ['v'])
-            ]
+                suffixInflection('heshin', 'hem', [], ['v']),
+            ],
         },
         {
             name: 'aorist first-person singular indicative',
@@ -208,8 +208,8 @@ export const albanianTransforms = {
             rules: [
                 suffixInflection('ova', 'uaj', [], ['v']),
                 suffixInflection('va', 'j', [], ['v']),
-                conjugationIISuffixInflection('a', '', [], ['v'])
-            ]
+                conjugationIISuffixInflection('a', '', [], ['v']),
+            ],
         },
         {
             name: 'aorist second-person singular indicative',
@@ -217,8 +217,8 @@ export const albanianTransforms = {
             rules: [
                 suffixInflection('ove', 'uaj', [], ['v']),
                 suffixInflection('ve', 'j', [], ['v']),
-                conjugationIISuffixInflection('e', '', [], ['v'])
-            ]
+                conjugationIISuffixInflection('e', '', [], ['v']),
+            ],
         },
         {
             name: 'aorist third-person singular indicative',
@@ -228,8 +228,8 @@ export const albanianTransforms = {
                 suffixInflection('oi', 'uaj', [], ['v']),
                 suffixInflection('u', 'j', [], ['v']),
                 conjugationIISuffixInflection('i', '', [], ['v']),
-                suffixInflection('ye', 'ej', [], ['v'])
-            ]
+                suffixInflection('ye', 'ej', [], ['v']),
+            ],
         },
         {
             name: 'aorist first-person plural indicative',
@@ -238,8 +238,8 @@ export const albanianTransforms = {
                 suffixInflection('uam', 'oj', [], ['v']),
                 suffixInflection('uam', 'uaj', [], ['v']),
                 suffixInflection('më', 'j', [], ['v']),
-                conjugationIISuffixInflection('ëm', '', [], ['v'])
-            ]
+                conjugationIISuffixInflection('ëm', '', [], ['v']),
+            ],
         },
         {
             name: 'aorist second-person plural indicative',
@@ -248,8 +248,8 @@ export const albanianTransforms = {
                 suffixInflection('uat', 'oj', [], ['v']),
                 suffixInflection('uat', 'uaj', [], ['v']),
                 suffixInflection('të', 'j', [], ['v']),
-                conjugationIISuffixInflection('ët', '', [], ['v'])
-            ]
+                conjugationIISuffixInflection('ët', '', [], ['v']),
+            ],
         },
         {
             name: 'aorist third-person plural indicative',
@@ -258,16 +258,16 @@ export const albanianTransforms = {
                 suffixInflection('uan', 'oj', [], ['v']),
                 suffixInflection('uan', 'uaj', [], ['v']),
                 suffixInflection('në', 'j', [], ['v']),
-                conjugationIISuffixInflection('ën', '', [], ['v'])
-            ]
+                conjugationIISuffixInflection('ën', '', [], ['v']),
+            ],
         },
         {
             name: 'imperative second-person singular present',
             description: 'Imperative second-person singular present form of a verb',
             rules: [
                 suffixInflection('o', 'oj', [], ['v']),
-                suffixInflection('hu', 'hem', [], ['v'])
-            ]
+                suffixInflection('hu', 'hem', [], ['v']),
+            ],
         },
         {
             name: 'imperative second-person plural present',
@@ -275,8 +275,8 @@ export const albanianTransforms = {
             rules: [
                 suffixInflection('ni', 'j', [], ['v']),
                 suffixInflection('ni', '', [], ['v']),
-                suffixInflection('huni', 'hem', [], ['v'])
-            ]
+                suffixInflection('huni', 'hem', [], ['v']),
+            ],
         },
         {
             name: 'participle',
@@ -285,58 +285,58 @@ export const albanianTransforms = {
                 suffixInflection('uar', 'oj', [], ['v']),
                 suffixInflection('ur', '', [], ['v']),
                 suffixInflection('rë', 'j', [], ['v']),
-                suffixInflection('yer', 'ej', [], ['v'])
-            ]
+                suffixInflection('yer', 'ej', [], ['v']),
+            ],
         },
         {
             name: 'mediopassive',
             description: 'Mediopassive form of a verb',
             rules: [
                 suffixInflection('hem', 'h', ['v'], ['v']),
-                suffixInflection('hem', 'j', ['v'], ['v'])
-            ]
+                suffixInflection('hem', 'j', ['v'], ['v']),
+            ],
         },
         {
             name: 'optative first-person singular present',
             description: 'Optative first-person singular present form of a verb',
             rules: [
-                suffixInflection('fsha', 'j', [], ['v'])
-            ]
+                suffixInflection('fsha', 'j', [], ['v']),
+            ],
         },
         {
             name: 'optative second-person singular present',
             description: 'Optative second-person singular present form of a verb',
             rules: [
-                suffixInflection('fsh', 'j', [], ['v'])
-            ]
+                suffixInflection('fsh', 'j', [], ['v']),
+            ],
         },
         {
             name: 'optative third-person singular present',
             description: 'Optative third-person singular present form of a verb',
             rules: [
-                suffixInflection('ftë', 'j', [], ['v'])
-            ]
+                suffixInflection('ftë', 'j', [], ['v']),
+            ],
         },
         {
             name: 'optative first-person plural present',
             description: 'Optative first-person plural present form of a verb',
             rules: [
-                suffixInflection('fshim', 'j', [], ['v'])
-            ]
+                suffixInflection('fshim', 'j', [], ['v']),
+            ],
         },
         {
             name: 'optative second-person plural present',
             description: 'Optative second-person plural present form of a verb',
             rules: [
-                suffixInflection('fshi', 'j', [], ['v'])
-            ]
+                suffixInflection('fshi', 'j', [], ['v']),
+            ],
         },
         {
             name: 'optative third-person plural present',
             description: 'Optative third-person plural present form of a verb',
             rules: [
-                suffixInflection('fshin', 'j', [], ['v'])
-            ]
+                suffixInflection('fshin', 'j', [], ['v']),
+            ],
         },
         {
             name: 'nominalization',
@@ -344,8 +344,8 @@ export const albanianTransforms = {
             rules: [
                 suffixInflection('im', 'oj', [], ['v']),
                 suffixInflection('im', 'ej', [], ['v']),
-                suffixInflection('je', '', [], ['v'])
-            ]
-        }
-    ]
+                suffixInflection('je', '', [], ['v']),
+            ],
+        },
+    ],
 };

--- a/ext/js/language/text-processors.js
+++ b/ext/js/language/text-processors.js
@@ -23,7 +23,7 @@ export const decapitalize = {
     name: 'Decapitalize text',
     description: 'CAPITALIZED TEXT → capitalized text',
     options: basicTextProcessorOptions,
-    process: (str, setting) => (setting ? str.toLowerCase() : str)
+    process: (str, setting) => (setting ? str.toLowerCase() : str),
 };
 
 /** @type {import('language').TextProcessor<boolean>} */
@@ -31,7 +31,7 @@ export const capitalizeFirstLetter = {
     name: 'Capitalize first letter',
     description: 'lowercase text → Lowercase text',
     options: basicTextProcessorOptions,
-    process: (str, setting) => (setting ? str.charAt(0).toUpperCase() + str.slice(1) : str)
+    process: (str, setting) => (setting ? str.charAt(0).toUpperCase() + str.slice(1) : str),
 };
 
 /**
@@ -45,5 +45,5 @@ export const removeAlphabeticDiacritics = {
     name: 'Remove Alphabetic Diacritics',
     description: 'ἄήé -> αηe',
     options: basicTextProcessorOptions,
-    process: (str, setting) => (setting ? str.normalize('NFD').replace(/[\u0300-\u036f]/g, '') : str)
+    process: (str, setting) => (setting ? str.normalize('NFD').replace(/[\u0300-\u036f]/g, '') : str),
 };

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -40,7 +40,7 @@ export class TextScanner extends EventDispatcher {
         searchKanji = false,
         searchOnClick = false,
         searchOnClickOnly = false,
-        textSourceGenerator
+        textSourceGenerator,
     }) {
         super();
         /** @type {import('../comm/api.js').API} */
@@ -253,7 +253,7 @@ export class TextScanner extends EventDispatcher {
         layoutAwareScan,
         preventMiddleMouse,
         sentenceParsingOptions,
-        matchTypePrefix
+        matchTypePrefix,
     }) {
         if (Array.isArray(inputs)) {
             this._inputs = inputs.map((input) => this._convertInput(input));
@@ -482,7 +482,7 @@ export class TextScanner extends EventDispatcher {
                     inputInfo,
                     textSource,
                     optionsContext,
-                    detail
+                    detail,
                 });
             } else {
                 this._triggerSearchEmpty(inputInfo);
@@ -491,7 +491,7 @@ export class TextScanner extends EventDispatcher {
             this.trigger('searchError', {
                 error: error instanceof Error ? error : new Error(`A search error occurred: ${error}`),
                 textSource,
-                inputInfo
+                inputInfo,
             });
         }
     }
@@ -580,7 +580,7 @@ export class TextScanner extends EventDispatcher {
                 metaKey: modifiers.includes('meta'),
                 button: this._lastMouseMove.button,
                 buttons: this._lastMouseMove.buttons,
-                relatedTarget: this._lastMouseMove.relatedTarget
+                relatedTarget: this._lastMouseMove.relatedTarget,
             });
             this._onMouseMove(syntheticMouseEvent);
         }
@@ -1126,7 +1126,7 @@ export class TextScanner extends EventDispatcher {
             [this._node, 'touchmove', this._onTouchMovePreventScroll.bind(this), {passive: false, capture}],
             [this._node, 'mousedown', this._onMouseDown.bind(this), capture],
             [this._node, 'click', this._onClick.bind(this), capture],
-            [this._node, 'auxclick', this._onAuxClick.bind(this), capture]
+            [this._node, 'auxclick', this._onAuxClick.bind(this), capture],
         ];
     }
 
@@ -1140,7 +1140,7 @@ export class TextScanner extends EventDispatcher {
             [this._node, 'mousemove', this._onMouseMove.bind(this), capture],
             [this._node, 'mouseover', this._onMouseOver.bind(this), capture],
             [this._node, 'mouseout', this._onMouseOut.bind(this), capture],
-            [this._node, 'click', this._onClick.bind(this), capture]
+            [this._node, 'click', this._onClick.bind(this), capture],
         ];
     }
 
@@ -1150,7 +1150,7 @@ export class TextScanner extends EventDispatcher {
      */
     _getKeyboardEventListeners(capture) {
         return [
-            [this._node, 'keydown', this._onKeyDown.bind(this), capture]
+            [this._node, 'keydown', this._onKeyDown.bind(this), capture],
         ];
     }
 
@@ -1165,7 +1165,7 @@ export class TextScanner extends EventDispatcher {
             [this._node, 'touchend', this._onTouchEnd.bind(this), capture],
             [this._node, 'touchcancel', this._onTouchCancel.bind(this), capture],
             [this._node, 'touchmove', this._onTouchMove.bind(this), {passive: false, capture}],
-            [this._node, 'contextmenu', this._onContextMenu.bind(this), capture]
+            [this._node, 'contextmenu', this._onContextMenu.bind(this), capture],
         ];
     }
 
@@ -1175,7 +1175,7 @@ export class TextScanner extends EventDispatcher {
      */
     _getMouseClickOnlyEventListeners(capture) {
         return [
-            [this._node, 'click', this._onClick.bind(this), capture]
+            [this._node, 'click', this._onClick.bind(this), capture],
         ];
     }
 
@@ -1187,7 +1187,7 @@ export class TextScanner extends EventDispatcher {
         const {documentElement} = document;
         /** @type {import('event-listener-collection').AddEventListenerArgs[]} */
         const entries = [
-            [document, 'selectionchange', this._onSelectionChange.bind(this)]
+            [document, 'selectionchange', this._onSelectionChange.bind(this)],
         ];
         if (documentElement !== null) {
             entries.push([documentElement, 'mousedown', this._onSearchClickMouseDown.bind(this), capture]);
@@ -1271,7 +1271,7 @@ export class TextScanner extends EventDispatcher {
             sentenceTerminateAtNewlines,
             sentenceTerminatorMap,
             sentenceForwardQuoteMap,
-            sentenceBackwardQuoteMap
+            sentenceBackwardQuoteMap,
         );
 
         return {dictionaryEntries, sentence, type: 'terms'};
@@ -1303,7 +1303,7 @@ export class TextScanner extends EventDispatcher {
             sentenceTerminateAtNewlines,
             sentenceTerminatorMap,
             sentenceForwardQuoteMap,
-            sentenceBackwardQuoteMap
+            sentenceBackwardQuoteMap,
         );
 
         return {dictionaryEntries, sentence, type: 'kanji'};
@@ -1335,7 +1335,7 @@ export class TextScanner extends EventDispatcher {
 
             const textSource = this._textSourceGenerator.getRangeFromPoint(x, y, {
                 deepContentScan: this._deepContentScan,
-                normalizeCssZoom: this._normalizeCssZoom
+                normalizeCssZoom: this._normalizeCssZoom,
             });
             if (textSource !== null) {
                 try {
@@ -1545,7 +1545,7 @@ export class TextScanner extends EventDispatcher {
             scanOnPenPress: this._getInputBoolean(options.scanOnPenPress),
             scanOnPenRelease: this._getInputBoolean(options.scanOnPenRelease),
             preventTouchScrolling: this._getInputBoolean(options.preventTouchScrolling),
-            preventPenScrolling: this._getInputBoolean(options.preventPenScrolling)
+            preventPenScrolling: this._getInputBoolean(options.preventPenScrolling),
         };
     }
 

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -196,7 +196,7 @@ export class Translator {
                 hasReading,
                 frequency: frequencyValue,
                 displayValue,
-                displayValueParsed
+                displayValueParsed,
             });
         }
         return results;
@@ -354,7 +354,7 @@ export class Translator {
                         const inflectionRuleChainCandidates = algorithmChains.map(({inflectionRules: algInflections}) => {
                             return {
                                 source: /** @type {import('dictionary').InflectionSource} */ (algInflections.length === 0 ? 'dictionary' : 'both'),
-                                inflectionRules: [...algInflections, ...inflectionRules]
+                                inflectionRules: [...algInflections, ...inflectionRules],
                             };
                         });
 
@@ -458,7 +458,7 @@ export class Translator {
                         /** @type {import('dictionary').InflectionRuleChainCandidate} */
                         const inflectionRuleChainCandidate = {
                             source: 'algorithm',
-                            inflectionRules: trace.map((frame) => frame.transform)
+                            inflectionRules: trace.map((frame) => frame.transform),
                         };
                         deinflections.push(this._createDeinflection(rawSource, source, transformedText, conditions, [inflectionRuleChainCandidate]));
                     }
@@ -609,7 +609,7 @@ export class Translator {
                 if (typeof group === 'undefined') {
                     group = {
                         ids: new Set(),
-                        dictionaryEntries: []
+                        dictionaryEntries: [],
                     };
                     sequenceList.push({query: sequence, dictionary});
                     groupedDictionaryEntries.push(group);
@@ -686,7 +686,7 @@ export class Translator {
                 let target = targetMap.get(key);
                 if (typeof target === 'undefined') {
                     target = {
-                        groups: []
+                        groups: [],
                     };
                     targetMap.set(key, target);
                     termList.push({term, reading});
@@ -1124,7 +1124,7 @@ export class Translator {
                                     hasReading,
                                     frequencyValue,
                                     displayValue,
-                                    displayValueParsed
+                                    displayValueParsed,
                                 ));
                             }
                         }
@@ -1147,7 +1147,7 @@ export class Translator {
                                     position,
                                     nasalPositions,
                                     devoicePositions,
-                                    tags: tags2
+                                    tags: tags2,
                                 });
                             }
                             for (const {pronunciations, headwordIndex} of targets) {
@@ -1157,7 +1157,7 @@ export class Translator {
                                     dictionary,
                                     dictionaryIndex,
                                     dictionaryPriority,
-                                    pitches
+                                    pitches,
                                 ));
                             }
                         }
@@ -1176,7 +1176,7 @@ export class Translator {
                             phoneticTranscriptions.push({
                                 type: 'phonetic-transcription',
                                 ipa,
-                                tags: tags2
+                                tags: tags2,
                             });
                         }
                         for (const {pronunciations, headwordIndex} of targets) {
@@ -1186,7 +1186,7 @@ export class Translator {
                                 dictionary,
                                 dictionaryIndex,
                                 dictionaryPriority,
-                                phoneticTranscriptions
+                                phoneticTranscriptions,
                             ));
                         }
                     }
@@ -1221,7 +1221,7 @@ export class Translator {
                             character,
                             frequency,
                             displayValue,
-                            displayValueParsed
+                            displayValueParsed,
                         ));
                     }
                     break;
@@ -1389,7 +1389,7 @@ export class Translator {
             order: (typeof order === 'number' ? order : 0),
             score: (typeof score === 'number' ? score : 0),
             dictionary,
-            value
+            value,
         };
     }
 
@@ -1427,7 +1427,7 @@ export class Translator {
             tags: [],
             stats,
             definitions,
-            frequencies: []
+            frequencies: [],
         };
     }
 
@@ -1451,7 +1451,7 @@ export class Translator {
             score: (typeof score === 'number' ? score : 0),
             content: (typeof notes === 'string' && notes.length > 0 ? [notes] : []),
             dictionaries: [dictionary],
-            redundant: false
+            redundant: false,
         };
     }
 
@@ -1508,7 +1508,7 @@ export class Translator {
             sequences,
             isPrimary,
             tags,
-            entries
+            entries,
         };
     }
 
@@ -1567,7 +1567,7 @@ export class Translator {
             headwords,
             definitions,
             pronunciations: [],
-            frequencies: []
+            frequencies: [],
         };
     }
 
@@ -1595,7 +1595,7 @@ export class Translator {
             dictionary,
             id,
             sequence: rawSequence,
-            rules
+            rules,
         } = databaseEntry;
         // Cast is safe because getDeinflections filters out deinflection definitions
         const contentDefinitions = /** @type {import('dictionary-data').TermGlossaryContent[]} */ (definitions);
@@ -1623,7 +1623,7 @@ export class Translator {
             sourceTermExactMatchCount,
             maxOriginalTextLength,
             [this._createTermHeadword(0, term, reading, [source], headwordTagGroups, rules)],
-            [this._createTermDefinition(0, [0], dictionary, dictionaryIndex, dictionaryPriority, id, score, [sequence], isPrimary, definitionTagGroups, contentDefinitions)]
+            [this._createTermDefinition(0, [0], dictionary, dictionaryIndex, dictionaryPriority, id, score, [sequence], isPrimary, definitionTagGroups, contentDefinitions)],
         );
     }
 
@@ -1700,7 +1700,7 @@ export class Translator {
             sourceTermExactMatchCount,
             maxOriginalTextLength,
             headwordsArray,
-            definitions
+            definitions,
         );
     }
 

--- a/ext/js/media/audio-downloader.js
+++ b/ext/js/media/audio-downloader.js
@@ -42,7 +42,7 @@ export class AudioDownloader {
             ['text-to-speech', this._getInfoTextToSpeech.bind(this)],
             ['text-to-speech-reading', this._getInfoTextToSpeechReading.bind(this)],
             ['custom', this._getInfoCustom.bind(this)],
-            ['custom-json', this._getInfoCustomJson.bind(this)]
+            ['custom-json', this._getInfoCustomJson.bind(this)],
         ]));
     }
 
@@ -134,7 +134,7 @@ export class AudioDownloader {
             post: 'dictionary_reference',
             match_type: 'exact',
             search_query: term,
-            vulgar: 'true'
+            vulgar: 'true',
         });
         const response = await this._requestBuilder.fetchAnonymous(fetchUrl, {
             method: 'POST',
@@ -144,9 +144,9 @@ export class AudioDownloader {
             redirect: 'follow',
             referrerPolicy: 'no-referrer',
             headers: {
-                'Content-Type': 'application/x-www-form-urlencoded'
+                'Content-Type': 'application/x-www-form-urlencoded',
             },
-            body: data
+            body: data,
         });
         const responseText = await response.text();
 
@@ -187,7 +187,7 @@ export class AudioDownloader {
             cache: 'default',
             credentials: 'omit',
             redirect: 'follow',
-            referrerPolicy: 'no-referrer'
+            referrerPolicy: 'no-referrer',
         });
         const responseText = await response.text();
 
@@ -265,7 +265,7 @@ export class AudioDownloader {
             cache: 'default',
             credentials: 'omit',
             redirect: 'follow',
-            referrerPolicy: 'no-referrer'
+            referrerPolicy: 'no-referrer',
         });
 
         if (!response.ok) {
@@ -351,7 +351,7 @@ export class AudioDownloader {
             credentials: 'omit',
             redirect: 'follow',
             referrerPolicy: 'no-referrer',
-            signal
+            signal,
         });
 
         if (!response.ok) {
@@ -434,7 +434,7 @@ export class AudioDownloader {
             cache: 'default',
             credentials: 'omit',
             redirect: 'follow',
-            referrerPolicy: 'no-referrer'
+            referrerPolicy: 'no-referrer',
         });
         return await readResponseJson(response);
     }

--- a/ext/js/pages/action-popup-main.js
+++ b/ext/js/pages/action-popup-main.js
@@ -262,7 +262,7 @@ class DisplayController {
             path: 'profileCurrent',
             value,
             scope: 'global',
-            optionsContext: null
+            optionsContext: null,
         };
         await this._api.modifySettings([modification], 'action-popup');
     }

--- a/ext/js/pages/permissions-main.js
+++ b/ext/js/pages/permissions-main.js
@@ -108,7 +108,7 @@ await Application.main(true, async (application) => {
 
     const permissions = await Promise.all([
         isAllowedIncognitoAccess(),
-        isAllowedFileSchemeAccess()
+        isAllowedFileSchemeAccess(),
     ]);
 
     for (let i = 0, ii = permissions.length; i < ii; ++i) {

--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -43,7 +43,7 @@ export class AnkiController {
             ignoreSelector: null,
             onAdded: this._createCardController.bind(this),
             onRemoved: this._removeCardController.bind(this),
-            isStale: this._isCardControllerStale.bind(this)
+            isStale: this._isCardControllerStale.bind(this),
         });
         /** @type {Intl.Collator} */
         this._stringComparer = new Intl.Collator(); // Locale does not matter
@@ -95,7 +95,7 @@ export class AnkiController {
             this._ankiEnableCheckbox.addEventListener(
                 /** @type {string} */ ('settingChanged'),
                 /** @type {EventListener} */ (this._onAnkiEnableChanged.bind(this)),
-                false
+                false,
             );
         }
         for (const input of ankiCardPrimaryTypeRadios) {
@@ -314,7 +314,7 @@ export class AnkiController {
         const fieldMenuTargets = [
             [['term'], 'anki-card-terms-field-menu'],
             [['kanji'], 'anki-card-kanji-field-menu'],
-            [['term', 'kanji'], 'anki-card-all-field-menu']
+            [['term', 'kanji'], 'anki-card-all-field-menu'],
         ];
         const {templates} = this._settingsController;
         for (const [types, templateName] of fieldMenuTargets) {
@@ -363,10 +363,10 @@ export class AnkiController {
         this._setAnkiStatusChanging();
         const [
             [deckNames, getDeckNamesError],
-            [modelNames, getModelNamesError]
+            [modelNames, getModelNamesError],
         ] = await Promise.all([
             this._getDeckNames(),
-            this._getModelNames()
+            this._getModelNames(),
         ]);
 
         if (getDeckNamesError !== null) {
@@ -481,7 +481,7 @@ export class AnkiController {
             '"よむ" deck:current',
             '"よむ"',
             'deck:current',
-            ''
+            '',
         ];
 
         let noteId = null;
@@ -864,7 +864,7 @@ class AnkiCardController {
         await this._settingsController.modifyProfileSettings([{
             action: 'set',
             path: ObjectPropertyAccessor.getPathString(['anki', this._optionsType, 'deck']),
-            value
+            value,
         }]);
     }
 
@@ -909,13 +909,13 @@ class AnkiCardController {
             {
                 action: 'set',
                 path: ObjectPropertyAccessor.getPathString(['anki', this._optionsType, 'model']),
-                value
+                value,
             },
             {
                 action: 'set',
                 path: ObjectPropertyAccessor.getPathString(['anki', this._optionsType, 'fields']),
-                value: fields
-            }
+                value: fields,
+            },
         ];
 
         this._modelController.value = value;
@@ -1011,7 +1011,7 @@ class AnkiCardController {
             ['glossary', ['definition', 'meaning']],
             ['audio', ['sound']],
             ['dictionary', ['dict']],
-            ['pitch-accents', ['pitch']]
+            ['pitch-accents', ['pitch']],
         ]);
 
         const hyphenPattern = /-/g;

--- a/ext/js/pages/settings/anki-deck-generator-controller.js
+++ b/ext/js/pages/settings/anki-deck-generator-controller.js
@@ -427,11 +427,11 @@ export class AnkiDeckGeneratorController {
             url: window.location.href,
             sentence: {
                 text: sentenceText,
-                offset: 0
+                offset: 0,
             },
             documentTitle: document.title,
             query: sentenceText,
-            fullQuery: sentenceText
+            fullQuery: sentenceText,
         };
         const template = this._getAnkiTemplate(options);
         const deckOptionsFields = options.anki.terms.fields;
@@ -460,7 +460,7 @@ export class AnkiDeckGeneratorController {
             mediaOptions: mediaOptions,
             requirements: requirements,
             duplicateScope: options.anki.duplicateScope,
-            duplicateScopeCheckAllModels: options.anki.duplicateScopeCheckAllModels
+            duplicateScopeCheckAllModels: options.anki.duplicateScopeCheckAllModels,
         }));
         return note;
     }
@@ -476,7 +476,7 @@ export class AnkiDeckGeneratorController {
 
         return {
             dictionaryEntry: /** @type {import('dictionary').TermDictionaryEntry} */ (dictionaryEntries[0]),
-            text: text
+            text: text,
         };
     }
 

--- a/ext/js/pages/settings/anki-templates-controller.js
+++ b/ext/js/pages/settings/anki-templates-controller.js
@@ -85,7 +85,7 @@ export class AnkiTemplatesController {
             menuButton.addEventListener(
                 /** @type {string} */ ('menuClose'),
                 /** @type {EventListener} */ (this._onFieldMenuClose.bind(this)),
-                false
+                false,
             );
         }
 
@@ -231,7 +231,7 @@ export class AnkiTemplatesController {
         }
         return {
             dictionaryEntry: /** @type {import('dictionary').TermDictionaryEntry} */ (this._cachedDictionaryEntryValue),
-            text: this._cachedDictionaryEntryText
+            text: this._cachedDictionaryEntryText,
         };
     }
 
@@ -257,11 +257,11 @@ export class AnkiTemplatesController {
                     url: window.location.href,
                     sentence: {
                         text: sentenceText,
-                        offset: 0
+                        offset: 0,
                     },
                     documentTitle: document.title,
                     query: sentenceText,
-                    fullQuery: sentenceText
+                    fullQuery: sentenceText,
                 };
                 const template = this._getAnkiTemplate(options);
                 const {general: {resultOutputMode, glossaryLayoutMode, compactTags}} = options;
@@ -273,11 +273,11 @@ export class AnkiTemplatesController {
                     deckName: '',
                     modelName: '',
                     fields: [
-                        ['field', field]
+                        ['field', field],
                     ],
                     resultOutputMode,
                     glossaryLayoutMode,
-                    compactTags
+                    compactTags,
                 }));
                 result = note.fields.field;
                 allErrors.push(...errors);

--- a/ext/js/pages/settings/audio-controller.js
+++ b/ext/js/pages/settings/audio-controller.js
@@ -97,7 +97,7 @@ export class AudioController extends EventDispatcher {
             path: 'audio.sources',
             start: index,
             deleteCount: 1,
-            items: []
+            items: [],
         }]);
     }
 
@@ -158,7 +158,7 @@ export class AudioController extends EventDispatcher {
             [...speechSynthesis.getVoices()].map((voice, index) => ({
                 voice,
                 isJapanese: this._languageTagIsJapanese(voice.lang),
-                index
+                index,
             })) :
             []
         );
@@ -221,7 +221,7 @@ export class AudioController extends EventDispatcher {
             'jpod101',
             'jpod101-alternate',
             'jisho',
-            'custom'
+            'custom',
         ];
         for (const type of typesAvailable) {
             if (!this._audioSourceEntries.some((entry) => entry.type === type)) {
@@ -243,7 +243,7 @@ export class AudioController extends EventDispatcher {
             path: 'audio.sources',
             start: index,
             deleteCount: 0,
-            items: [source]
+            items: [source],
         }]);
     }
 }

--- a/ext/js/pages/settings/backup-controller.js
+++ b/ext/js/pages/settings/backup-controller.js
@@ -122,7 +122,7 @@ export class BackupController {
             timeSeparator,
             date.getUTCMinutes().toString().padStart(2, '0'),
             timeSeparator,
-            date.getUTCSeconds().toString().padStart(2, '0')
+            date.getUTCSeconds().toString().padStart(2, '0'),
         ];
         return values.slice(0, resolution * 2 - 1).join('');
     }
@@ -152,7 +152,7 @@ export class BackupController {
             environment,
             userAgent: navigator.userAgent,
             permissions,
-            options: optionsFull
+            options: optionsFull,
         };
     }
 
@@ -285,7 +285,7 @@ export class BackupController {
                 e.preventDefault();
                 complete({
                     result: true,
-                    sanitize: element.dataset.importSanitize === 'true'
+                    sanitize: element.dataset.importSanitize === 'true',
                 });
                 modal.setVisible(false);
             };
@@ -580,7 +580,7 @@ export class BackupController {
         /** @type {unknown} */
         // @ts-expect-error - The export function is declared as an extension which has no type information.
         const blob = await db.export({
-            progressCallback: this._databaseExportProgressCallback.bind(this)
+            progressCallback: this._databaseExportProgressCallback.bind(this),
         });
         db.close();
         return /** @type {Blob} */ (blob);
@@ -644,7 +644,7 @@ export class BackupController {
     async _importDatabase(_databaseName, file) {
         await this._settingsController.application.api.purgeDatabase();
         await Dexie.import(file, {
-            progressCallback: this._databaseImportProgressCallback.bind(this)
+            progressCallback: this._databaseImportProgressCallback.bind(this),
         });
         void this._settingsController.application.api.triggerDatabaseUpdated('dictionary', 'import');
         this._settingsController.application.triggerStorageChanged();

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -216,7 +216,7 @@ class DictionaryEntry {
             ['Description', 'description'],
             ['Attribution', 'attribution'],
             ['Source Language', 'sourceLanguage'],
-            ['Target Language', 'targetLanguage']
+            ['Target Language', 'targetLanguage'],
         ];
 
         const dictionaryInfo = this._dictionaryInfo;
@@ -484,7 +484,7 @@ export class DictionaryController {
         await this._settingsController.modifyProfileSettings([{
             action: 'set',
             path: 'dictionaries',
-            value: dictionaries
+            value: dictionaries,
         }]);
 
         /** @type {import('settings-controller').EventArgument<'dictionarySettingsReordered'>} */
@@ -529,7 +529,7 @@ export class DictionaryController {
             allowSecondarySearches: false,
             definitionsCollapsible: 'not-collapsible',
             partsOfSpeechFilter: true,
-            useDeinflections: true
+            useDeinflections: true,
         };
     }
 
@@ -581,7 +581,7 @@ export class DictionaryController {
                 targets.push({
                     action: 'set',
                     path: `profiles[${i}].options.dictionaries`,
-                    value: dictionaryOptionsArray
+                    value: dictionaryOptionsArray,
                 });
             }
         }
@@ -938,7 +938,7 @@ export class DictionaryController {
                     path,
                     start: j,
                     deleteCount: 1,
-                    items: []
+                    items: [],
                 });
             }
         }
@@ -968,7 +968,7 @@ export class DictionaryController {
             targets.push({
                 action: 'set',
                 path: `dictionaries[${i}].enabled`,
-                value
+                value,
             });
         }
         await this._settingsController.modifyProfileSettings(targets);

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -62,12 +62,12 @@ export class DictionaryImportController {
         this._errorToStringOverrides = [
             [
                 'A mutation operation was attempted on a database that did not allow mutations.',
-                'Access to IndexedDB appears to be restricted. Firefox seems to require that the history preference is set to "Remember history" before IndexedDB use of any kind is allowed.'
+                'Access to IndexedDB appears to be restricted. Firefox seems to require that the history preference is set to "Remember history" before IndexedDB use of any kind is allowed.',
             ],
             [
                 'The operation failed for reasons unrelated to the database itself and not covered by any other error code.',
-                'Unable to access IndexedDB due to a possibly corrupt user profile. Try using the "Refresh Firefox" feature to reset your user profile.'
-            ]
+                'Unable to access IndexedDB due to a possibly corrupt user profile. Try using the "Refresh Firefox" feature to reset your user profile.',
+            ],
         ];
     }
 
@@ -319,7 +319,7 @@ export class DictionaryImportController {
 
             const optionsFull = await this._settingsController.getOptionsFull();
             const importDetails = {
-                prefixWildcardsSupported: optionsFull.global.database.prefixWildcardsSupported
+                prefixWildcardsSupported: optionsFull.global.database.prefixWildcardsSupported,
             };
 
             let statusPrefix = '';
@@ -355,7 +355,7 @@ export class DictionaryImportController {
                     stepIndex: -1,
                     stepCount: 6,
                     index: 0,
-                    count: 0
+                    count: 0,
                 });
                 if (statusFooter !== null) { statusFooter.setTaskActive(progressSelector, true); }
                 errors = [...errors, ...(await this._importDictionary(files[i], importDetails, onProgress) ?? [])];

--- a/ext/js/pages/settings/generic-setting-controller.js
+++ b/ext/js/pages/settings/generic-setting-controller.js
@@ -36,7 +36,7 @@ export class GenericSettingController {
             this._createElementMetadata.bind(this),
             this._compareElementMetadata.bind(this),
             this._getValues.bind(this),
-            this._setValues.bind(this)
+            this._setValues.bind(this),
         );
         /** @type {Map<import('generic-setting-controller').TransformType, import('generic-setting-controller').TransformFunction>} */
         this._transforms = new Map(/** @type {[key: import('generic-setting-controller').TransformType, value: import('generic-setting-controller').TransformFunction][]} */ ([
@@ -47,7 +47,7 @@ export class GenericSettingController {
             ['toNumber', this._toNumber.bind(this)],
             ['toBoolean', this._toBoolean.bind(this)],
             ['toString', this._toString.bind(this)],
-            ['conditionalConvert', this._conditionalConvert.bind(this)]
+            ['conditionalConvert', this._conditionalConvert.bind(this)],
         ]));
     }
 
@@ -82,7 +82,7 @@ export class GenericSettingController {
             path,
             scope: scope2 !== null ? scope2 : this._defaultScope,
             transforms: this._getTransformDataArray(transformRaw),
-            transformRaw
+            transformRaw,
         };
     }
 
@@ -112,7 +112,7 @@ export class GenericSettingController {
             const target = {
                 path,
                 scope: typeof scope === 'string' ? scope : defaultScope,
-                optionsContext: null
+                optionsContext: null,
             };
             settingsTargets.push(target);
         }
@@ -135,7 +135,7 @@ export class GenericSettingController {
                 scope: typeof scope === 'string' ? scope : defaultScope,
                 action: 'set',
                 value: transformedValue,
-                optionsContext: null
+                optionsContext: null,
             };
             settingsTargets.push(target);
         }

--- a/ext/js/pages/settings/keyboard-mouse-input-field.js
+++ b/ext/js/pages/settings/keyboard-mouse-input-field.js
@@ -75,7 +75,7 @@ export class KeyboardMouseInputField extends EventDispatcher {
         /** @type {import('event-listener-collection').AddEventListenerArgs[]} */
         const events = [
             [this._inputNode, 'keydown', this._onModifierKeyDown.bind(this), false],
-            [this._inputNode, 'keyup', this._onModifierKeyUp.bind(this), false]
+            [this._inputNode, 'keyup', this._onModifierKeyUp.bind(this), false],
         ];
         if (mouseModifiersSupported && this._mouseButton !== null) {
             events.push(
@@ -85,7 +85,7 @@ export class KeyboardMouseInputField extends EventDispatcher {
                 [this._mouseButton, 'pointerout', this._onMouseButtonPointerOut.bind(this), false],
                 [this._mouseButton, 'pointercancel', this._onMouseButtonPointerCancel.bind(this), false],
                 [this._mouseButton, 'mouseup', this._onMouseButtonMouseUp.bind(this), false],
-                [this._mouseButton, 'contextmenu', this._onMouseButtonContextMenu.bind(this), false]
+                [this._mouseButton, 'contextmenu', this._onMouseButtonContextMenu.bind(this), false],
             );
         }
         for (const args of events) {

--- a/ext/js/pages/settings/keyboard-shortcuts-controller.js
+++ b/ext/js/pages/settings/keyboard-shortcuts-controller.js
@@ -71,7 +71,7 @@ export class KeyboardShortcutController {
             ['scanSelectedText',                 {scopes: new Set(['web'])}],
             ['scanTextAtSelection',              {scopes: new Set(['web'])}],
             ['scanTextAtCaret',                  {scopes: new Set(['web'])}],
-            ['toggleOption',                     {scopes: new Set(['popup', 'search']), argument: {template: 'hotkey-argument-setting-path', default: ''}}]
+            ['toggleOption',                     {scopes: new Set(['popup', 'search']), argument: {template: 'hotkey-argument-setting-path', default: ''}}],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
     }
@@ -105,7 +105,7 @@ export class KeyboardShortcutController {
             path: 'inputs.hotkeys',
             start: hotkeys.length,
             deleteCount: 0,
-            items: [terminationCharacterEntry]
+            items: [terminationCharacterEntry],
         }]);
 
         await this._updateOptions();
@@ -128,7 +128,7 @@ export class KeyboardShortcutController {
             path: 'inputs.hotkeys',
             start: index,
             deleteCount: 1,
-            items: []
+            items: [],
         }]);
 
         await this._updateOptions();
@@ -214,7 +214,7 @@ export class KeyboardShortcutController {
             key: null,
             modifiers: [],
             scopes: ['popup', 'search'],
-            enabled: true
+            enabled: true,
         };
         await this.addEntry(newEntry);
     }
@@ -460,13 +460,13 @@ class KeyboardShortcutHotkeyEntry {
             {
                 action: 'set',
                 path: `${this._basePath}.key`,
-                value: key
+                value: key,
             },
             {
                 action: 'set',
                 path: `${this._basePath}.modifiers`,
-                value: modifiers
-            }
+                value: modifiers,
+            },
         ]);
     }
 
@@ -490,7 +490,7 @@ class KeyboardShortcutHotkeyEntry {
         await this._modifyProfileSettings([{
             action: 'set',
             path: `${this._basePath}.scopes`,
-            value: scopes
+            value: scopes,
         }]);
 
         this._updateScopesButton();
@@ -580,18 +580,18 @@ class KeyboardShortcutHotkeyEntry {
             {
                 action: 'set',
                 path: `${this._basePath}.action`,
-                value: this._data.action
+                value: this._data.action,
             },
             {
                 action: 'set',
                 path: `${this._basePath}.argument`,
-                value: this._data.argument
+                value: this._data.argument,
             },
             {
                 action: 'set',
                 path: `${this._basePath}.scopes`,
-                value: this._data.scopes
-            }
+                value: this._data.scopes,
+            },
         ]);
 
         this._updateScopesButton();
@@ -615,7 +615,7 @@ class KeyboardShortcutHotkeyEntry {
         await this._modifyProfileSettings([{
             action: 'set',
             path: `${this._basePath}.argument`,
-            value
+            value,
         }]);
     }
 

--- a/ext/js/pages/settings/permissions-origin-controller.js
+++ b/ext/js/pages/settings/permissions-origin-controller.js
@@ -81,7 +81,7 @@ export class PermissionsOriginController {
 
         let any = false;
         const excludeOrigins = new Set([
-            '<all_urls>'
+            '<all_urls>',
         ]);
         const fragment = document.createDocumentFragment();
         for (const origin of originsSet) {

--- a/ext/js/pages/settings/popup-preview-controller.js
+++ b/ext/js/pages/settings/popup-preview-controller.js
@@ -52,7 +52,7 @@ export class PopupPreviewController {
         languageSelect.addEventListener(
             /** @type {string} */ ('settingChanged'),
             /** @type {EventListener} */ (this._onLanguageSelectChanged.bind(this)),
-            false
+            false,
         );
 
 

--- a/ext/js/pages/settings/popup-preview-frame.js
+++ b/ext/js/pages/settings/popup-preview-frame.js
@@ -65,7 +65,7 @@ export class PopupPreviewFrame {
             ['setCustomCss',           this._setCustomCss.bind(this)],
             ['setCustomOuterCss',      this._setCustomOuterCss.bind(this)],
             ['updateOptionsContext',   this._updateOptionsContext.bind(this)],
-            ['setLanguageExampleText', this._setLanguageExampleText.bind(this)]
+            ['setLanguageExampleText', this._setLanguageExampleText.bind(this)],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
     }
@@ -103,7 +103,7 @@ export class PopupPreviewFrame {
             pageType: 'web',
             allowRootFramePopupProxy: false,
             childrenSupported: false,
-            hotkeyHandler: this._hotkeyHandler
+            hotkeyHandler: this._hotkeyHandler,
         });
         this._frontend.setOptionsContextOverride(this._optionsContext);
         await this._frontend.prepare();

--- a/ext/js/pages/settings/profile-conditions-ui.js
+++ b/ext/js/pages/settings/profile-conditions-ui.js
@@ -65,9 +65,9 @@ export class ProfileConditionsUI extends EventDispatcher {
                         ['lessThan',           {displayName: '<',      type: 'integer', defaultValue: '0', validate: validateInteger, normalize: normalizeInteger}],
                         ['greaterThan',        {displayName: '>',      type: 'integer', defaultValue: '0', validate: validateInteger, normalize: normalizeInteger}],
                         ['lessThanOrEqual',    {displayName: '\u2264', type: 'integer', defaultValue: '0', validate: validateInteger, normalize: normalizeInteger}],
-                        ['greaterThanOrEqual', {displayName: '\u2265', type: 'integer', defaultValue: '0', validate: validateInteger, normalize: normalizeInteger}]
-                    ])
-                }
+                        ['greaterThanOrEqual', {displayName: '\u2265', type: 'integer', defaultValue: '0', validate: validateInteger, normalize: normalizeInteger}],
+                    ]),
+                },
             ],
             [
                 'url',
@@ -76,9 +76,9 @@ export class ProfileConditionsUI extends EventDispatcher {
                     defaultOperator: 'matchDomain',
                     operators: new Map([
                         ['matchDomain', {displayName: 'Matches Domain', type: 'string', defaultValue: 'example.com',   resetDefaultOnChange: true, validate: this._validateDomains.bind(this), normalize: this._normalizeDomains.bind(this)}],
-                        ['matchRegExp', {displayName: 'Matches RegExp', type: 'string', defaultValue: 'example\\.com', resetDefaultOnChange: true, validate: this._validateRegExp.bind(this)}]
-                    ])
-                }
+                        ['matchRegExp', {displayName: 'Matches RegExp', type: 'string', defaultValue: 'example\\.com', resetDefaultOnChange: true, validate: this._validateRegExp.bind(this)}],
+                    ]),
+                },
             ],
             [
                 'modifierKeys',
@@ -89,9 +89,9 @@ export class ProfileConditionsUI extends EventDispatcher {
                         ['are',        {displayName: 'Are',            type: 'modifierKeys', defaultValue: ''}],
                         ['areNot',     {displayName: 'Are Not',        type: 'modifierKeys', defaultValue: ''}],
                         ['include',    {displayName: 'Include',        type: 'modifierKeys', defaultValue: ''}],
-                        ['notInclude', {displayName: 'Don\'t Include', type: 'modifierKeys', defaultValue: ''}]
-                    ])
-                }
+                        ['notInclude', {displayName: 'Don\'t Include', type: 'modifierKeys', defaultValue: ''}],
+                    ]),
+                },
             ],
             [
                 'flags',
@@ -102,15 +102,15 @@ export class ProfileConditionsUI extends EventDispatcher {
                         ['are',        {displayName: 'Are',            type: 'string', defaultValue: '', validate: validateFlags, normalize: normalizeFlags}],
                         ['areNot',     {displayName: 'Are Not',        type: 'string', defaultValue: '', validate: validateFlags, normalize: normalizeFlags}],
                         ['include',    {displayName: 'Include',        type: 'string', defaultValue: '', validate: validateFlags, normalize: normalizeFlags}],
-                        ['notInclude', {displayName: 'Don\'t Include', type: 'string', defaultValue: '', validate: validateFlags, normalize: normalizeFlags}]
-                    ])
-                }
-            ]
+                        ['notInclude', {displayName: 'Don\'t Include', type: 'string', defaultValue: '', validate: validateFlags, normalize: normalizeFlags}],
+                    ]),
+                },
+            ],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
         /** @type {Set<string>} */
         this._validFlags = new Set([
-            'clipboard'
+            'clipboard',
         ]);
     }
 
@@ -225,7 +225,7 @@ export class ProfileConditionsUI extends EventDispatcher {
             defaultValue = '',
             resetDefaultOnChange = false,
             validate = null,
-            normalize = null
+            normalize = null,
         } = (typeof info === 'undefined' ? {} : info);
 
         return {
@@ -234,7 +234,7 @@ export class ProfileConditionsUI extends EventDispatcher {
             defaultValue,
             resetDefaultOnChange,
             validate,
-            normalize
+            normalize,
         };
     }
 
@@ -271,7 +271,7 @@ export class ProfileConditionsUI extends EventDispatcher {
             path: this.getPath('conditionGroups'),
             start: index,
             deleteCount: 1,
-            items: []
+            items: [],
         }]);
 
         this._triggerConditionGroupCountChanged(this._children.length);
@@ -327,7 +327,7 @@ export class ProfileConditionsUI extends EventDispatcher {
     _onAddConditionGroupButtonClick() {
         /** @type {import('settings').ProfileConditionGroup} */
         const conditionGroup = {
-            conditions: [this.getDefaultCondition()]
+            conditions: [this.getDefaultCondition()],
         };
         const index = this._children.length;
 
@@ -338,7 +338,7 @@ export class ProfileConditionsUI extends EventDispatcher {
             path: this.getPath('conditionGroups'),
             start: index,
             deleteCount: 0,
-            items: [conditionGroup]
+            items: [conditionGroup],
         }]);
 
         this._triggerConditionGroupCountChanged(this._children.length);
@@ -548,7 +548,7 @@ class ProfileConditionGroupUI {
             path: this.getPath('conditions'),
             start: index,
             deleteCount: 1,
-            items: []
+            items: [],
         }]);
 
         if (this._children.length === 0) {
@@ -586,7 +586,7 @@ class ProfileConditionGroupUI {
             path: this.getPath('conditions'),
             start: index,
             deleteCount: 0,
-            items: [condition]
+            items: [condition],
         }]);
     }
 
@@ -971,7 +971,7 @@ class ProfileConditionUI {
         await this.settingsController.modifyGlobalSettings([
             {action: 'set', path: this.getPath('type'), value: type},
             {action: 'set', path: this.getPath('operator'), value: operator},
-            {action: 'set', path: this.getPath('value'), value: defaultValue}
+            {action: 'set', path: this.getPath('value'), value: defaultValue},
         ]);
     }
 

--- a/ext/js/pages/settings/profile-controller.js
+++ b/ext/js/pages/settings/profile-controller.js
@@ -168,7 +168,7 @@ export class ProfileController {
         await this._settingsController.modifyGlobalSettings([{
             action: 'set',
             path: `profiles[${destinationProfileIndex}].options`,
-            value: options
+            value: options,
         }]);
 
         await this._settingsController.refresh();
@@ -199,7 +199,7 @@ export class ProfileController {
             path: 'profiles',
             start: index,
             deleteCount: 0,
-            items: [newProfile]
+            items: [newProfile],
         }]);
 
         // Update profile index
@@ -224,14 +224,14 @@ export class ProfileController {
             path: 'profiles',
             start: profileIndex,
             deleteCount: 1,
-            items: []
+            items: [],
         }];
         if (profileCurrentNew >= profileIndex) {
             profileCurrentNew = Math.min(profileCurrentNew - 1, this._profiles.length - 1);
             modifications.push({
                 action: 'set',
                 path: 'profileCurrent',
-                value: profileCurrentNew
+                value: profileCurrentNew,
             });
         }
 
@@ -287,13 +287,13 @@ export class ProfileController {
         const modifications = [{
             action: 'swap',
             path1: `profiles[${index1}]`,
-            path2: `profiles[${index2}]`
+            path2: `profiles[${index2}]`,
         }];
         if (profileCurrentNew !== profileCurrent) {
             modifications.push({
                 action: 'set',
                 path: 'profileCurrent',
-                value: profileCurrentNew
+                value: profileCurrentNew,
             });
         }
 
@@ -534,7 +534,7 @@ export class ProfileController {
         return [
             /** @type {HTMLSelectElement} */ (this._profileActiveSelect),
             /** @type {HTMLSelectElement} */ (this._profileTargetSelect),
-            /** @type {HTMLSelectElement} */ (this._profileCopySourceSelect)
+            /** @type {HTMLSelectElement} */ (this._profileCopySourceSelect),
         ];
     }
 

--- a/ext/js/pages/settings/scan-inputs-controller.js
+++ b/ext/js/pages/settings/scan-inputs-controller.js
@@ -72,7 +72,7 @@ export class ScanInputsController {
             path: 'scanning.inputs',
             start: index,
             deleteCount: 1,
-            items: []
+            items: [],
         }]);
         return true;
     }
@@ -149,7 +149,7 @@ export class ScanInputsController {
             path: 'scanning.inputs',
             start: index,
             deleteCount: 0,
-            items: [scanningInput]
+            items: [scanningInput],
         }]);
 
         // Scroll to bottom
@@ -218,8 +218,8 @@ export class ScanInputsController {
                 scanOnPenPress: true,
                 scanOnPenRelease: false,
                 preventTouchScrolling: true,
-                preventPenScrolling: true
-            }
+                preventPenScrolling: true,
+            },
         };
     }
 }

--- a/ext/js/pages/settings/scan-inputs-simple-controller.js
+++ b/ext/js/pages/settings/scan-inputs-simple-controller.js
@@ -132,7 +132,7 @@ export class ScanInputsSimpleController {
      */
     _populateSelect(select, hasOther) {
         const modifierKeys = [
-            {value: 'none', name: 'No key'}
+            {value: 'none', name: 'No key'},
         ];
         for (const value of /** @type {import('input').ModifierKey[]} */ (['alt', 'ctrl', 'shift', 'meta'])) {
             const name = this._hotkeyUtil.getModifierDisplayValue(value);
@@ -182,7 +182,7 @@ export class ScanInputsSimpleController {
                 path: 'scanning.inputs',
                 start: insertionPosition,
                 deleteCount: 0,
-                items: [input]
+                items: [input],
             }]);
         } else {
             // Modify existing
@@ -192,7 +192,7 @@ export class ScanInputsSimpleController {
                 path: 'scanning.inputs',
                 start: index,
                 deleteCount: 1,
-                items: []
+                items: [],
             }]);
         }
     }
@@ -218,14 +218,14 @@ export class ScanInputsSimpleController {
                 path: 'scanning.inputs',
                 start: inputs.length,
                 deleteCount: 0,
-                items: [input]
+                items: [input],
             }]);
         } else {
             // Modify existing
             await this._modifyProfileSettings([{
                 action: 'set',
                 path: `scanning.inputs[${index}].include`,
-                value: value2
+                value: value2,
             }]);
         }
     }

--- a/ext/js/pages/settings/sentence-termination-characters-controller.js
+++ b/ext/js/pages/settings/sentence-termination-characters-controller.js
@@ -66,7 +66,7 @@ export class SentenceTerminationCharactersController {
             path: 'sentenceParsing.terminationCharacters',
             start: terminationCharacters.length,
             deleteCount: 0,
-            items: [terminationCharacterEntry]
+            items: [terminationCharacterEntry],
         }]);
 
         await this._updateOptions();
@@ -87,7 +87,7 @@ export class SentenceTerminationCharactersController {
             path: 'sentenceParsing.terminationCharacters',
             start: index,
             deleteCount: 1,
-            items: []
+            items: [],
         }]);
 
         await this._updateOptions();
@@ -153,7 +153,7 @@ export class SentenceTerminationCharactersController {
             character1: '"',
             character2: '"',
             includeCharacterAtStart: false,
-            includeCharacterAtEnd: false
+            includeCharacterAtEnd: false,
         };
         await this.addEntry(newEntry);
     }

--- a/ext/js/pages/settings/settings-display-controller.js
+++ b/ext/js/pages/settings/settings-display-controller.js
@@ -70,14 +70,14 @@ export class SettingsDisplayController {
         const moreSelectorObserver = new SelectorObserver({
             selector: '.more-toggle',
             onAdded: this._onMoreSetup.bind(this),
-            onRemoved: this._onMoreCleanup.bind(this)
+            onRemoved: this._onMoreCleanup.bind(this),
         });
         moreSelectorObserver.observe(document.documentElement, false);
 
         const menuSelectorObserver = new SelectorObserver({
             selector: '[data-menu]',
             onAdded: this._onMenuSetup.bind(this),
-            onRemoved: this._onMenuCleanup.bind(this)
+            onRemoved: this._onMenuCleanup.bind(this),
         });
         menuSelectorObserver.observe(document.documentElement, false);
 

--- a/ext/js/pages/settings/sort-frequency-dictionary-controller.js
+++ b/ext/js/pages/settings/sort-frequency-dictionary-controller.js
@@ -159,7 +159,7 @@ export class SortFrequencyDictionaryController {
 
         const frequencies = await this._settingsController.application.api.getTermFrequencies(
             terms.map((term) => ({term, reading: null})),
-            [dictionary]
+            [dictionary],
         );
 
         /** @type {Map<string, {hasValue: boolean, minValue: number, maxValue: number}>} */

--- a/ext/js/pages/settings/translation-text-replacements-controller.js
+++ b/ext/js/pages/settings/translation-text-replacements-controller.js
@@ -56,14 +56,14 @@ export class TranslationTextReplacementsController {
                 path: 'translation.textReplacements.groups',
                 start: 0,
                 deleteCount: 0,
-                items: [[newEntry]]
+                items: [[newEntry]],
             } :
             {
                 action: 'splice',
                 path: 'translation.textReplacements.groups[0]',
                 start: groups[0].length,
                 deleteCount: 0,
-                items: [newEntry]
+                items: [newEntry],
             }
         );
 
@@ -91,14 +91,14 @@ export class TranslationTextReplacementsController {
                 path: 'translation.textReplacements.groups[0]',
                 start: index,
                 deleteCount: 1,
-                items: []
+                items: [],
             } :
             {
                 action: 'splice',
                 path: 'translation.textReplacements.groups',
                 start: 0,
                 deleteCount: group0.length,
-                items: []
+                items: [],
             }
         );
 

--- a/ext/js/templates/anki-template-renderer.js
+++ b/ext/js/templates/anki-template-renderer.js
@@ -96,20 +96,20 @@ export class AnkiTemplateRenderer {
             ['getMedia',         this._getMedia.bind(this)],
             ['pronunciation',    this._pronunciation.bind(this)],
             ['hiragana',         this._hiragana.bind(this)],
-            ['katakana',         this._katakana.bind(this)]
+            ['katakana',         this._katakana.bind(this)],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
         this._templateRenderer.registerDataType('ankiNote', {
             modifier: ({marker, commonData}) => createAnkiNoteData(marker, commonData),
-            composeData: ({marker}, commonData) => ({marker, commonData})
+            composeData: ({marker}, commonData) => ({marker, commonData}),
         });
         this._templateRenderer.setRenderCallbacks(
             this._onRenderSetup.bind(this),
-            this._onRenderCleanup.bind(this)
+            this._onRenderCleanup.bind(this),
         );
         await Promise.all([
             this._structuredContentStyleApplier.prepare(),
-            this._pronunciationStyleApplier.prepare()
+            this._pronunciationStyleApplier.prepare(),
         ]);
     }
 
@@ -201,7 +201,7 @@ export class AnkiTemplateRenderer {
         }
         return {
             expression: typeof expression === 'string' ? expression : '',
-            reading: typeof reading === 'string' ? reading : ''
+            reading: typeof reading === 'string' ? reading : '',
         };
     }
 

--- a/ext/js/templates/template-renderer-frame-api.js
+++ b/ext/js/templates/template-renderer-frame-api.js
@@ -30,7 +30,7 @@ export class TemplateRendererFrameApi {
         this._windowMessageHandlers = createApiMap([
             ['render', this._onRender.bind(this)],
             ['renderMulti', this._onRenderMulti.bind(this)],
-            ['getModifiedData', this._onGetModifiedData.bind(this)]
+            ['getModifiedData', this._onGetModifiedData.bind(this)],
         ]);
     }
 

--- a/ext/js/templates/template-renderer-media-provider.js
+++ b/ext/js/templates/template-renderer-media-provider.js
@@ -146,7 +146,7 @@ export class TemplateRendererMediaProvider {
         this._addRequirement({
             type: 'dictionaryMedia',
             dictionary,
-            path
+            path,
         });
         return null;
     }
@@ -170,7 +170,7 @@ export class TemplateRendererMediaProvider {
         this._addRequirement({
             type: 'textFurigana',
             text,
-            readingMode
+            readingMode,
         });
         return null;
     }

--- a/ext/js/templates/template-renderer-proxy.js
+++ b/ext/js/templates/template-renderer-proxy.js
@@ -179,7 +179,7 @@ export class TemplateRendererProxy {
                 cancel: () => {
                     cleanup();
                     reject(new Error('Terminated'));
-                }
+                },
             };
 
             const cleanup = () => {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -36,7 +36,7 @@ export default defineConfig({
          * Maximum time expect() should wait for the condition to be met.
          * For example in `await expect(locator).toHaveText();`
          */
-        timeout: 5000
+        timeout: 5000,
     },
     /* Run tests in files in parallel */
     fullyParallel: true,
@@ -56,7 +56,7 @@ export default defineConfig({
         // baseURL: 'http://localhost:3000',
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-        trace: 'on-first-retry'
+        trace: 'on-first-retry',
     },
 
     /* Configure projects for major browsers */
@@ -64,17 +64,17 @@ export default defineConfig({
         {
             name: 'playwright setup',
             testMatch: /global\.setup\.js/,
-            teardown: 'playwright teardown'
+            teardown: 'playwright teardown',
         },
         {
             name: 'playwright teardown',
-            testMatch: /global\.teardown\.js/
+            testMatch: /global\.teardown\.js/,
         },
         {
             name: 'chromium',
             use: {...devices['Desktop Chrome']},
-            dependencies: ['playwright setup']
-        }
+            dependencies: ['playwright setup'],
+        },
 
         // {
         //   name: 'firefox',
@@ -105,7 +105,7 @@ export default defineConfig({
         //   name: 'Google Chrome',
         //   use: { channel: 'chrome' },
         // },
-    ]
+    ],
 
     /* Folder for test artifacts such as screenshots, videos, traces, etc. */
     // outputDir: 'test-results/',

--- a/test/ajv-schemas.test.js
+++ b/test/ajv-schemas.test.js
@@ -59,8 +59,8 @@ describe('Ajv schema compilation', () => {
                 logger: {
                     log,
                     warn: log,
-                    error: log
-                }
+                    error: log,
+                },
             });
             standaloneCode(ajv);
             if (messages.length > 0) {

--- a/test/anki-template-renderer.test.js
+++ b/test/anki-template-renderer.test.js
@@ -34,7 +34,7 @@ describe('AnkiTemplateRenderer', () => {
                 tags: [],
                 stats: {},
                 definitions: [],
-                frequencies: []
+                frequencies: [],
             },
             resultOutputMode: 'split',
             mode: 'test',
@@ -47,43 +47,43 @@ describe('AnkiTemplateRenderer', () => {
                 fullQuery: 'query.full',
                 sentence: {
                     text: 'sentence.query.full',
-                    offset: 9
-                }
+                    offset: 9,
+                },
             },
-            media: void 0
-        }
+            media: void 0,
+        },
     };
     const testCases = [
         {
             name: 'regexMatch 1',
             template: '{{#regexMatch "test" "gu"}}this is a test of regexMatch{{/regexMatch}}',
-            result: 'test'
+            result: 'test',
         },
         {
             name: 'regexMatch 2',
             template: '{{regexMatch "test" "gu" "this is a test of regexMatch"}}',
-            result: 'test'
+            result: 'test',
         },
         {
             name: 'regexMatch 3',
             template: '{{#if (regexMatch "test" "gu" "this is a test of regexMatch")}}true{{else}}false{{/if}}',
-            result: 'true'
+            result: 'true',
         },
         {
             name: 'regexReplace 1',
             template: '{{#regexReplace "test" "TEST" "gu"}}this is a test of regexReplace{{/regexReplace}}',
-            result: 'this is a TEST of regexReplace'
+            result: 'this is a TEST of regexReplace',
         },
         {
             name: 'regexReplace 2',
             template: '{{regexReplace "test" "TEST" "gu" "this is a test of regexReplace"}}',
-            result: 'this is a TEST of regexReplace'
+            result: 'this is a TEST of regexReplace',
         },
         {
             name: 'regexReplace 3',
             template: '{{#if (regexReplace "test" "" "gu" "test")}}true{{else}}false{{/if}}',
-            result: 'false'
-        }
+            result: 'false',
+        },
     ];
     describe.each(testCases)('$name', ({template, result: expectedResult}) => {
         test('Test', ({expect, ankiTemplateRenderer}) => {

--- a/test/cache-map.test.js
+++ b/test/cache-map.test.js
@@ -38,7 +38,7 @@ describe('CacheMap', () => {
             {
                 maxSize: 1,
                 expectedSize: 0,
-                calls: []
+                calls: [],
             },
             {
                 maxSize: 10,
@@ -48,8 +48,8 @@ describe('CacheMap', () => {
                     {func: 'has', args: ['a1-b-c'],     returnValue: false},
                     {func: 'set', args: ['a1-b-c', 32], returnValue: void 0},
                     {func: 'get', args: ['a1-b-c'],     returnValue: 32},
-                    {func: 'has', args: ['a1-b-c'],     returnValue: true}
-                ]
+                    {func: 'has', args: ['a1-b-c'],     returnValue: true},
+                ],
             },
             {
                 maxSize: 10,
@@ -60,8 +60,8 @@ describe('CacheMap', () => {
                     {func: 'set', args: ['a1-b-c', 64], returnValue: void 0},
                     {func: 'get', args: ['a1-b-c'],     returnValue: 64},
                     {func: 'set', args: ['a2-b-c', 96], returnValue: void 0},
-                    {func: 'get', args: ['a2-b-c'],     returnValue: 96}
-                ]
+                    {func: 'get', args: ['a2-b-c'],     returnValue: 96},
+                ],
             },
             {
                 maxSize: 2,
@@ -81,9 +81,9 @@ describe('CacheMap', () => {
                     {func: 'set', args: ['a3-b-c', 3], returnValue: void 0},
                     {func: 'has', args: ['a1-b-c'],    returnValue: false},
                     {func: 'has', args: ['a2-b-c'],    returnValue: true},
-                    {func: 'has', args: ['a3-b-c'],    returnValue: true}
-                ]
-            }
+                    {func: 'has', args: ['a3-b-c'],    returnValue: true},
+                ],
+            },
         ];
         /* eslint-enable @stylistic/no-multi-spaces */
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -32,7 +32,7 @@ describe('DynamicProperty', () => {
                     expectedDefaultValue: 0,
                     expectedValue: 0,
                     expectedOverrideCount: 0,
-                    expectedEventOccurred: false
+                    expectedEventOccurred: false,
                 },
                 {
                     operation: 'set.defaultValue',
@@ -40,7 +40,7 @@ describe('DynamicProperty', () => {
                     expectedDefaultValue: 1,
                     expectedValue: 1,
                     expectedOverrideCount: 0,
-                    expectedEventOccurred: true
+                    expectedEventOccurred: true,
                 },
                 {
                     operation: 'set.defaultValue',
@@ -48,7 +48,7 @@ describe('DynamicProperty', () => {
                     expectedDefaultValue: 1,
                     expectedValue: 1,
                     expectedOverrideCount: 0,
-                    expectedEventOccurred: false
+                    expectedEventOccurred: false,
                 },
                 {
                     operation: 'set.defaultValue',
@@ -56,7 +56,7 @@ describe('DynamicProperty', () => {
                     expectedDefaultValue: 0,
                     expectedValue: 0,
                     expectedOverrideCount: 0,
-                    expectedEventOccurred: true
+                    expectedEventOccurred: true,
                 },
                 {
                     operation: 'setOverride',
@@ -64,7 +64,7 @@ describe('DynamicProperty', () => {
                     expectedDefaultValue: 0,
                     expectedValue: 8,
                     expectedOverrideCount: 1,
-                    expectedEventOccurred: true
+                    expectedEventOccurred: true,
                 },
                 {
                     operation: 'setOverride',
@@ -72,7 +72,7 @@ describe('DynamicProperty', () => {
                     expectedDefaultValue: 0,
                     expectedValue: 8,
                     expectedOverrideCount: 2,
-                    expectedEventOccurred: false
+                    expectedEventOccurred: false,
                 },
                 {
                     operation: 'setOverride',
@@ -80,7 +80,7 @@ describe('DynamicProperty', () => {
                     expectedDefaultValue: 0,
                     expectedValue: 32,
                     expectedOverrideCount: 3,
-                    expectedEventOccurred: true
+                    expectedEventOccurred: true,
                 },
                 {
                     operation: 'setOverride',
@@ -88,7 +88,7 @@ describe('DynamicProperty', () => {
                     expectedDefaultValue: 0,
                     expectedValue: 32,
                     expectedOverrideCount: 4,
-                    expectedEventOccurred: false
+                    expectedEventOccurred: false,
                 },
                 {
                     operation: 'clearOverride',
@@ -96,7 +96,7 @@ describe('DynamicProperty', () => {
                     expectedDefaultValue: 0,
                     expectedValue: 32,
                     expectedOverrideCount: 3,
-                    expectedEventOccurred: false
+                    expectedEventOccurred: false,
                 },
                 {
                     operation: 'clearOverride',
@@ -104,7 +104,7 @@ describe('DynamicProperty', () => {
                     expectedDefaultValue: 0,
                     expectedValue: 32,
                     expectedOverrideCount: 2,
-                    expectedEventOccurred: false
+                    expectedEventOccurred: false,
                 },
                 {
                     operation: 'clearOverride',
@@ -112,7 +112,7 @@ describe('DynamicProperty', () => {
                     expectedDefaultValue: 0,
                     expectedValue: 64,
                     expectedOverrideCount: 1,
-                    expectedEventOccurred: true
+                    expectedEventOccurred: true,
                 },
                 {
                     operation: 'clearOverride',
@@ -120,10 +120,10 @@ describe('DynamicProperty', () => {
                     expectedDefaultValue: 0,
                     expectedValue: 0,
                     expectedOverrideCount: 0,
-                    expectedEventOccurred: true
-                }
-            ]
-        }
+                    expectedEventOccurred: true,
+                },
+            ],
+        },
     ];
 
     describe.each(data)('Test DynamicProperty($initialValue)', ({initialValue, operations}) => {
@@ -156,110 +156,110 @@ describe('deepEqual', () => {
         {
             value1: 0,
             value2: 0,
-            expected: true
+            expected: true,
         },
         {
             value1: null,
             value2: null,
-            expected: true
+            expected: true,
         },
         {
             value1: 'test',
             value2: 'test',
-            expected: true
+            expected: true,
         },
         {
             value1: true,
             value2: true,
-            expected: true
+            expected: true,
         },
         {
             value1: 0,
             value2: 1,
-            expected: false
+            expected: false,
         },
         {
             value1: null,
             value2: false,
-            expected: false
+            expected: false,
         },
         {
             value1: 'test1',
             value2: 'test2',
-            expected: false
+            expected: false,
         },
         {
             value1: true,
             value2: false,
-            expected: false
-        }
+            expected: false,
+        },
     ];
     /** @type {import('test/core').DeepEqualTestData} */
     const simpleObjectTestsData = [
         {
             value1: {},
             value2: {},
-            expected: true
+            expected: true,
         },
         {
             value1: {},
             value2: [],
-            expected: false
+            expected: false,
         },
         {
             value1: [],
             value2: [],
-            expected: true
+            expected: true,
         },
         {
             value1: {},
             value2: null,
-            expected: false
-        }
+            expected: false,
+        },
     ];
     /** @type {import('test/core').DeepEqualTestData} */
     const complexObjectTestsData = [
         {
             value1: [1],
             value2: [],
-            expected: false
+            expected: false,
         },
         {
             value1: [1],
             value2: [1],
-            expected: true
+            expected: true,
         },
         {
             value1: [1],
             value2: [2],
-            expected: false
+            expected: false,
         },
 
         {
             value1: {},
             value2: {test: 1},
-            expected: false
+            expected: false,
         },
         {
             value1: {test: 1},
             value2: {test: 1},
-            expected: true
+            expected: true,
         },
         {
             value1: {test: 1},
             value2: {test: {test2: false}},
-            expected: false
+            expected: false,
         },
         {
             value1: {test: {test2: true}},
             value2: {test: {test2: false}},
-            expected: false
+            expected: false,
         },
         {
             value1: {test: {test2: [true]}},
             value2: {test: {test2: [true]}},
-            expected: true
-        }
+            expected: true,
+        },
     ];
     /** @type {import('test/core').DeepEqualTestData} */
     const recursiveTestsData = [
@@ -274,8 +274,8 @@ describe('deepEqual', () => {
                 x.x = x;
                 return x;
             })(),
-            expected: false
-        }
+            expected: false,
+        },
     ];
     describe('simple tests', () => {
         test.each(simpleTestsData)('deepEqual($value1, $value2) -> $expected', ({value1, value2, expected}) => {

--- a/test/data/html/js/html-test-utilities.js
+++ b/test/data/html/js/html-test-utilities.js
@@ -161,7 +161,7 @@ class HtmlTestUtilities {
         if (template !== null && templateContentContainer !== null) {
             const mode = (container instanceof HTMLElement ? container.dataset.shadowMode : void 0);
             const shadow = templateContentContainer.attachShadow({
-                mode: (mode === 'open' || mode === 'closed' ? mode : 'open')
+                mode: (mode === 'open' || mode === 'closed' ? mode : 'open'),
             });
 
             const containerStyles = document.querySelector('#container-styles');

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -115,7 +115,7 @@ describe('Database', () => {
 
         const title = testDictionaryIndex.title;
         const titles = new Map([
-            [title, {priority: 0, allowSecondarySearches: false}]
+            [title, {priority: 0, allowSecondarySearches: false}],
         ]);
 
         // Setup database
@@ -156,7 +156,7 @@ describe('Database', () => {
             {name: 'invalid-dictionary3'},
             {name: 'invalid-dictionary4'},
             {name: 'invalid-dictionary5'},
-            {name: 'invalid-dictionary6'}
+            {name: 'invalid-dictionary6'},
         ];
         describe.each(invalidDictionaries)('Invalid dictionary: $name', ({name}) => {
             test('Has invalid data', async ({expect}) => {
@@ -185,7 +185,7 @@ describe('Database', () => {
 
             const title = testDictionaryIndex.title;
             const titles = new Map([
-                [title, {priority: 0, allowSecondarySearches: false}]
+                [title, {priority: 0, allowSecondarySearches: false}],
             ]);
 
             // Setup database
@@ -198,7 +198,7 @@ describe('Database', () => {
             const {result: importDictionaryResult, errors: importDictionaryErrors} = await dictionaryImporter.importDictionary(
                 dictionaryDatabase,
                 testDictionarySource,
-                {prefixWildcardsSupported: true}
+                {prefixWildcardsSupported: true},
             );
 
             if (importDictionaryResult) {
@@ -309,7 +309,7 @@ describe('Database', () => {
         /** @type {{clearMethod: 'purge'|'delete'}[]} */
         const cleanupTestCases = [
             {clearMethod: 'purge'},
-            {clearMethod: 'delete'}
+            {clearMethod: 'delete'},
         ];
         describe.each(cleanupTestCases)('Testing cleanup method $clearMethod', ({clearMethod}) => {
             test('Import data and test', async ({expect}) => {
@@ -336,7 +336,7 @@ describe('Database', () => {
                             await dictionaryDatabase.deleteDictionary(
                                 testDictionaryIndex.title,
                                 1000,
-                                () => { progressEvent2 = true; }
+                                () => { progressEvent2 = true; },
                             );
                             expect(progressEvent2).toBe(true);
                         }
@@ -351,7 +351,7 @@ describe('Database', () => {
                 /** @type {import('dictionary-database').DictionaryCounts} */
                 const countsExpected = {
                     counts: [],
-                    total: {kanji: 0, kanjiMeta: 0, terms: 0, termMeta: 0, tagMeta: 0, media: 0}
+                    total: {kanji: 0, kanjiMeta: 0, terms: 0, termMeta: 0, tagMeta: 0, media: 0},
                 };
                 expect.soft(counts).toStrictEqual(countsExpected);
 

--- a/test/dictionary-data-validate.test.js
+++ b/test/dictionary-data-validate.test.js
@@ -42,7 +42,7 @@ describe('Dictionary validation', () => {
         {name: 'invalid-dictionary3', valid: false},
         {name: 'invalid-dictionary4', valid: false},
         {name: 'invalid-dictionary5', valid: false},
-        {name: 'invalid-dictionary6', valid: false}
+        {name: 'invalid-dictionary6', valid: false},
     ];
     const schemas = dictionaryValidate.getSchemas();
     describe.each(testCases)('Test dictionary $name', ({name, valid}) => {

--- a/test/dictionary-data.test.js
+++ b/test/dictionary-data.test.js
@@ -50,7 +50,7 @@ describe('Dictionary data', () => {
         data,
         expected1: expectedResults1[i],
         expected2: expectedResults2[i],
-        expected3: expectedResults3[i]
+        expected3: expectedResults3[i],
     }));
     describe.each(testCases)('Test %#: $data.name', ({data, expected1, expected2, expected3}) => {
         test('Test', async ({window, translator, expect}) => {

--- a/test/document-util.test.js
+++ b/test/document-util.test.js
@@ -135,7 +135,7 @@ describe('Document utility tests', () => {
                         sentenceScanExtent,
                         sentence,
                         hasImposter,
-                        terminateAtNewlines
+                        terminateAtNewlines,
                     } = parseJson(/** @type {string} */ (testElement.dataset.testData));
 
                     const elementFromPointValue = querySelectorChildOrSelf(testElement, elementFromPointSelector);
@@ -174,8 +174,8 @@ describe('Document utility tests', () => {
                                      * @param {number} index
                                      * @returns {DOMRect}
                                      */
-                                    item: function item(index) { return this[index]; }
-                                }
+                                    item: function item(index) { return this[index]; },
+                                },
                             );
                             return domRectList;
                         };
@@ -186,7 +186,7 @@ describe('Document utility tests', () => {
                     const textSourceGenerator = new TextSourceGenerator();
                     const source = textSourceGenerator.getRangeFromPoint(0, 0, {
                         deepContentScan: false,
-                        normalizeCssZoom: true
+                        normalizeCssZoom: true,
                     });
                     switch (resultType) {
                         case 'TextSourceRange':
@@ -229,7 +229,7 @@ describe('Document utility tests', () => {
                         terminateAtNewlines2,
                         terminatorMap,
                         forwardQuoteMap,
-                        backwardQuoteMap
+                        backwardQuoteMap,
                     ).text;
                     expect(sentenceActual).toStrictEqual(sentence);
 
@@ -257,7 +257,7 @@ describe('Document utility tests', () => {
                         expectedResultNodeSelector,
                         expectedResultNodeIsText,
                         expectedResultOffset,
-                        expectedResultContent
+                        expectedResultContent,
                     } = parseJson(/** @type {string} */ (testElement.dataset.testData));
 
                     /** @type {?Node} */

--- a/test/dom-text-scanner.test.js
+++ b/test/dom-text-scanner.test.js
@@ -105,7 +105,7 @@ function createAbsoluteGetComputedStyle(window) {
                     result = result.replace(/([-+]?\d(?:\.\d)?(?:[eE][-+]?\d+)?)em/g, replacer);
                 }
                 return result;
-            }
+            },
         });
     };
 }
@@ -138,8 +138,8 @@ describe('DOMTextScanner', () => {
                         node: expectedNodeSelector,
                         offset: expectedOffset,
                         content: expectedContent,
-                        remainder: expectedRemainder
-                    }
+                        remainder: expectedRemainder,
+                    },
                 } = testDataItem;
 
                 const node = querySelectorTextNode(testElement, nodeSelector);

--- a/test/eslint-config.test.js
+++ b/test/eslint-config.test.js
@@ -37,7 +37,7 @@ async function getDependencies(scriptPaths) {
         target: 'es2022',
         format: 'esm',
         write: false,
-        metafile: true
+        metafile: true,
     });
     const dependencies = Object.keys(v.metafile.inputs);
     const stringComparer = new Intl.Collator('en-US'); // Invariant locale
@@ -90,35 +90,35 @@ const targets = [
     {
         name: 'sandbox',
         paths: [
-            'ext/js/templates/template-renderer-frame-main.js'
+            'ext/js/templates/template-renderer-frame-main.js',
         ],
         /** @type {import('test/eslint-config').MinimalEslintConfigEnv} */
         env: {
-            webextensions: false
-        }
+            webextensions: false,
+        },
     },
     {
         name: 'worker',
         paths: [
-            'ext/js/dictionary/dictionary-worker-main.js'
+            'ext/js/dictionary/dictionary-worker-main.js',
         ],
         /** @type {import('test/eslint-config').MinimalEslintConfigEnv} */
         env: {
             browser: false,
-            worker: true
-        }
+            worker: true,
+        },
     },
     {
         name: 'serviceworker',
         paths: [
-            'ext/js/background/background-main.js'
+            'ext/js/background/background-main.js',
         ],
         /** @type {import('test/eslint-config').MinimalEslintConfigEnv} */
         env: {
             browser: false,
-            serviceworker: true
-        }
-    }
+            serviceworker: true,
+        },
+    },
 ];
 
 describe('Eslint configuration', () => {

--- a/test/fixtures/anki-template-renderer-test.js
+++ b/test/fixtures/anki-template-renderer-test.js
@@ -38,7 +38,7 @@ export async function createAnkiTemplateRendererTest() {
             // It is needed for DOM access for structured content.
             void window;
             await use(ankiTemplateRenderer);
-        }
+        },
     });
     return result;
 }

--- a/test/fixtures/dom-test.js
+++ b/test/fixtures/dom-test.js
@@ -31,7 +31,7 @@ function prepareWindow(window) {
         /** @returns {string} */
         get() { return this.textContent; },
         /** @param {string} value */
-        set(value) { this.textContent = value; }
+        set(value) { this.textContent = value; },
     });
 
     // Placeholder for feature detection
@@ -51,7 +51,7 @@ export async function setupDomTest(htmlFilePath) {
     prepareWindow(window);
     return {
         window,
-        teardown: (global) => environment.teardown(global)
+        teardown: (global) => environment.teardown(global),
     };
 }
 
@@ -73,6 +73,6 @@ export function createDomTest(htmlFilePath) {
             } finally {
                 await environment.teardown(global);
             }
-        }
+        },
     });
 }

--- a/test/fixtures/language-transformer-test.js
+++ b/test/fixtures/language-transformer-test.js
@@ -48,7 +48,7 @@ function hasTermReasons(languageTransformer, source, expectedTerm, expectedCondi
             return {
                 has: true,
                 reasons: trace.map((frame) => frame.transform),
-                rules: conditions
+                rules: conditions,
             };
         }
     }

--- a/test/fixtures/translator-test.js
+++ b/test/fixtures/translator-test.js
@@ -49,7 +49,7 @@ export async function createTranslatorContext(dictionaryDirectory, dictionaryNam
     const {errors} = await dictionaryImporter.importDictionary(
         dictionaryDatabase,
         testDictionaryData,
-        {prefixWildcardsSupported: true}
+        {prefixWildcardsSupported: true},
     );
 
     expect(errors.length).toEqual(0);
@@ -75,7 +75,7 @@ export async function createTranslatorTest(htmlFilePath, dictionaryDirectory, di
     const result = test.extend({
         window: async ({window}, use) => { await use(window); },
         // eslint-disable-next-line no-empty-pattern
-        translator: async ({}, use) => { await use(translator); }
+        translator: async ({}, use) => { await use(translator); },
     });
     return result;
 }

--- a/test/handlebars.test.js
+++ b/test/handlebars.test.js
@@ -39,7 +39,7 @@ describe('Handlebars', () => {
         const template = '{{~test1~}}';
 
         const data = {
-            test1: '<div style="font-size: 4em;">Test</div>'
+            test1: '<div style="font-size: 4em;">Test</div>',
         };
 
         const instance1 = compile(template);
@@ -56,8 +56,8 @@ describe('Handlebars', () => {
 
         const data = {
             test1: {
-                test2: '<div style="font-size: 4em;">Test</div>'
-            }
+                test2: '<div style="font-size: 4em;">Test</div>',
+            },
         };
 
         const instance1 = compile(template);

--- a/test/hotkey-util.test.js
+++ b/test/hotkey-util.test.js
@@ -37,7 +37,7 @@ describe('HotkeyUtil', () => {
 
             {os: 'linux', command: 'Ctrl+Alt+Shift+F1',    expectedCommand: 'Ctrl+Alt+Shift+F1',    expectedInput: {key: 'F1', modifiers: ['ctrl', 'alt', 'shift']}},
             {os: 'linux', command: 'MacCtrl+Alt+Shift+F1', expectedCommand: 'Ctrl+Alt+Shift+F1',    expectedInput: {key: 'F1', modifiers: ['ctrl', 'alt', 'shift']}},
-            {os: 'linux', command: 'Command+Alt+Shift+F1', expectedCommand: 'Command+Alt+Shift+F1', expectedInput: {key: 'F1', modifiers: ['meta', 'alt', 'shift']}}
+            {os: 'linux', command: 'Command+Alt+Shift+F1', expectedCommand: 'Command+Alt+Shift+F1', expectedInput: {key: 'F1', modifiers: ['meta', 'alt', 'shift']}},
         ];
         /* eslint-enable @stylistic/no-multi-spaces */
 
@@ -131,7 +131,7 @@ describe('HotkeyUtil', () => {
             {os: 'unknown', key: 'F1',   modifiers: ['meta'], expected: 'Meta + F1'},
             {os: 'unknown', key: null,   modifiers: ['mouse1'], expected: 'Mouse 1'},
             {os: 'unknown', key: 'KeyF', modifiers: ['mouse1'], expected: 'Mouse 1 + F'},
-            {os: 'unknown', key: 'F1',   modifiers: ['mouse1'], expected: 'Mouse 1 + F1'}
+            {os: 'unknown', key: 'F1',   modifiers: ['mouse1'], expected: 'Mouse 1 + F1'},
         ];
         /* eslint-enable @stylistic/no-multi-spaces */
 
@@ -148,7 +148,7 @@ describe('HotkeyUtil', () => {
         /** @type {{modifiers: import('input').Modifier[], expected: import('input').Modifier[]}[]} */
         const data = [
             {modifiers: [], expected: []},
-            {modifiers: ['shift', 'alt', 'ctrl', 'mouse4', 'meta', 'mouse1', 'mouse0'], expected: ['meta', 'ctrl', 'alt', 'shift', 'mouse0', 'mouse1', 'mouse4']}
+            {modifiers: ['shift', 'alt', 'ctrl', 'mouse4', 'meta', 'mouse1', 'mouse0'], expected: ['meta', 'ctrl', 'alt', 'shift', 'mouse0', 'mouse1', 'mouse4']},
         ];
 
         const hotkeyUtil = new HotkeyUtil();

--- a/test/japanese-util.test.js
+++ b/test/japanese-util.test.js
@@ -27,7 +27,7 @@ describe('Japanese utility functions', () => {
             ['力方', true],
             ['\u53f1\u{20b9f}', true],
             ['かたカタ々kata、。？,.?', false],
-            ['逸逸', true]
+            ['逸逸', true],
         ];
 
         test.each(data)('%s -> %o', (characters, expected) => {
@@ -44,7 +44,7 @@ describe('Japanese utility functions', () => {
         const data = [
             ['かたカタ', true],
             ['力方々kata、。？,.?', false],
-            ['\u53f1\u{20b9f}', false]
+            ['\u53f1\u{20b9f}', false],
         ];
 
         test.each(data)('%s -> %o', (characters, expected) => {
@@ -62,7 +62,7 @@ describe('Japanese utility functions', () => {
             ['かたカタ力方々、。？', true],
             ['\u53f1\u{20b9f}', true],
             ['kata,.?', false],
-            ['逸逸', true]
+            ['逸逸', true],
         ];
 
         test.each(data)('%s -> %o', (characters, expected) => {
@@ -87,7 +87,7 @@ describe('Japanese utility functions', () => {
             ['kata,.?', false],
             ['かたカタ力方々、。？invalid', false],
             ['\u53f1\u{20b9f}invalid', false],
-            ['kata,.?かた', false]
+            ['kata,.?かた', false],
         ];
 
         test.each(data)('%s -> %o', (string, expected) => {
@@ -109,7 +109,7 @@ describe('Japanese utility functions', () => {
             ['かたカタ力方々、。？invalid', true],
             ['\u53f1\u{20b9f}invalid', true],
             ['kata,.?かた', true],
-            ['逸逸', true]
+            ['逸逸', true],
         ];
 
         test.each(data)('%s -> %o', (string, expected) => {
@@ -130,7 +130,7 @@ describe('Japanese utility functions', () => {
             ['katakana', 'katakana'],
             ['hiragana', 'hiragana'],
             ['カーナー', 'かあなあ'],
-            ['カーナー', 'かーなー', true]
+            ['カーナー', 'かーなー', true],
         ];
 
         for (const [string, expected, keepProlongedSoundMarks = false] of data) {
@@ -151,7 +151,7 @@ describe('Japanese utility functions', () => {
             ['ヒラガナひらがな', 'ヒラガナヒラガナ'],
             ['chikaraちからチカラ力', 'chikaraチカラチカラ力'],
             ['katakana', 'katakana'],
-            ['hiragana', 'hiragana']
+            ['hiragana', 'hiragana'],
         ];
 
         test.each(data)('%s -> %o', (string, expected) => {
@@ -170,7 +170,7 @@ describe('Japanese utility functions', () => {
             ['ヒラガナひらがな', 'hiraganahiragana'],
             ['chikaraちからチカラ力', 'chikarachikarachikara力'],
             ['katakana', 'katakana'],
-            ['hiragana', 'hiragana']
+            ['hiragana', 'hiragana'],
         ];
 
         test.each(data)('%s -> %o', (string, expected) => {
@@ -184,7 +184,7 @@ describe('Japanese utility functions', () => {
             ['0123456789', '０１２３４５６７８９'],
             ['abcdefghij', 'ａｂｃｄｅｆｇｈｉｊ'],
             ['カタカナ', 'カタカナ'],
-            ['ひらがな', 'ひらがな']
+            ['ひらがな', 'ひらがな'],
         ];
 
         test.each(data)('%s -> %o', (string, expected) => {
@@ -202,7 +202,7 @@ describe('Japanese utility functions', () => {
             ['ｶｷ', 'カキ'],
             ['ｶﾞｷ', 'ガキ'],
             ['ﾆﾎﾝ', 'ニホン'],
-            ['ﾆｯﾎﾟﾝ', 'ニッポン']
+            ['ﾆｯﾎﾟﾝ', 'ニッポン'],
         ];
 
         for (const [string, expected] of data) {
@@ -224,7 +224,7 @@ describe('Japanese utility functions', () => {
             ['カタカナ', 'カタカナ'],
             ['ひらがな', 'ひらがな'],
             ['chikara', 'ちから'],
-            ['CHIKARA', 'ちから']
+            ['CHIKARA', 'ちから'],
         ];
 
         for (const [string, expected] of data) {
@@ -246,37 +246,37 @@ describe('Japanese utility functions', () => {
                     {text: '有', reading: 'あ'},
                     {text: 'り', reading: ''},
                     {text: '難', reading: 'がと'},
-                    {text: 'う', reading: ''}
-                ]
+                    {text: 'う', reading: ''},
+                ],
             ],
             [
                 ['方々', 'かたがた'],
                 [
-                    {text: '方々', reading: 'かたがた'}
-                ]
+                    {text: '方々', reading: 'かたがた'},
+                ],
             ],
             [
                 ['お祝い', 'おいわい'],
                 [
                     {text: 'お', reading: ''},
                     {text: '祝', reading: 'いわ'},
-                    {text: 'い', reading: ''}
-                ]
+                    {text: 'い', reading: ''},
+                ],
             ],
             [
                 ['美味しい', 'おいしい'],
                 [
                     {text: '美味', reading: 'おい'},
-                    {text: 'しい', reading: ''}
-                ]
+                    {text: 'しい', reading: ''},
+                ],
             ],
             [
                 ['食べ物', 'たべもの'],
                 [
                     {text: '食', reading: 'た'},
                     {text: 'べ', reading: ''},
-                    {text: '物', reading: 'もの'}
-                ]
+                    {text: '物', reading: 'もの'},
+                ],
             ],
             [
                 ['試し切り', 'ためしぎり'],
@@ -284,53 +284,53 @@ describe('Japanese utility functions', () => {
                     {text: '試', reading: 'ため'},
                     {text: 'し', reading: ''},
                     {text: '切', reading: 'ぎ'},
-                    {text: 'り', reading: ''}
-                ]
+                    {text: 'り', reading: ''},
+                ],
             ],
             // Ambiguous
             [
                 ['飼い犬', 'かいいぬ'],
                 [
-                    {text: '飼い犬', reading: 'かいいぬ'}
-                ]
+                    {text: '飼い犬', reading: 'かいいぬ'},
+                ],
             ],
             [
                 ['長い間', 'ながいあいだ'],
                 [
-                    {text: '長い間', reading: 'ながいあいだ'}
-                ]
+                    {text: '長い間', reading: 'ながいあいだ'},
+                ],
             ],
             // Same/empty reading
             [
                 ['飼い犬', ''],
                 [
-                    {text: '飼い犬', reading: ''}
-                ]
+                    {text: '飼い犬', reading: ''},
+                ],
             ],
             [
                 ['かいいぬ', 'かいいぬ'],
                 [
-                    {text: 'かいいぬ', reading: ''}
-                ]
+                    {text: 'かいいぬ', reading: ''},
+                ],
             ],
             [
                 ['かいぬ', 'かいぬ'],
                 [
-                    {text: 'かいぬ', reading: ''}
-                ]
+                    {text: 'かいぬ', reading: ''},
+                ],
             ],
             // Misc
             [
                 ['月', 'か'],
                 [
-                    {text: '月', reading: 'か'}
-                ]
+                    {text: '月', reading: 'か'},
+                ],
             ],
             [
                 ['月', 'カ'],
                 [
-                    {text: '月', reading: 'カ'}
-                ]
+                    {text: '月', reading: 'カ'},
+                ],
             ],
             // Mismatched kana readings
             [
@@ -339,125 +339,125 @@ describe('Japanese utility functions', () => {
                     {text: '有', reading: 'ア'},
                     {text: 'り', reading: 'リ'},
                     {text: '難', reading: 'ガト'},
-                    {text: 'う', reading: 'ウ'}
-                ]
+                    {text: 'う', reading: 'ウ'},
+                ],
             ],
             [
                 ['ありがとう', 'アリガトウ'],
                 [
-                    {text: 'ありがとう', reading: 'アリガトウ'}
-                ]
+                    {text: 'ありがとう', reading: 'アリガトウ'},
+                ],
             ],
             // Mismatched kana readings (real examples)
             [
                 ['カ月', 'かげつ'],
                 [
                     {text: 'カ', reading: 'か'},
-                    {text: '月', reading: 'げつ'}
-                ]
+                    {text: '月', reading: 'げつ'},
+                ],
             ],
             [
                 ['序ノ口', 'じょのくち'],
                 [
                     {text: '序', reading: 'じょ'},
                     {text: 'ノ', reading: 'の'},
-                    {text: '口', reading: 'くち'}
-                ]
+                    {text: '口', reading: 'くち'},
+                ],
             ],
             [
                 ['スズメの涙', 'すずめのなみだ'],
                 [
                     {text: 'スズメ', reading: 'すずめ'},
                     {text: 'の', reading: ''},
-                    {text: '涙', reading: 'なみだ'}
-                ]
+                    {text: '涙', reading: 'なみだ'},
+                ],
             ],
             [
                 ['二カ所', 'にかしょ'],
                 [
                     {text: '二', reading: 'に'},
                     {text: 'カ', reading: 'か'},
-                    {text: '所', reading: 'しょ'}
-                ]
+                    {text: '所', reading: 'しょ'},
+                ],
             ],
             [
                 ['八ツ橋', 'やつはし'],
                 [
                     {text: '八', reading: 'や'},
                     {text: 'ツ', reading: 'つ'},
-                    {text: '橋', reading: 'はし'}
-                ]
+                    {text: '橋', reading: 'はし'},
+                ],
             ],
             [
                 ['八ツ橋', 'やつはし'],
                 [
                     {text: '八', reading: 'や'},
                     {text: 'ツ', reading: 'つ'},
-                    {text: '橋', reading: 'はし'}
-                ]
+                    {text: '橋', reading: 'はし'},
+                ],
             ],
             [
                 ['一カ月', 'いっかげつ'],
                 [
                     {text: '一', reading: 'いっ'},
                     {text: 'カ', reading: 'か'},
-                    {text: '月', reading: 'げつ'}
-                ]
+                    {text: '月', reading: 'げつ'},
+                ],
             ],
             [
                 ['一カ所', 'いっかしょ'],
                 [
                     {text: '一', reading: 'いっ'},
                     {text: 'カ', reading: 'か'},
-                    {text: '所', reading: 'しょ'}
-                ]
+                    {text: '所', reading: 'しょ'},
+                ],
             ],
             [
                 ['カ所', 'かしょ'],
                 [
                     {text: 'カ', reading: 'か'},
-                    {text: '所', reading: 'しょ'}
-                ]
+                    {text: '所', reading: 'しょ'},
+                ],
             ],
             [
                 ['数カ月', 'すうかげつ'],
                 [
                     {text: '数', reading: 'すう'},
                     {text: 'カ', reading: 'か'},
-                    {text: '月', reading: 'げつ'}
-                ]
+                    {text: '月', reading: 'げつ'},
+                ],
             ],
             [
                 ['くノ一', 'くのいち'],
                 [
                     {text: 'く', reading: ''},
                     {text: 'ノ', reading: 'の'},
-                    {text: '一', reading: 'いち'}
-                ]
+                    {text: '一', reading: 'いち'},
+                ],
             ],
             [
                 ['くノ一', 'くのいち'],
                 [
                     {text: 'く', reading: ''},
                     {text: 'ノ', reading: 'の'},
-                    {text: '一', reading: 'いち'}
-                ]
+                    {text: '一', reading: 'いち'},
+                ],
             ],
             [
                 ['数カ国', 'すうかこく'],
                 [
                     {text: '数', reading: 'すう'},
                     {text: 'カ', reading: 'か'},
-                    {text: '国', reading: 'こく'}
-                ]
+                    {text: '国', reading: 'こく'},
+                ],
             ],
             [
                 ['数カ所', 'すうかしょ'],
                 [
                     {text: '数', reading: 'すう'},
                     {text: 'カ', reading: 'か'},
-                    {text: '所', reading: 'しょ'}
-                ]
+                    {text: '所', reading: 'しょ'},
+                ],
             ],
             [
                 ['壇ノ浦の戦い', 'だんのうらのたたかい'],
@@ -467,8 +467,8 @@ describe('Japanese utility functions', () => {
                     {text: '浦', reading: 'うら'},
                     {text: 'の', reading: ''},
                     {text: '戦', reading: 'たたか'},
-                    {text: 'い', reading: ''}
-                ]
+                    {text: 'い', reading: ''},
+                ],
             ],
             [
                 ['壇ノ浦の戦', 'だんのうらのたたかい'],
@@ -477,38 +477,38 @@ describe('Japanese utility functions', () => {
                     {text: 'ノ', reading: 'の'},
                     {text: '浦', reading: 'うら'},
                     {text: 'の', reading: ''},
-                    {text: '戦', reading: 'たたかい'}
-                ]
+                    {text: '戦', reading: 'たたかい'},
+                ],
             ],
             [
                 ['序ノ口格', 'じょのくちかく'],
                 [
                     {text: '序', reading: 'じょ'},
                     {text: 'ノ', reading: 'の'},
-                    {text: '口格', reading: 'くちかく'}
-                ]
+                    {text: '口格', reading: 'くちかく'},
+                ],
             ],
             [
                 ['二カ国語', 'にかこくご'],
                 [
                     {text: '二', reading: 'に'},
                     {text: 'カ', reading: 'か'},
-                    {text: '国語', reading: 'こくご'}
-                ]
+                    {text: '国語', reading: 'こくご'},
+                ],
             ],
             [
                 ['カ国', 'かこく'],
                 [
                     {text: 'カ', reading: 'か'},
-                    {text: '国', reading: 'こく'}
-                ]
+                    {text: '国', reading: 'こく'},
+                ],
             ],
             [
                 ['カ国語', 'かこくご'],
                 [
                     {text: 'カ', reading: 'か'},
-                    {text: '国語', reading: 'こくご'}
-                ]
+                    {text: '国語', reading: 'こくご'},
+                ],
             ],
             [
                 ['壇ノ浦の合戦', 'だんのうらのかっせん'],
@@ -517,46 +517,46 @@ describe('Japanese utility functions', () => {
                     {text: 'ノ', reading: 'の'},
                     {text: '浦', reading: 'うら'},
                     {text: 'の', reading: ''},
-                    {text: '合戦', reading: 'かっせん'}
-                ]
+                    {text: '合戦', reading: 'かっせん'},
+                ],
             ],
             [
                 ['一タ偏', 'いちたへん'],
                 [
                     {text: '一', reading: 'いち'},
                     {text: 'タ', reading: 'た'},
-                    {text: '偏', reading: 'へん'}
-                ]
+                    {text: '偏', reading: 'へん'},
+                ],
             ],
             [
                 ['ル又', 'るまた'],
                 [
                     {text: 'ル', reading: 'る'},
-                    {text: '又', reading: 'また'}
-                ]
+                    {text: '又', reading: 'また'},
+                ],
             ],
             [
                 ['ノ木偏', 'のぎへん'],
                 [
                     {text: 'ノ', reading: 'の'},
-                    {text: '木偏', reading: 'ぎへん'}
-                ]
+                    {text: '木偏', reading: 'ぎへん'},
+                ],
             ],
             [
                 ['一ノ貝', 'いちのかい'],
                 [
                     {text: '一', reading: 'いち'},
                     {text: 'ノ', reading: 'の'},
-                    {text: '貝', reading: 'かい'}
-                ]
+                    {text: '貝', reading: 'かい'},
+                ],
             ],
             [
                 ['虎ノ門事件', 'とらのもんじけん'],
                 [
                     {text: '虎', reading: 'とら'},
                     {text: 'ノ', reading: 'の'},
-                    {text: '門事件', reading: 'もんじけん'}
-                ]
+                    {text: '門事件', reading: 'もんじけん'},
+                ],
             ],
             [
                 ['教育ニ関スル勅語', 'きょういくにかんするちょくご'],
@@ -565,96 +565,96 @@ describe('Japanese utility functions', () => {
                     {text: 'ニ', reading: 'に'},
                     {text: '関', reading: 'かん'},
                     {text: 'スル', reading: 'する'},
-                    {text: '勅語', reading: 'ちょくご'}
-                ]
+                    {text: '勅語', reading: 'ちょくご'},
+                ],
             ],
             [
                 ['二カ年', 'にかねん'],
                 [
                     {text: '二', reading: 'に'},
                     {text: 'カ', reading: 'か'},
-                    {text: '年', reading: 'ねん'}
-                ]
+                    {text: '年', reading: 'ねん'},
+                ],
             ],
             [
                 ['三カ年', 'さんかねん'],
                 [
                     {text: '三', reading: 'さん'},
                     {text: 'カ', reading: 'か'},
-                    {text: '年', reading: 'ねん'}
-                ]
+                    {text: '年', reading: 'ねん'},
+                ],
             ],
             [
                 ['四カ年', 'よんかねん'],
                 [
                     {text: '四', reading: 'よん'},
                     {text: 'カ', reading: 'か'},
-                    {text: '年', reading: 'ねん'}
-                ]
+                    {text: '年', reading: 'ねん'},
+                ],
             ],
             [
                 ['五カ年', 'ごかねん'],
                 [
                     {text: '五', reading: 'ご'},
                     {text: 'カ', reading: 'か'},
-                    {text: '年', reading: 'ねん'}
-                ]
+                    {text: '年', reading: 'ねん'},
+                ],
             ],
             [
                 ['六カ年', 'ろっかねん'],
                 [
                     {text: '六', reading: 'ろっ'},
                     {text: 'カ', reading: 'か'},
-                    {text: '年', reading: 'ねん'}
-                ]
+                    {text: '年', reading: 'ねん'},
+                ],
             ],
             [
                 ['七カ年', 'ななかねん'],
                 [
                     {text: '七', reading: 'なな'},
                     {text: 'カ', reading: 'か'},
-                    {text: '年', reading: 'ねん'}
-                ]
+                    {text: '年', reading: 'ねん'},
+                ],
             ],
             [
                 ['八カ年', 'はちかねん'],
                 [
                     {text: '八', reading: 'はち'},
                     {text: 'カ', reading: 'か'},
-                    {text: '年', reading: 'ねん'}
-                ]
+                    {text: '年', reading: 'ねん'},
+                ],
             ],
             [
                 ['九カ年', 'きゅうかねん'],
                 [
                     {text: '九', reading: 'きゅう'},
                     {text: 'カ', reading: 'か'},
-                    {text: '年', reading: 'ねん'}
-                ]
+                    {text: '年', reading: 'ねん'},
+                ],
             ],
             [
                 ['十カ年', 'じゅうかねん'],
                 [
                     {text: '十', reading: 'じゅう'},
                     {text: 'カ', reading: 'か'},
-                    {text: '年', reading: 'ねん'}
-                ]
+                    {text: '年', reading: 'ねん'},
+                ],
             ],
             [
                 ['鏡ノ間', 'かがみのま'],
                 [
                     {text: '鏡', reading: 'かがみ'},
                     {text: 'ノ', reading: 'の'},
-                    {text: '間', reading: 'ま'}
-                ]
+                    {text: '間', reading: 'ま'},
+                ],
             ],
             [
                 ['鏡ノ間', 'かがみのま'],
                 [
                     {text: '鏡', reading: 'かがみ'},
                     {text: 'ノ', reading: 'の'},
-                    {text: '間', reading: 'ま'}
-                ]
+                    {text: '間', reading: 'ま'},
+                ],
             ],
             [
                 ['ページ違反', 'ぺーじいはん'],
@@ -662,39 +662,39 @@ describe('Japanese utility functions', () => {
                     {text: 'ペ', reading: 'ぺ'},
                     {text: 'ー', reading: ''},
                     {text: 'ジ', reading: 'じ'},
-                    {text: '違反', reading: 'いはん'}
-                ]
+                    {text: '違反', reading: 'いはん'},
+                ],
             ],
             // Mismatched kana
             [
                 ['サボる', 'サボル'],
                 [
                     {text: 'サボ', reading: ''},
-                    {text: 'る', reading: 'ル'}
-                ]
+                    {text: 'る', reading: 'ル'},
+                ],
             ],
             // Reading starts with term, but has remainder characters
             [
                 ['シック', 'シック・ビルしょうこうぐん'],
                 [
-                    {text: 'シック', reading: 'シック・ビルしょうこうぐん'}
-                ]
+                    {text: 'シック', reading: 'シック・ビルしょうこうぐん'},
+                ],
             ],
             // Kanji distribution tests
             [
                 ['逸らす', 'そらす'],
                 [
                     {text: '逸', reading: 'そ'},
-                    {text: 'らす', reading: ''}
-                ]
+                    {text: 'らす', reading: ''},
+                ],
             ],
             [
                 ['逸らす', 'そらす'],
                 [
                     {text: '逸', reading: 'そ'},
-                    {text: 'らす', reading: ''}
-                ]
-            ]
+                    {text: 'らす', reading: ''},
+                ],
+            ],
         ];
 
         test.each(data)('%o -> %o', (input, expected) => {
@@ -711,41 +711,41 @@ describe('Japanese utility functions', () => {
                 ['美味しい', 'おいしい', '美味しかた'],
                 [
                     {text: '美味', reading: 'おい'},
-                    {text: 'しかた', reading: ''}
-                ]
+                    {text: 'しかた', reading: ''},
+                ],
             ],
             [
                 ['食べる', 'たべる', '食べた'],
                 [
                     {text: '食', reading: 'た'},
-                    {text: 'べた', reading: ''}
-                ]
+                    {text: 'べた', reading: ''},
+                ],
             ],
             [
                 ['迄に', 'までに', 'までに'],
                 [
-                    {text: 'までに', reading: ''}
-                ]
+                    {text: 'までに', reading: ''},
+                ],
             ],
             [
                 ['行う', 'おこなう', 'おこなわなかった'],
                 [
-                    {text: 'おこなわなかった', reading: ''}
-                ]
+                    {text: 'おこなわなかった', reading: ''},
+                ],
             ],
             [
                 ['いい', 'いい', 'イイ'],
                 [
-                    {text: 'イイ', reading: ''}
-                ]
+                    {text: 'イイ', reading: ''},
+                ],
             ],
             [
                 ['否か', 'いなか', '否カ'],
                 [
                     {text: '否', reading: 'いな'},
-                    {text: 'カ', reading: 'か'}
-                ]
-            ]
+                    {text: 'カ', reading: 'か'},
+                ],
+            ],
         ];
 
         test.each(data)('%o -> %o', (input, expected) => {
@@ -794,7 +794,7 @@ describe('Japanese utility functions', () => {
             [['っっ', false], 'っ'],
             [['っっ', true], ''],
             [['っっっ', false], 'っ'],
-            [['っっっ', true], '']
+            [['っっっ', true], ''],
         ];
 
         test.each(data)('%o -> %o', (input, output) => {
@@ -833,7 +833,7 @@ describe('Japanese utility functions', () => {
             [[0, 4], false],
             [[1, 4], true],
             [[2, 4], true],
-            [[3, 4], true]
+            [[3, 4], true],
         ];
 
         test.each(data)('%o -> %o', (input, expected) => {
@@ -854,7 +854,7 @@ describe('Japanese utility functions', () => {
             ['ちゃんと', ['ちゃ', 'ん', 'と']],
             ['とうきょう', ['と', 'う', 'きょ', 'う']],
             ['ぎゅう', ['ぎゅ', 'う']],
-            ['ディスコ', ['ディ', 'ス', 'コ']]
+            ['ディスコ', ['ディ', 'ス', 'コ']],
         ];
 
         test.each(data)('%s -> %o', (text, expected) => {

--- a/test/json-schema.test.js
+++ b/test/json-schema.test.js
@@ -53,28 +53,28 @@ describe('JsonSchema', () => {
         const schema = {
             allOf: [
                 {
-                    type: 'number'
+                    type: 'number',
                 },
                 {
                     anyOf: [
                         {minimum: 10, maximum: 100},
-                        {minimum: -100, maximum: -10}
-                    ]
+                        {minimum: -100, maximum: -10},
+                    ],
                 },
                 {
                     oneOf: [
                         {multipleOf: 3},
-                        {multipleOf: 5}
-                    ]
+                        {multipleOf: 5},
+                    ],
                 },
                 {
                     not: {
                         anyOf: [
-                            {multipleOf: 20}
-                        ]
-                    }
-                }
-            ]
+                            {multipleOf: 20},
+                        ],
+                    },
+                },
+            ],
         };
 
         /**
@@ -115,7 +115,7 @@ describe('JsonSchema', () => {
             // String tests
             {
                 schema: {
-                    type: 'string'
+                    type: 'string',
                 },
                 inputs: [
                     {expected: false, value: null},
@@ -123,97 +123,97 @@ describe('JsonSchema', () => {
                     {expected: false, value: 0},
                     {expected: false, value: {}},
                     {expected: false, value: []},
-                    {expected: true,  value: ''}
-                ]
+                    {expected: true,  value: ''},
+                ],
             },
             {
                 schema: {
                     type: 'string',
-                    minLength: 2
+                    minLength: 2,
                 },
                 inputs: [
                     {expected: false, value: ''},
                     {expected: false,  value: '1'},
                     {expected: true,  value: '12'},
-                    {expected: true,  value: '123'}
-                ]
+                    {expected: true,  value: '123'},
+                ],
             },
             {
                 schema: {
                     type: 'string',
-                    maxLength: 2
+                    maxLength: 2,
                 },
                 inputs: [
                     {expected: true,  value: ''},
                     {expected: true,  value: '1'},
                     {expected: true,  value: '12'},
-                    {expected: false, value: '123'}
-                ]
+                    {expected: false, value: '123'},
+                ],
             },
             {
                 schema: {
                     type: 'string',
-                    pattern: 'test'
+                    pattern: 'test',
                 },
                 inputs: [
                     {expected: false, value: ''},
                     {expected: true,  value: 'test'},
                     {expected: false, value: 'TEST'},
                     {expected: true,  value: 'ABCtestDEF'},
-                    {expected: false, value: 'ABCTESTDEF'}
-                ]
+                    {expected: false, value: 'ABCTESTDEF'},
+                ],
             },
             {
                 schema: {
                     type: 'string',
-                    pattern: '^test$'
+                    pattern: '^test$',
                 },
                 inputs: [
                     {expected: false, value: ''},
                     {expected: true,  value: 'test'},
                     {expected: false, value: 'TEST'},
                     {expected: false, value: 'ABCtestDEF'},
-                    {expected: false, value: 'ABCTESTDEF'}
-                ]
+                    {expected: false, value: 'ABCTESTDEF'},
+                ],
             },
             {
                 schema: {
                     type: 'string',
                     pattern: '^test$',
-                    patternFlags: 'i'
+                    patternFlags: 'i',
                 },
                 inputs: [
                     {expected: false, value: ''},
                     {expected: true,  value: 'test'},
                     {expected: true,  value: 'TEST'},
                     {expected: false, value: 'ABCtestDEF'},
-                    {expected: false, value: 'ABCTESTDEF'}
-                ]
+                    {expected: false, value: 'ABCTESTDEF'},
+                ],
             },
             {
                 schema: {
                     type: 'string',
-                    pattern: '*'
+                    pattern: '*',
                 },
                 inputs: [
-                    {expected: false, value: ''}
-                ]
+                    {expected: false, value: ''},
+                ],
             },
             {
                 schema: {
                     type: 'string',
                     pattern: '.',
-                    patternFlags: '?'
+                    patternFlags: '?',
                 },
                 inputs: [
-                    {expected: false, value: ''}
-                ]
+                    {expected: false, value: ''},
+                ],
             },
 
             // Const tests
             {
                 schema: {
-                    const: 32
+                    const: 32,
                 },
                 inputs: [
                     {expected: true,  value: 32},
@@ -221,12 +221,12 @@ describe('JsonSchema', () => {
                     {expected: false, value: '32'},
                     {expected: false, value: null},
                     {expected: false, value: {a: 'b'}},
-                    {expected: false, value: [1, 2, 3]}
-                ]
+                    {expected: false, value: [1, 2, 3]},
+                ],
             },
             {
                 schema: {
-                    const: '32'
+                    const: '32',
                 },
                 inputs: [
                     {expected: false, value: 32},
@@ -234,12 +234,12 @@ describe('JsonSchema', () => {
                     {expected: true,  value: '32'},
                     {expected: false, value: null},
                     {expected: false, value: {a: 'b'}},
-                    {expected: false, value: [1, 2, 3]}
-                ]
+                    {expected: false, value: [1, 2, 3]},
+                ],
             },
             {
                 schema: {
-                    const: null
+                    const: null,
                 },
                 inputs: [
                     {expected: false, value: 32},
@@ -247,12 +247,12 @@ describe('JsonSchema', () => {
                     {expected: false, value: '32'},
                     {expected: true,  value: null},
                     {expected: false, value: {a: 'b'}},
-                    {expected: false, value: [1, 2, 3]}
-                ]
+                    {expected: false, value: [1, 2, 3]},
+                ],
             },
             {
                 schema: {
-                    const: {a: 'b'}
+                    const: {a: 'b'},
                 },
                 inputs: [
                     {expected: false, value: 32},
@@ -260,12 +260,12 @@ describe('JsonSchema', () => {
                     {expected: false, value: '32'},
                     {expected: false, value: null},
                     {expected: false, value: {a: 'b'}},
-                    {expected: false, value: [1, 2, 3]}
-                ]
+                    {expected: false, value: [1, 2, 3]},
+                ],
             },
             {
                 schema: {
-                    const: [1, 2, 3]
+                    const: [1, 2, 3],
                 },
                 inputs: [
                     {expected: false, value: 32},
@@ -273,15 +273,15 @@ describe('JsonSchema', () => {
                     {expected: false,  value: '32'},
                     {expected: false, value: null},
                     {expected: false, value: {a: 'b'}},
-                    {expected: false, value: [1, 2, 3]}
-                ]
+                    {expected: false, value: [1, 2, 3]},
+                ],
             },
 
             // Array contains tests
             {
                 schema: {
                     type: 'array',
-                    contains: {const: 32}
+                    contains: {const: 32},
                 },
                 inputs: [
                     {expected: false, value: []},
@@ -290,119 +290,119 @@ describe('JsonSchema', () => {
                     {expected: true,  value: [1, 32, 1]},
                     {expected: false, value: [33]},
                     {expected: false, value: [1, 33]},
-                    {expected: false, value: [1, 33, 1]}
-                ]
+                    {expected: false, value: [1, 33, 1]},
+                ],
             },
 
             // Number limits tests
             {
                 schema: {
                     type: 'number',
-                    minimum: 0
+                    minimum: 0,
                 },
                 inputs: [
                     {expected: false, value: -1},
                     {expected: true,  value: 0},
-                    {expected: true,  value: 1}
-                ]
+                    {expected: true,  value: 1},
+                ],
             },
             {
                 schema: {
                     type: 'number',
-                    exclusiveMinimum: 0
+                    exclusiveMinimum: 0,
                 },
                 inputs: [
                     {expected: false, value: -1},
                     {expected: false, value: 0},
-                    {expected: true,  value: 1}
-                ]
+                    {expected: true,  value: 1},
+                ],
             },
             {
                 schema: {
                     type: 'number',
-                    maximum: 0
+                    maximum: 0,
                 },
                 inputs: [
                     {expected: true,  value: -1},
                     {expected: true,  value: 0},
-                    {expected: false, value: 1}
-                ]
+                    {expected: false, value: 1},
+                ],
             },
             {
                 schema: {
                     type: 'number',
-                    exclusiveMaximum: 0
+                    exclusiveMaximum: 0,
                 },
                 inputs: [
                     {expected: true,  value: -1},
                     {expected: false, value: 0},
-                    {expected: false, value: 1}
-                ]
+                    {expected: false, value: 1},
+                ],
             },
 
             // Integer limits tests
             {
                 schema: {
                     type: 'integer',
-                    minimum: 0
+                    minimum: 0,
                 },
                 inputs: [
                     {expected: false, value: -1},
                     {expected: true,  value: 0},
-                    {expected: true,  value: 1}
-                ]
+                    {expected: true,  value: 1},
+                ],
             },
             {
                 schema: {
                     type: 'integer',
-                    exclusiveMinimum: 0
+                    exclusiveMinimum: 0,
                 },
                 inputs: [
                     {expected: false, value: -1},
                     {expected: false, value: 0},
-                    {expected: true,  value: 1}
-                ]
+                    {expected: true,  value: 1},
+                ],
             },
             {
                 schema: {
                     type: 'integer',
-                    maximum: 0
+                    maximum: 0,
                 },
                 inputs: [
                     {expected: true,  value: -1},
                     {expected: true,  value: 0},
-                    {expected: false, value: 1}
-                ]
+                    {expected: false, value: 1},
+                ],
             },
             {
                 schema: {
                     type: 'integer',
-                    exclusiveMaximum: 0
+                    exclusiveMaximum: 0,
                 },
                 inputs: [
                     {expected: true,  value: -1},
                     {expected: false, value: 0},
-                    {expected: false, value: 1}
-                ]
+                    {expected: false, value: 1},
+                ],
             },
             {
                 schema: {
                     type: 'integer',
-                    multipleOf: 2
+                    multipleOf: 2,
                 },
                 inputs: [
                     {expected: true,  value: -2},
                     {expected: false, value: -1},
                     {expected: true,  value: 0},
                     {expected: false, value: 1},
-                    {expected: true,  value: 2}
-                ]
+                    {expected: true,  value: 2},
+                ],
             },
 
             // Numeric type tests
             {
                 schema: {
-                    type: 'number'
+                    type: 'number',
                 },
                 inputs: [
                     {expected: true,  value: 0},
@@ -411,12 +411,12 @@ describe('JsonSchema', () => {
                     {expected: false, value: '0'},
                     {expected: false, value: null},
                     {expected: false, value: []},
-                    {expected: false, value: {}}
-                ]
+                    {expected: false, value: {}},
+                ],
             },
             {
                 schema: {
-                    type: 'integer'
+                    type: 'integer',
                 },
                 inputs: [
                     {expected: true,  value: 0},
@@ -425,8 +425,8 @@ describe('JsonSchema', () => {
                     {expected: false, value: '0'},
                     {expected: false, value: null},
                     {expected: false, value: []},
-                    {expected: false, value: {}}
-                ]
+                    {expected: false, value: {}},
+                ],
             },
 
             // Reference tests
@@ -434,10 +434,10 @@ describe('JsonSchema', () => {
                 schema: {
                     definitions: {
                         example: {
-                            type: 'number'
-                        }
+                            type: 'number',
+                        },
                     },
-                    $ref: '#/definitions/example'
+                    $ref: '#/definitions/example',
                 },
                 inputs: [
                     {expected: true,  value: 0},
@@ -446,17 +446,17 @@ describe('JsonSchema', () => {
                     {expected: false, value: '0'},
                     {expected: false, value: null},
                     {expected: false, value: []},
-                    {expected: false, value: {}}
-                ]
+                    {expected: false, value: {}},
+                ],
             },
             {
                 schema: {
                     definitions: {
                         example: {
-                            type: 'integer'
-                        }
+                            type: 'integer',
+                        },
                     },
-                    $ref: '#/definitions/example'
+                    $ref: '#/definitions/example',
                 },
                 inputs: [
                     {expected: true,  value: 0},
@@ -465,8 +465,8 @@ describe('JsonSchema', () => {
                     {expected: false, value: '0'},
                     {expected: false, value: null},
                     {expected: false, value: []},
-                    {expected: false, value: {}}
-                ]
+                    {expected: false, value: {}},
+                ],
             },
             {
                 schema: {
@@ -476,12 +476,12 @@ describe('JsonSchema', () => {
                             additionalProperties: false,
                             properties: {
                                 test: {
-                                    $ref: '#/definitions/example'
-                                }
-                            }
-                        }
+                                    $ref: '#/definitions/example',
+                                },
+                            },
+                        },
                     },
-                    $ref: '#/definitions/example'
+                    $ref: '#/definitions/example',
                 },
                 inputs: [
                     {expected: false, value: 0},
@@ -499,9 +499,9 @@ describe('JsonSchema', () => {
                     {expected: false, value: {test: []}},
                     {expected: true,  value: {test: {}}},
                     {expected: true,  value: {test: {test: {}}}},
-                    {expected: true,  value: {test: {test: {test: {}}}}}
-                ]
-            }
+                    {expected: true,  value: {test: {test: {test: {}}}}},
+                ],
+            },
         ];
         /* eslint-enable @stylistic/no-multi-spaces */
 
@@ -524,49 +524,49 @@ describe('JsonSchema', () => {
                     properties: {
                         test: {
                             type: 'string',
-                            default: 'default'
-                        }
+                            default: 'default',
+                        },
                     },
-                    additionalProperties: false
+                    additionalProperties: false,
                 },
                 inputs: [
                     [
                         void 0,
-                        {test: 'default'}
+                        {test: 'default'},
                     ],
                     [
                         null,
-                        {test: 'default'}
+                        {test: 'default'},
                     ],
                     [
                         0,
-                        {test: 'default'}
+                        {test: 'default'},
                     ],
                     [
                         '',
-                        {test: 'default'}
+                        {test: 'default'},
                     ],
                     [
                         [],
-                        {test: 'default'}
+                        {test: 'default'},
                     ],
                     [
                         {},
-                        {test: 'default'}
+                        {test: 'default'},
                     ],
                     [
                         {test: 'value'},
-                        {test: 'value'}
+                        {test: 'value'},
                     ],
                     [
                         {test2: 'value2'},
-                        {test: 'default'}
+                        {test: 'default'},
                     ],
                     [
                         {test: 'value', test2: 'value2'},
-                        {test: 'value'}
-                    ]
-                ]
+                        {test: 'value'},
+                    ],
+                ],
             },
 
             // Test value defaulting on objects with additionalProperties=true
@@ -577,29 +577,29 @@ describe('JsonSchema', () => {
                     properties: {
                         test: {
                             type: 'string',
-                            default: 'default'
-                        }
+                            default: 'default',
+                        },
                     },
-                    additionalProperties: true
+                    additionalProperties: true,
                 },
                 inputs: [
                     [
                         {},
-                        {test: 'default'}
+                        {test: 'default'},
                     ],
                     [
                         {test: 'value'},
-                        {test: 'value'}
+                        {test: 'value'},
                     ],
                     [
                         {test2: 'value2'},
-                        {test: 'default', test2: 'value2'}
+                        {test: 'default', test2: 'value2'},
                     ],
                     [
                         {test: 'value', test2: 'value2'},
-                        {test: 'value', test2: 'value2'}
-                    ]
-                ]
+                        {test: 'value', test2: 'value2'},
+                    ],
+                ],
             },
 
             // Test value defaulting on objects with additionalProperties={schema}
@@ -610,48 +610,48 @@ describe('JsonSchema', () => {
                     properties: {
                         test: {
                             type: 'string',
-                            default: 'default'
-                        }
+                            default: 'default',
+                        },
                     },
                     additionalProperties: {
                         type: 'number',
-                        default: 10
-                    }
+                        default: 10,
+                    },
                 },
                 inputs: [
                     [
                         {},
-                        {test: 'default'}
+                        {test: 'default'},
                     ],
                     [
                         {test: 'value'},
-                        {test: 'value'}
+                        {test: 'value'},
                     ],
                     [
                         {test2: 'value2'},
-                        {test: 'default', test2: 10}
+                        {test: 'default', test2: 10},
                     ],
                     [
                         {test: 'value', test2: 'value2'},
-                        {test: 'value', test2: 10}
+                        {test: 'value', test2: 10},
                     ],
                     [
                         {test2: 2},
-                        {test: 'default', test2: 2}
+                        {test: 'default', test2: 2},
                     ],
                     [
                         {test: 'value', test2: 2},
-                        {test: 'value', test2: 2}
+                        {test: 'value', test2: 2},
                     ],
                     [
                         {test: 'value', test2: 2, test3: null},
-                        {test: 'value', test2: 2, test3: 10}
+                        {test: 'value', test2: 2, test3: 10},
                     ],
                     [
                         {test: 'value', test2: 2, test3: void 0},
-                        {test: 'value', test2: 2, test3: 10}
-                    ]
-                ]
+                        {test: 'value', test2: 2, test3: 10},
+                    ],
+                ],
             },
 
             // Test value defaulting where hasOwnProperty is false
@@ -662,24 +662,24 @@ describe('JsonSchema', () => {
                     properties: {
                         test: {
                             type: 'string',
-                            default: 'default'
-                        }
-                    }
+                            default: 'default',
+                        },
+                    },
                 },
                 inputs: [
                     [
                         {},
-                        {test: 'default'}
+                        {test: 'default'},
                     ],
                     [
                         {test: 'value'},
-                        {test: 'value'}
+                        {test: 'value'},
                     ],
                     [
                         Object.create({test: 'value'}),
-                        {test: 'default'}
-                    ]
-                ]
+                        {test: 'default'},
+                    ],
+                ],
             },
             {
                 schema: {
@@ -688,24 +688,24 @@ describe('JsonSchema', () => {
                     properties: {
                         toString: /** @type {import('ext/json-schema').SchemaObject} */ ({
                             type: 'string',
-                            default: 'default'
-                        })
-                    }
+                            default: 'default',
+                        }),
+                    },
                 },
                 inputs: [
                     [
                         {},
-                        {toString: 'default'}
+                        {toString: 'default'},
                     ],
                     [
                         {toString: 'value'},
-                        {toString: 'value'}
+                        {toString: 'value'},
                     ],
                     [
                         Object.create({toString: 'value'}),
-                        {toString: 'default'}
-                    ]
-                ]
+                        {toString: 'default'},
+                    ],
+                ],
             },
 
             // Test enum
@@ -717,28 +717,28 @@ describe('JsonSchema', () => {
                         test: {
                             type: 'string',
                             default: 'value1',
-                            enum: ['value1', 'value2', 'value3']
-                        }
-                    }
+                            enum: ['value1', 'value2', 'value3'],
+                        },
+                    },
                 },
                 inputs: [
                     [
                         {test: 'value1'},
-                        {test: 'value1'}
+                        {test: 'value1'},
                     ],
                     [
                         {test: 'value2'},
-                        {test: 'value2'}
+                        {test: 'value2'},
                     ],
                     [
                         {test: 'value3'},
-                        {test: 'value3'}
+                        {test: 'value3'},
                     ],
                     [
                         {test: 'value4'},
-                        {test: 'value1'}
-                    ]
-                ]
+                        {test: 'value1'},
+                    ],
+                ],
             },
 
             // Test valid vs invalid default
@@ -750,16 +750,16 @@ describe('JsonSchema', () => {
                         test: {
                             type: 'integer',
                             default: 2,
-                            minimum: 1
-                        }
-                    }
+                            minimum: 1,
+                        },
+                    },
                 },
                 inputs: [
                     [
                         {test: -1},
-                        {test: 2}
-                    ]
-                ]
+                        {test: 2},
+                    ],
+                ],
             },
             {
                 schema: {
@@ -769,16 +769,16 @@ describe('JsonSchema', () => {
                         test: {
                             type: 'integer',
                             default: 1,
-                            minimum: 2
-                        }
-                    }
+                            minimum: 2,
+                        },
+                    },
                 },
                 inputs: [
                     [
                         {test: -1},
-                        {test: -1}
-                    ]
-                ]
+                        {test: -1},
+                    ],
+                ],
             },
 
             // Test references
@@ -787,29 +787,29 @@ describe('JsonSchema', () => {
                     definitions: {
                         example: {
                             type: 'number',
-                            default: 0
-                        }
+                            default: 0,
+                        },
                     },
-                    $ref: '#/definitions/example'
+                    $ref: '#/definitions/example',
                 },
                 inputs: [
                     [
                         1,
-                        1
+                        1,
                     ],
                     [
                         null,
-                        0
+                        0,
                     ],
                     [
                         'test',
-                        0
+                        0,
                     ],
                     [
                         {test: 'value'},
-                        0
-                    ]
-                ]
+                        0,
+                    ],
+                ],
             },
             {
                 schema: {
@@ -819,44 +819,44 @@ describe('JsonSchema', () => {
                             additionalProperties: false,
                             properties: {
                                 test: {
-                                    $ref: '#/definitions/example'
-                                }
-                            }
-                        }
+                                    $ref: '#/definitions/example',
+                                },
+                            },
+                        },
                     },
-                    $ref: '#/definitions/example'
+                    $ref: '#/definitions/example',
                 },
                 inputs: [
                     [
                         1,
-                        {}
+                        {},
                     ],
                     [
                         null,
-                        {}
+                        {},
                     ],
                     [
                         'test',
-                        {}
+                        {},
                     ],
                     [
                         {},
-                        {}
+                        {},
                     ],
                     [
                         {test: {}},
-                        {test: {}}
+                        {test: {}},
                     ],
                     [
                         {test: 'value'},
-                        {test: {}}
+                        {test: {}},
                     ],
                     [
                         {test: {test: {}}},
-                        {test: {test: {}}}
-                    ]
-                ]
-            }
+                        {test: {test: {}}},
+                    ],
+                ],
+            },
         ];
 
         describe.each(data)('Schema %#', ({schema, inputs}) => {
@@ -880,17 +880,17 @@ describe('JsonSchema', () => {
                     properties: {
                         test: {
                             type: 'string',
-                            default: 'default'
-                        }
-                    }
+                            default: 'default',
+                        },
+                    },
                 },
                 tests: [
                     {error: false, value: {test: 'default'}, action: (value) => { value.test = 'string'; }},
                     {error: true,  value: {test: 'default'}, action: (value) => { value.test = null; }},
                     {error: true,  value: {test: 'default'}, action: (value) => { delete value.test; }},
                     {error: true,  value: {test: 'default'}, action: (value) => { value.test2 = 'string'; }},
-                    {error: false, value: {test: 'default'}, action: (value) => { delete value.test2; }}
-                ]
+                    {error: false, value: {test: 'default'}, action: (value) => { delete value.test2; }},
+                ],
             },
             {
                 schema: {
@@ -900,17 +900,17 @@ describe('JsonSchema', () => {
                     properties: {
                         test: {
                             type: 'string',
-                            default: 'default'
-                        }
-                    }
+                            default: 'default',
+                        },
+                    },
                 },
                 tests: [
                     {error: false, value: {test: 'default'}, action: (value) => { value.test = 'string'; }},
                     {error: true,  value: {test: 'default'}, action: (value) => { value.test = null; }},
                     {error: true,  value: {test: 'default'}, action: (value) => { delete value.test; }},
                     {error: false, value: {test: 'default'}, action: (value) => { value.test2 = 'string'; }},
-                    {error: false, value: {test: 'default'}, action: (value) => { delete value.test2; }}
-                ]
+                    {error: false, value: {test: 'default'}, action: (value) => { delete value.test2; }},
+                ],
             },
             {
                 schema: {
@@ -930,13 +930,13 @@ describe('JsonSchema', () => {
                                     properties: {
                                         test3: {
                                             type: 'string',
-                                            default: 'default'
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                                            default: 'default',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
                 },
                 tests: [
                     {error: false, action: (value) => { value.test1.test2.test3 = 'string'; }},
@@ -945,8 +945,8 @@ describe('JsonSchema', () => {
                     {error: true,  action: (value) => { value.test1.test2 = null; }},
                     {error: true,  action: (value) => { value.test1 = null; }},
                     {error: true,  action: (value) => { value.test4 = 'string'; }},
-                    {error: false, action: (value) => { delete value.test4; }}
-                ]
+                    {error: false, action: (value) => { delete value.test4; }},
+                ],
             },
 
             // Array tests
@@ -955,8 +955,8 @@ describe('JsonSchema', () => {
                     type: 'array',
                     items: {
                         type: 'string',
-                        default: 'default'
-                    }
+                        default: 'default',
+                    },
                 },
                 tests: [
                     {error: false, value: ['default'], action: (value) => { value[0] = 'string'; }},
@@ -970,9 +970,9 @@ describe('JsonSchema', () => {
                             value[1] = 'string';
                             if (value.length !== 2) { throw new Error(`Invalid length; expected=2; actual=${value.length}`); }
                             if (typeof value.push !== 'function') { throw new Error(`Invalid push; expected=function; actual=${typeof value.push}`); }
-                        }
-                    }
-                ]
+                        },
+                    },
+                ],
             },
 
             // Reference tests
@@ -984,12 +984,12 @@ describe('JsonSchema', () => {
                             additionalProperties: false,
                             properties: {
                                 test: {
-                                    $ref: '#/definitions/example'
-                                }
-                            }
-                        }
+                                    $ref: '#/definitions/example',
+                                },
+                            },
+                        },
                     },
-                    $ref: '#/definitions/example'
+                    $ref: '#/definitions/example',
                 },
                 tests: [
                     {error: false, value: {}, action: (value) => { value.test = {}; }},
@@ -998,9 +998,9 @@ describe('JsonSchema', () => {
                     {error: true,  value: {}, action: (value) => { value.test = null; }},
                     {error: true,  value: {}, action: (value) => { value.test = 'string'; }},
                     {error: true,  value: {}, action: (value) => { value.test = {}; value.test.test = 'string'; }},
-                    {error: true,  value: {}, action: (value) => { value.test = {test: 'string'}; }}
-                ]
-            }
+                    {error: true,  value: {}, action: (value) => { value.test = {test: 'string'}; }},
+                ],
+            },
         ];
         /* eslint-enable @stylistic/no-multi-spaces */
 

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -49,7 +49,7 @@ function createAjv() {
     return new Ajv({
         meta: true,
         strictTuples: false,
-        allowUnionTypes: true
+        allowUnionTypes: true,
     });
 }
 
@@ -69,7 +69,7 @@ function createValidatorFunctionFromTypeScript(path, type, jsconfigType) {
         additionalProperties: false,
         minify: false,
         expose: 'none',
-        strictTuples: true
+        strictTuples: true,
     };
     const schema = createGenerator(config).createSchema(config.type);
     const ajv = createAjv();
@@ -105,7 +105,7 @@ describe.concurrent('JSON validation', () => {
         'playwright',
         'test-results',
         'dev/lib',
-        'test/playwright'
+        'test/playwright',
     ]);
 
     const existingJsonFiles = getAllFiles(rootDir, (path, isDirectory) => {

--- a/test/language-transformer-cycles.test.js
+++ b/test/language-transformer-cycles.test.js
@@ -133,7 +133,7 @@ describe.each(languagesWithTransforms)('Cycles Test $iso', ({languageTransforms}
                 if (
                     !LanguageTransformer.conditionsMatch(
                         languageTransformer.getConditionFlagsFromConditionTypes(ruleNames),
-                        languageTransformer.getConditionFlagsFromConditionTypes(conditionsIn)
+                        languageTransformer.getConditionFlagsFromConditionTypes(conditionsIn),
                     ) ||
                     !text.endsWith(suffixIn) ||
                     (text.length - suffixIn.length + suffixOut.length) <= 0
@@ -145,7 +145,7 @@ describe.each(languagesWithTransforms)('Cycles Test $iso', ({languageTransforms}
                     text.substring(0, text.length - suffixIn.length) + suffixOut,
                     conditionsOut,
                     ruleNode,
-                    deinflectionNode
+                    deinflectionNode,
                 );
 
                 // Cycle check

--- a/test/language/albanian-transforms.test.js
+++ b/test/language/albanian-transforms.test.js
@@ -124,8 +124,8 @@ const tests = [
             {term: 'kujtohem', source: 'kujtohuni', rule: 'v', reasons: ['imperative second-person plural present']},
 
             {term: 'kthej', source: 'kthye', rule: 'v', reasons: ['aorist third-person singular indicative']},
-            {term: 'shkëlqej', source: 'shkëlqyer', rule: 'v', reasons: ['participle']}
-        ]
+            {term: 'shkëlqej', source: 'shkëlqyer', rule: 'v', reasons: ['participle']},
+        ],
     },
     {
         category: 'nouns',
@@ -136,9 +136,9 @@ const tests = [
             {term: 'gëzoj', source: 'gëzim', rule: 'v', reasons: ['nominalization']},
             {term: 'zbuloj', source: 'zbulim', rule: 'v', reasons: ['nominalization']},
             {term: 'përkthej', source: 'përkthim', rule: 'v', reasons: ['nominalization']},
-            {term: 'lëviz', source: 'lëvizje', rule: 'v', reasons: ['nominalization']}
-        ]
-    }
+            {term: 'lëviz', source: 'lëvizje', rule: 'v', reasons: ['nominalization']},
+        ],
+    },
 ];
 /* eslint-enable @stylistic/no-multi-spaces */
 

--- a/test/language/english-transforms.test.js
+++ b/test/language/english-transforms.test.js
@@ -37,8 +37,8 @@ const tests = [
             {term: 'slip', source: 'slippy',  rule: 'ns', reasons: ['-y']},
             {term: 'star', source: 'starry',  rule: 'ns', reasons: ['-y']},
             {term: 'gas', source: 'gassy',  rule: 'ns', reasons: ['-y']},
-            {term: 'wit', source: 'witty',  rule: 'ns', reasons: ['-y']}
-        ]
+            {term: 'wit', source: 'witty',  rule: 'ns', reasons: ['-y']},
+        ],
     },
     {
         category: 'verbs',
@@ -95,8 +95,8 @@ const tests = [
             {term: 'slip', source: 'slippy',  rule: 'v', reasons: ['-y']},
             {term: 'blur', source: 'blurry',  rule: 'v', reasons: ['-y']},
             {term: 'chat', source: 'chatty',  rule: 'v', reasons: ['-y']},
-            {term: 'learn', source: 'unlearn',  rule: 'v', reasons: ['un-']}
-        ]
+            {term: 'learn', source: 'unlearn',  rule: 'v', reasons: ['un-']},
+        ],
     },
     {
         category: 'phrasal verbs',
@@ -106,15 +106,15 @@ const tests = [
             {term: 'look up', source: 'looking up',  rule: 'v_phr', reasons: ['ing']},
             {term: 'look up', source: 'looked up',  rule: 'v_phr', reasons: ['past']},
             {term: 'look up', source: 'looks up',  rule: 'v_phr', reasons: ['3rd pers. sing. pres']},
-            {term: 'look up', source: 'looked something up',  rule: 'v_phr', reasons: ['past', 'interposed object']}
-        ]
+            {term: 'look up', source: 'looked something up',  rule: 'v_phr', reasons: ['past', 'interposed object']},
+        ],
     },
     {
         category: 'adverbs',
         valid: true,
         tests: [
-            {term: 'interestingly', source: 'uninterestingly',  rule: 'adj', reasons: ['un-']}
-        ]
+            {term: 'interestingly', source: 'uninterestingly',  rule: 'adj', reasons: ['un-']},
+        ],
     },
     {
         category: 'adjectives',
@@ -141,9 +141,9 @@ const tests = [
             {term: 'hot', source: 'hottest',  rule: 'adj', reasons: ['superlative']},
             {term: 'quick', source: 'quickly',  rule: 'adj', reasons: ['adverb']},
             {term: 'happy', source: 'happily',  rule: 'adj', reasons: ['adverb']},
-            {term: 'humble', source: 'humbly',  rule: 'adj', reasons: ['adverb']}
-        ]
-    }
+            {term: 'humble', source: 'humbly',  rule: 'adj', reasons: ['adverb']},
+        ],
+    },
 ];
 /* eslint-enable @stylistic/no-multi-spaces */
 

--- a/test/language/japanese-transforms.test.js
+++ b/test/language/japanese-transforms.test.js
@@ -41,8 +41,8 @@ const tests = [
             {term: '愛しい', source: '愛しき',                 rule: 'adj-i', reasons: ['-ki']},
             {term: '愛しい', source: '愛しげ',                 rule: 'adj-i', reasons: ['-ge']},
             {term: '愛しい', source: '愛し気',                 rule: 'adj-i', reasons: ['-ge']},
-            {term: '愛しい', source: '愛しがる',                 rule: 'adj-i', reasons: ['-garu']}
-        ]
+            {term: '愛しい', source: '愛しがる',                 rule: 'adj-i', reasons: ['-garu']},
+        ],
     },
     {
         category: 'ichidan verbs',
@@ -96,8 +96,8 @@ const tests = [
             {term: '食べる', source: '食べておる',       rule: 'v1', reasons: ['-te', 'progressive or perfect']},
             {term: '食べる', source: '食べてる',         rule: 'v1', reasons: ['-te', 'progressive or perfect']},
             {term: '食べる', source: '食べとる',         rule: 'v1', reasons: ['-te', 'progressive or perfect']},
-            {term: '食べる', source: '食べてしまう',     rule: 'v1', reasons: ['-te', '-shimau']}
-        ]
+            {term: '食べる', source: '食べてしまう',     rule: 'v1', reasons: ['-te', '-shimau']},
+        ],
     },
     {
         category: '-u verbs',
@@ -151,8 +151,8 @@ const tests = [
             {term: '買う', source: '買っておる',       rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '買う', source: '買ってる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '買う', source: '買っとる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
-            {term: '買う', source: '買ってしまう',     rule: 'v5', reasons: ['-te', '-shimau']}
-        ]
+            {term: '買う', source: '買ってしまう',     rule: 'v5', reasons: ['-te', '-shimau']},
+        ],
     },
     {
         category: '-ku verbs',
@@ -206,8 +206,8 @@ const tests = [
             {term: '行く', source: '行っておる',       rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '行く', source: '行ってる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '行く', source: '行っとる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
-            {term: '行く', source: '行ってしまう',     rule: 'v5', reasons: ['-te', '-shimau']}
-        ]
+            {term: '行く', source: '行ってしまう',     rule: 'v5', reasons: ['-te', '-shimau']},
+        ],
     },
     {
         category: '-gu verbs',
@@ -260,8 +260,8 @@ const tests = [
             {term: '泳ぐ', source: '泳いでいる',       rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '泳ぐ', source: '泳いでおる',       rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '泳ぐ', source: '泳いでる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
-            {term: '泳ぐ', source: '泳いでしまう',     rule: 'v5', reasons: ['-te', '-shimau']}
-        ]
+            {term: '泳ぐ', source: '泳いでしまう',     rule: 'v5', reasons: ['-te', '-shimau']},
+        ],
     },
     {
         category: '-su verbs',
@@ -315,8 +315,8 @@ const tests = [
             {term: '話す', source: '話しておる',       rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '話す', source: '話してる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '話す', source: '話しとる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
-            {term: '話す', source: '話してしまう',     rule: 'v5', reasons: ['-te', '-shimau']}
-        ]
+            {term: '話す', source: '話してしまう',     rule: 'v5', reasons: ['-te', '-shimau']},
+        ],
     },
     {
         category: '-tsu verbs',
@@ -370,8 +370,8 @@ const tests = [
             {term: '待つ', source: '待っておる',       rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '待つ', source: '待ってる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '待つ', source: '待っとる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
-            {term: '待つ', source: '待ってしまう',     rule: 'v5', reasons: ['-te', '-shimau']}
-        ]
+            {term: '待つ', source: '待ってしまう',     rule: 'v5', reasons: ['-te', '-shimau']},
+        ],
     },
     {
         category: '-nu verbs',
@@ -424,8 +424,8 @@ const tests = [
             {term: '死ぬ', source: '死んでいる',       rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '死ぬ', source: '死んでおる',       rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '死ぬ', source: '死んでる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
-            {term: '死ぬ', source: '死んでしまう',     rule: 'v5', reasons: ['-te', '-shimau']}
-        ]
+            {term: '死ぬ', source: '死んでしまう',     rule: 'v5', reasons: ['-te', '-shimau']},
+        ],
     },
     {
         category: '-bu verbs',
@@ -478,8 +478,8 @@ const tests = [
             {term: '遊ぶ', source: '遊んでいる',       rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '遊ぶ', source: '遊んでおる',       rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '遊ぶ', source: '遊んでる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
-            {term: '遊ぶ', source: '遊んでしまう',     rule: 'v5', reasons: ['-te', '-shimau']}
-        ]
+            {term: '遊ぶ', source: '遊んでしまう',     rule: 'v5', reasons: ['-te', '-shimau']},
+        ],
     },
     {
         category: '-mu verbs',
@@ -532,8 +532,8 @@ const tests = [
             {term: '飲む', source: '飲んでいる',       rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '飲む', source: '飲んでおる',       rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '飲む', source: '飲んでる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
-            {term: '飲む', source: '飲んでしまう',     rule: 'v5', reasons: ['-te', '-shimau']}
-        ]
+            {term: '飲む', source: '飲んでしまう',     rule: 'v5', reasons: ['-te', '-shimau']},
+        ],
     },
     {
         category: 'godan verbs',
@@ -587,8 +587,8 @@ const tests = [
             {term: '作る', source: '作っておる',       rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '作る', source: '作ってる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
             {term: '作る', source: '作っとる',         rule: 'v5', reasons: ['-te', 'progressive or perfect']},
-            {term: '作る', source: '作ってしまう',     rule: 'v5', reasons: ['-te', '-shimau']}
-        ]
+            {term: '作る', source: '作ってしまう',     rule: 'v5', reasons: ['-te', '-shimau']},
+        ],
     },
     {
         category: 'irregular verbs',
@@ -853,8 +853,8 @@ const tests = [
             {term: 'くる', source: 'きておる',       rule: 'vk', reasons: ['-te', 'progressive or perfect']},
             {term: 'くる', source: 'きてる',         rule: 'vk', reasons: ['-te', 'progressive or perfect']},
             {term: 'くる', source: 'きとる',         rule: 'vk', reasons: ['-te', 'progressive or perfect']},
-            {term: 'くる', source: 'きてしまう',     rule: 'vk', reasons: ['-te', '-shimau']}
-        ]
+            {term: 'くる', source: 'きてしまう',     rule: 'vk', reasons: ['-te', '-shimau']},
+        ],
     },
     {
         category: '-zuru verbs',
@@ -915,8 +915,8 @@ const tests = [
             {term: '論ずる', source: '論じておる',       rule: 'vz', reasons: ['-te', 'progressive or perfect']},
             {term: '論ずる', source: '論じてる',         rule: 'vz', reasons: ['-te', 'progressive or perfect']},
             {term: '論ずる', source: '論じとる',         rule: 'vz', reasons: ['-te', 'progressive or perfect']},
-            {term: '論ずる', source: '論じてしまう',     rule: 'vz', reasons: ['-te', '-shimau']}
-        ]
+            {term: '論ずる', source: '論じてしまう',     rule: 'vz', reasons: ['-te', '-shimau']},
+        ],
     },
     {
         category: '-e verbs',
@@ -967,8 +967,8 @@ const tests = [
             {term: 'うまい',     source: 'うめぇ',     rule: 'adj-i', reasons: ['-e']},
             {term: 'でかい',     source: 'でけぇ',     rule: 'adj-i', reasons: ['-e']},
             {term: 'まずい',     source: 'まっぜぇ',   rule: 'adj-i', reasons: ['-e']},
-            {term: 'あかい',     source: 'あけぇ',     rule: 'adj-i', reasons: ['-e']}
-        ]
+            {term: 'あかい',     source: 'あけぇ',     rule: 'adj-i', reasons: ['-e']},
+        ],
     },
     {
         category: 'irregular verbs',
@@ -1008,8 +1008,8 @@ const tests = [
             {term: 'くる', source: 'くられない',     rule: 'vk', reasons: null},
             {term: 'くる', source: 'くられない',     rule: 'vk', reasons: null},
             {term: 'くる', source: 'くさせない',     rule: 'vk', reasons: null},
-            {term: 'くる', source: 'くさせられない', rule: 'vk', reasons: null}
-        ]
+            {term: 'くる', source: 'くさせられない', rule: 'vk', reasons: null},
+        ],
     },
     {
         category: 'uncommon irregular verbs',
@@ -1074,8 +1074,8 @@ const tests = [
             {term: '沿う', source: '沿うたり', rule: 'v5', reasons: ['-tari']},
             {term: '添う', source: '添うたり', rule: 'v5', reasons: ['-tari']},
             {term: '副う', source: '副うたり', rule: 'v5', reasons: ['-tari']},
-            {term: '厭う', source: '厭うたり', rule: 'v5', reasons: ['-tari']}
-        ]
+            {term: '厭う', source: '厭うたり', rule: 'v5', reasons: ['-tari']},
+        ],
     },
     {
         category: 'combinations',
@@ -1084,8 +1084,8 @@ const tests = [
             {term: '抱き抱える', source: '抱き抱えていなければ', rule: 'v1', reasons: ['-te', 'progressive or perfect', 'negative', '-ba']},
             {term: '抱きかかえる', source: '抱きかかえていなければ', rule: 'v1', reasons: ['-te', 'progressive or perfect', 'negative', '-ba']},
             {term: '打ち込む', source: '打ち込んでいませんでした', rule: 'v5', reasons: ['-te', 'progressive or perfect', 'polite', 'negative', 'past']},
-            {term: '食べる', source: '食べさせられたくなかった', rule: 'v1', reasons: ['causative', 'potential or passive', '-tai', 'negative', 'past']}
-        ]
+            {term: '食べる', source: '食べさせられたくなかった', rule: 'v1', reasons: ['causative', 'potential or passive', '-tai', 'negative', 'past']},
+        ],
     },
     {
         category: 'kawaii',
@@ -1093,15 +1093,15 @@ const tests = [
         tests: [
             {term: 'かわいい', source: 'かわいげ',   rule: 'adj-i', reasons: ['-ge']},
             {term: '可愛い',   source: '可愛げ',   rule: 'adj-i', reasons: ['-ge']},
-            {term: '可愛い',   source: '可愛気',   rule: 'adj-i', reasons: ['-ge']}
-        ]
+            {term: '可愛い',   source: '可愛気',   rule: 'adj-i', reasons: ['-ge']},
+        ],
     },
     {
         category: 'incorrect -te rule chain',
         valid: false,
         tests: [
-            {term: '食べる', source: '食べて', rule: null, reasons: ['-te', 'progressive or perfect', 'masu stem']}
-        ]
+            {term: '食べる', source: '食べて', rule: null, reasons: ['-te', 'progressive or perfect', 'masu stem']},
+        ],
     },
     // Kansai-ben
     {
@@ -1111,8 +1111,8 @@ const tests = [
             {term: '宜しい', source: '宜しゅう', rule: null, reasons: ['adv', 'kansai-ben']},
             {term: 'よろしい', source: 'よろしゅう', rule: null, reasons: ['adv', 'kansai-ben']},
             {term: '良い', source: '良う', rule: null, reasons: ['adv', 'kansai-ben']},
-            {term: 'よい', source: 'よう', rule: null, reasons: ['adv', 'kansai-ben']}
-        ]
+            {term: 'よい', source: 'よう', rule: null, reasons: ['adv', 'kansai-ben']},
+        ],
     },
     {
         category: '-te form of kansai-ben adjectives',
@@ -1121,8 +1121,8 @@ const tests = [
             {term: 'よろしい', source: 'よろしゅうて', rule: null, reasons: ['-te', 'kansai-ben']},
             {term: '宜しい', source: '宜しゅうて', rule: null, reasons: ['-te', 'kansai-ben']},
             {term: 'よい', source: 'ようて', rule: null, reasons: ['-te', 'kansai-ben']},
-            {term: '良い', source: '良うて', rule: null, reasons: ['-te', 'kansai-ben']}
-        ]
+            {term: '良い', source: '良うて', rule: null, reasons: ['-te', 'kansai-ben']},
+        ],
     },
     {
         category: 'Negative form of kansai-ben adjectives',
@@ -1131,16 +1131,16 @@ const tests = [
             {term: 'よろしい', source: 'よろしゅうない', rule: null, reasons: ['negative', 'kansai-ben']},
             {term: '宜しい', source: '宜しゅうない', rule: null, reasons: ['negative', 'kansai-ben']},
             {term: 'よい', source: 'ようない', rule: null, reasons: ['negative', 'kansai-ben']},
-            {term: '良い', source: '良うない', rule: null, reasons: ['negative', 'kansai-ben']}
-        ]
+            {term: '良い', source: '良うない', rule: null, reasons: ['negative', 'kansai-ben']},
+        ],
     },
     {
         category: 'Negative form of kansai-ben verbs',
         valid: true,
         tests: [
             {term: '食べる', source: '食べへん', rule: null, reasons: ['negative', 'kansai-ben']},
-            {term: '食べる', source: '食べへんかった', rule: null, reasons: ['negative', 'past', 'kansai-ben']}
-        ]
+            {term: '食べる', source: '食べへんかった', rule: null, reasons: ['negative', 'past', 'kansai-ben']},
+        ],
     },
     {
         category: '-te form of kansai-ben verbs',
@@ -1148,8 +1148,8 @@ const tests = [
         tests: [
             {term: '買う', source: '買うて', rule: null, reasons: ['-te', 'kansai-ben']},
             {term: 'かう', source: 'こうて', rule: null, reasons: ['-te', 'kansai-ben']},
-            {term: 'はう', source: 'ほうて', rule: null, reasons: ['-te', 'kansai-ben']}
-        ]
+            {term: 'はう', source: 'ほうて', rule: null, reasons: ['-te', 'kansai-ben']},
+        ],
     },
     {
         category: 'past form of kansai-ben terms',
@@ -1157,8 +1157,8 @@ const tests = [
         tests: [
             {term: '買う', source: '買うた', rule: null, reasons: ['past', 'kansai-ben']},
             {term: 'かう', source: 'こうた', rule: null, reasons: ['past', 'kansai-ben']},
-            {term: 'はう', source: 'ほうた', rule: null, reasons: ['past', 'kansai-ben']}
-        ]
+            {term: 'はう', source: 'ほうた', rule: null, reasons: ['past', 'kansai-ben']},
+        ],
     },
     {
         category: '-tara form of kansai-ben terms',
@@ -1166,9 +1166,9 @@ const tests = [
         tests: [
             {term: '買う', source: '買うたら', rule: null, reasons: ['-tara', 'kansai-ben']},
             {term: 'かう', source: 'こうたら', rule: null, reasons: ['-tara', 'kansai-ben']},
-            {term: 'はう', source: 'ほうたら', rule: null, reasons: ['-tara', 'kansai-ben']}
-        ]
-    }
+            {term: 'はう', source: 'ほうたら', rule: null, reasons: ['-tara', 'kansai-ben']},
+        ],
+    },
 ];
 /* eslint-enable @stylistic/no-multi-spaces */
 

--- a/test/language/latin-transforms.test.js
+++ b/test/language/latin-transforms.test.js
@@ -28,8 +28,8 @@ const tests = [
         tests: [
             {term: 'fluvius',   source: 'fluvii',    rule: 'n',   reasons: ['plural']},
             {term: 'magnus',    source: 'magni',     rule: 'adj', reasons: ['plural']},
-            {term: 'insula',    source: 'insulae',   rule: 'n',   reasons: ['plural']}
-        ]
+            {term: 'insula',    source: 'insulae',   rule: 'n',   reasons: ['plural']},
+        ],
     },
     {
         category: 'adjective',
@@ -37,16 +37,16 @@ const tests = [
         tests: [
             {term: 'magnus',    source: 'magna',    rule: 'adj',  reasons: ['feminine']},
             {term: 'Graecus',   source: 'Graecum',  rule: 'adj',  reasons: ['neuter']},
-            {term: 'primus',    source: 'prima',    rule: 'adj',  reasons: ['neuter', 'plural']}
-        ]
+            {term: 'primus',    source: 'prima',    rule: 'adj',  reasons: ['neuter', 'plural']},
+        ],
     },
     {
         category: 'ablative',
         valid: true,
         tests: [
-            {term: 'vocabulum', source: 'vocabulo', rule: 'n',    reasons: ['ablative']}
-        ]
-    }
+            {term: 'vocabulum', source: 'vocabulo', rule: 'n',    reasons: ['ablative']},
+        ],
+    },
 ];
 /* eslint-enable @stylistic/no-multi-spaces */
 

--- a/test/language/spanish-transforms.test.js
+++ b/test/language/spanish-transforms.test.js
@@ -34,15 +34,15 @@ const tests = [
             {term: 'sí', source: 'síes', rule: 'ns', reasons: ['plural']},
             {term: 'zigzag', source: 'zigzags', rule: 'ns', reasons: ['plural']},
             {term: 'luz', source: 'luces', rule: 'ns', reasons: ['plural']},
-            {term: 'canción', source: 'canciones', rule: 'ns', reasons: ['plural']}
-        ]
+            {term: 'canción', source: 'canciones', rule: 'ns', reasons: ['plural']},
+        ],
     },
     {
         category: 'feminine adjectives',
         valid: true,
         tests: [
-            {term: 'rojo', source: 'roja', rule: 'adj', reasons: ['feminine adjective']}
-        ]
+            {term: 'rojo', source: 'roja', rule: 'adj', reasons: ['feminine adjective']},
+        ],
     },
     {
         category: 'present indicative verbs',
@@ -90,9 +90,9 @@ const tests = [
             {term: 'ser', source: 'soy', rule: 'v', reasons: ['present indicative']},
             {term: 'estar', source: 'estoy', rule: 'v', reasons: ['present indicative']},
             {term: 'ir', source: 'voy', rule: 'v', reasons: ['present indicative']},
-            {term: 'haber', source: 'he', rule: 'v', reasons: ['present indicative']}
-        ]
-    }
+            {term: 'haber', source: 'he', rule: 'v', reasons: ['present indicative']},
+        ],
+    },
 ];
 
 const languageTransformer = new LanguageTransformer();

--- a/test/mocks/common.js
+++ b/test/mocks/common.js
@@ -28,8 +28,8 @@ export const chrome = {
     runtime: {
         getURL: (path) => {
             return pathToFileURL(join(extDir, path.replace(/^\//, ''))).href;
-        }
-    }
+        },
+    },
 };
 
 /** @type {import('test/mocks').FetchMock} */
@@ -47,6 +47,6 @@ export async function fetch(url) {
         status: 200,
         statusText: 'OK',
         text: async () => content.toString('utf8'),
-        json: async () => parseJson(content.toString('utf8'))
+        json: async () => parseJson(content.toString('utf8')),
     };
 }

--- a/test/object-property-accessor.test.js
+++ b/test/object-property-accessor.test.js
@@ -28,13 +28,13 @@ function createTestObject() {
         value1: {
             value2: {},
             value3: [],
-            value4: null
+            value4: null,
         },
         value5: [
             {},
             [],
-            null
-        ]
+            null,
+        ],
     };
 }
 
@@ -51,7 +51,7 @@ describe('ObjectPropertyAccessor', () => {
             [['value5'], (object) => object.value5],
             [['value5', 0], (object) => object.value5[0]],
             [['value5', 1], (object) => object.value5[1]],
-            [['value5', 2], (object) => object.value5[2]]
+            [['value5', 2], (object) => object.value5[2]],
         ];
 
         for (const [pathArray, getExpected] of data) {
@@ -87,7 +87,7 @@ describe('ObjectPropertyAccessor', () => {
             [['value5', 2, 'invalid'], 'Invalid path: value5[2].invalid'],
             [['value5', 2, 0], 'Invalid path: value5[2][0]'],
             [['value5', 2, 0, 'invalid'], 'Invalid path: value5[2][0]'],
-            [['value5', 2.5], 'Invalid index']
+            [['value5', 2.5], 'Invalid index'],
         ];
 
         for (const [pathArray, message] of data) {
@@ -107,7 +107,7 @@ describe('ObjectPropertyAccessor', () => {
             ['value5', 0],
             ['value5', 1],
             ['value5', 2],
-            ['value5']
+            ['value5'],
         ];
 
         for (const pathArray of data) {
@@ -137,7 +137,7 @@ describe('ObjectPropertyAccessor', () => {
             [['value5', 2, 'invalid'], 'Invalid path: value5[2].invalid'],
             [['value5', 2, 0], 'Invalid path: value5[2][0]'],
             [['value5', 2, 0, 'invalid'], 'Invalid path: value5[2][0]'],
-            [['value5', 2.5], 'Invalid index']
+            [['value5', 2.5], 'Invalid index'],
         ];
 
         for (const [pathArray, message] of data) {
@@ -160,7 +160,7 @@ describe('ObjectPropertyAccessor', () => {
             [['value1', 'value3'], (object) => !hasOwn(object.value1, 'value3')],
             [['value1', 'value4'], (object) => !hasOwn(object.value1, 'value4')],
             [['value1'], (object) => !hasOwn(object, 'value1')],
-            [['value5'], (object) => !hasOwn(object, 'value5')]
+            [['value5'], (object) => !hasOwn(object, 'value5')],
         ];
 
         for (const [pathArray, validate] of data) {
@@ -189,7 +189,7 @@ describe('ObjectPropertyAccessor', () => {
             [['value5', 2.5], 'Invalid index'],
             [['value5', 0], 'Invalid type'],
             [['value5', 1], 'Invalid type'],
-            [['value5', 2], 'Invalid type']
+            [['value5', 2], 'Invalid type'],
         ];
 
         for (const [pathArray, message] of data) {
@@ -211,7 +211,7 @@ describe('ObjectPropertyAccessor', () => {
             [['value5', 0], true],
             [['value5', 1], true],
             [['value5', 2], true],
-            [['value5'], false]
+            [['value5'], false],
         ];
 
         for (const [pathArray1, compareValues1] of data) {
@@ -242,7 +242,7 @@ describe('ObjectPropertyAccessor', () => {
             [['0'], [], false, 'Invalid path 2'],
             [[], ['0'], false, 'Invalid path 1'],
             [[0], ['0'], false, 'Invalid path 1: [0]'],
-            [['0'], [0], false, 'Invalid path 2: [0]']
+            [['0'], [0], false, 'Invalid path 2: [0]'],
         ];
 
         for (const [pathArray1, pathArray2, checkRevert, message] of data) {
@@ -285,7 +285,7 @@ describe('ObjectPropertyAccessor', () => {
             [['part1', 'part2', '3'], 'part1.part2["3"]'],
             [['part1', 'part2', '3part'], 'part1.part2["3part"]'],
             [['part1', 'part2', '3part', 'part4'], 'part1.part2["3part"].part4'],
-            [['part1', 'part2', '3part', '4part'], 'part1.part2["3part"]["4part"]']
+            [['part1', 'part2', '3part', '4part'], 'part1.part2["3part"]["4part"]'],
         ];
 
         for (const [pathArray, expected] of data) {
@@ -297,7 +297,7 @@ describe('ObjectPropertyAccessor', () => {
         /** @type {[pathArray: unknown[], message: string][]} */
         const data = [
             [[1.5], 'Invalid index'],
-            [[null], 'Invalid type: object']
+            [[null], 'Invalid type: object'],
         ];
 
         for (const [pathArray, message] of data) {
@@ -323,7 +323,7 @@ describe('ObjectPropertyAccessor', () => {
             ['part1.part2["3part"].part4', ['part1', 'part2', '3part', 'part4']],
             ['part1.part2[\'3part\'].part4', ['part1', 'part2', '3part', 'part4']],
             ['part1.part2["3part"]["4part"]', ['part1', 'part2', '3part', '4part']],
-            ['part1.part2[\'3part\'][\'4part\']', ['part1', 'part2', '3part', '4part']]
+            ['part1.part2[\'3part\'][\'4part\']', ['part1', 'part2', '3part', '4part']],
         ];
 
         for (const [pathString, expected] of data) {
@@ -355,7 +355,7 @@ describe('ObjectPropertyAccessor', () => {
             ['part1[""', 'Path not terminated correctly'],
             ['part1[\'\'', 'Path not terminated correctly'],
             ['part1[0', 'Path not terminated correctly'],
-            ['part1[0].', 'Path not terminated correctly']
+            ['part1[0].', 'Path not terminated correctly'],
         ];
 
         for (const [pathString, message] of data) {
@@ -376,7 +376,7 @@ describe('ObjectPropertyAccessor', () => {
             [[0], null, false],
             ['string', 0, false],
             ['string', 'length', false],
-            ['string', null, false]
+            ['string', null, false],
         ];
 
         for (const [object, property, expected] of data) {
@@ -398,7 +398,7 @@ describe('ObjectPropertyAccessor', () => {
             [[0], null, false],
             ['string', 0, false],
             ['string', 'length', false],
-            ['string', null, false]
+            ['string', null, false],
         ];
 
         for (const [object, property, expected] of data) {

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -69,7 +69,7 @@ function createProfileOptionsTestData1() {
             showPitchAccentGraph: false,
             showIframePopupsInRootFrame: false,
             useSecurePopupFrameUrl: true,
-            usePopupShadowDom: true
+            usePopupShadowDom: true,
         },
         audio: {
             enabled: true,
@@ -77,7 +77,7 @@ function createProfileOptionsTestData1() {
             volume: 100,
             autoPlay: false,
             customSourceUrl: 'http://localhost/audio.mp3?term={expression}&reading={reading}',
-            textToSpeechVoice: 'example-voice'
+            textToSpeechVoice: 'example-voice',
         },
         scanning: {
             middleMouse: true,
@@ -94,7 +94,7 @@ function createProfileOptionsTestData1() {
             enableOnPopupExpressions: false,
             enableOnSearchPage: true,
             enableSearchTags: false,
-            layoutAwareScan: false
+            layoutAwareScan: false,
         },
         translation: {
             convertHalfWidthCharacters: 'false',
@@ -102,21 +102,21 @@ function createProfileOptionsTestData1() {
             convertAlphabeticCharacters: 'false',
             convertHiraganaToKatakana: 'false',
             convertKatakanaToHiragana: 'variant',
-            collapseEmphaticSequences: 'false'
+            collapseEmphaticSequences: 'false',
         },
         dictionaries: {
             'Test Dictionary': {
                 priority: 0,
                 enabled: true,
-                allowSecondarySearches: false
-            }
+                allowSecondarySearches: false,
+            },
         },
         parsing: {
             enableScanningParser: true,
             enableMecabParser: false,
             selectedParser: null,
             termSpacing: true,
-            readingMode: 'hiragana'
+            readingMode: 'hiragana',
         },
         anki: {
             enable: false,
@@ -127,8 +127,8 @@ function createProfileOptionsTestData1() {
             terms: {deck: '', model: '', fields: {}},
             kanji: {deck: '', model: '', fields: {}},
             duplicateScope: 'collection',
-            fieldTemplates: null
-        }
+            fieldTemplates: null,
+        },
     };
 }
 
@@ -147,48 +147,48 @@ function createOptionsTestData1() {
                             {
                                 type: 'popupLevel',
                                 operator: 'equal',
-                                value: 1
+                                value: 1,
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'notEqual',
-                                value: 0
+                                value: 0,
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'lessThan',
-                                value: 3
+                                value: 3,
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'greaterThan',
-                                value: 0
+                                value: 0,
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'lessThanOrEqual',
-                                value: 2
+                                value: 2,
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'greaterThanOrEqual',
-                                value: 1
-                            }
-                        ]
+                                value: 1,
+                            },
+                        ],
                     },
                     {
                         conditions: [
                             {
                                 type: 'url',
                                 operator: 'matchDomain',
-                                value: 'example.com'
+                                value: 'example.com',
                             },
                             {
                                 type: 'url',
                                 operator: 'matchRegExp',
-                                value: 'example\\.com'
-                            }
-                        ]
+                                value: 'example\\.com',
+                            },
+                        ],
                     },
                     {
                         conditions: [
@@ -197,39 +197,39 @@ function createOptionsTestData1() {
                                 operator: 'are',
                                 value: [
                                     'ctrl',
-                                    'shift'
-                                ]
+                                    'shift',
+                                ],
                             },
                             {
                                 type: 'modifierKeys',
                                 operator: 'areNot',
                                 value: [
                                     'alt',
-                                    'shift'
-                                ]
+                                    'shift',
+                                ],
                             },
                             {
                                 type: 'modifierKeys',
                                 operator: 'include',
-                                value: 'alt'
+                                value: 'alt',
                             },
                             {
                                 type: 'modifierKeys',
                                 operator: 'notInclude',
-                                value: 'ctrl'
-                            }
-                        ]
-                    }
-                ]
-            }
+                                value: 'ctrl',
+                            },
+                        ],
+                    },
+                ],
+            },
         ],
         profileCurrent: 0,
         version: 2,
         global: {
             database: {
-                prefixWildcardsSupported: false
-            }
-        }
+                prefixWildcardsSupported: false,
+            },
+        },
     };
 }
 
@@ -280,7 +280,7 @@ function createProfileOptionsUpdatedTestData1() {
             frequencyDisplayMode: 'split-tags-grouped',
             termDisplayMode: 'ruby',
             sortFrequencyDictionary: null,
-            sortFrequencyDictionaryOrder: 'descending'
+            sortFrequencyDictionaryOrder: 'descending',
         },
         audio: {
             enabled: true,
@@ -288,21 +288,21 @@ function createProfileOptionsUpdatedTestData1() {
                 {
                     type: 'jpod101',
                     url: '',
-                    voice: ''
+                    voice: '',
                 },
                 {
                     type: 'text-to-speech',
                     url: '',
-                    voice: 'example-voice'
+                    voice: 'example-voice',
                 },
                 {
                     type: 'custom',
                     url: 'http://localhost/audio.mp3?term={term}&reading={reading}',
-                    voice: ''
-                }
+                    voice: '',
+                },
             ],
             volume: 100,
-            autoPlay: false
+            autoPlay: false,
         },
         scanning: {
             touchInputEnabled: true,
@@ -328,7 +328,7 @@ function createProfileOptionsUpdatedTestData1() {
                 onWebPages: false,
                 onPopupPages: false,
                 onSearchPages: false,
-                onSearchQuery: false
+                onSearchQuery: false,
             },
             inputs: [
                 {
@@ -337,7 +337,7 @@ function createProfileOptionsUpdatedTestData1() {
                     types: {
                         mouse: true,
                         touch: false,
-                        pen: false
+                        pen: false,
                     },
                     options: {
                         showAdvanced: false,
@@ -353,8 +353,8 @@ function createProfileOptionsUpdatedTestData1() {
                         scanOnPenPress: true,
                         scanOnPenRelease: false,
                         preventTouchScrolling: true,
-                        preventPenScrolling: true
-                    }
+                        preventPenScrolling: true,
+                    },
                 },
                 {
                     include: 'mouse2',
@@ -362,7 +362,7 @@ function createProfileOptionsUpdatedTestData1() {
                     types: {
                         mouse: true,
                         touch: false,
-                        pen: false
+                        pen: false,
                     },
                     options: {
                         showAdvanced: false,
@@ -378,8 +378,8 @@ function createProfileOptionsUpdatedTestData1() {
                         scanOnPenPress: true,
                         scanOnPenRelease: false,
                         preventTouchScrolling: true,
-                        preventPenScrolling: true
-                    }
+                        preventPenScrolling: true,
+                    },
                 },
                 {
                     include: '',
@@ -387,7 +387,7 @@ function createProfileOptionsUpdatedTestData1() {
                     types: {
                         mouse: false,
                         touch: true,
-                        pen: true
+                        pen: true,
                     },
                     options: {
                         showAdvanced: false,
@@ -403,17 +403,17 @@ function createProfileOptionsUpdatedTestData1() {
                         scanOnPenPress: true,
                         scanOnPenRelease: false,
                         preventTouchScrolling: true,
-                        preventPenScrolling: true
-                    }
-                }
-            ]
+                        preventPenScrolling: true,
+                    },
+                },
+            ],
         },
         translation: {
             searchResolution: 'letter',
             textReplacements: {
                 searchOriginal: true,
-                groups: []
-            }
+                groups: [],
+            },
         },
         dictionaries: [
             {
@@ -423,15 +423,15 @@ function createProfileOptionsUpdatedTestData1() {
                 allowSecondarySearches: false,
                 definitionsCollapsible: 'not-collapsible',
                 partsOfSpeechFilter: true,
-                useDeinflections: true
-            }
+                useDeinflections: true,
+            },
         ],
         parsing: {
             enableScanningParser: true,
             enableMecabParser: false,
             selectedParser: null,
             termSpacing: true,
-            readingMode: 'hiragana'
+            readingMode: 'hiragana',
         },
         anki: {
             enable: false,
@@ -449,7 +449,7 @@ function createProfileOptionsUpdatedTestData1() {
             suspendNewCards: false,
             noteGuiMode: 'browse',
             apiKey: '',
-            downloadTimeout: 0
+            downloadTimeout: 0,
         },
         sentenceParsing: {
             scanExtent: 200,
@@ -470,8 +470,8 @@ function createProfileOptionsUpdatedTestData1() {
                 {enabled: true, character1: '︒', character2: null, includeCharacterAtStart: false, includeCharacterAtEnd: true},
                 {enabled: true, character1: '︕', character2: null, includeCharacterAtStart: false, includeCharacterAtEnd: true},
                 {enabled: true, character1: '︖', character2: null, includeCharacterAtStart: false, includeCharacterAtEnd: true},
-                {enabled: true, character1: '︙', character2: null, includeCharacterAtStart: false, includeCharacterAtEnd: true}
-            ]
+                {enabled: true, character1: '︙', character2: null, includeCharacterAtStart: false, includeCharacterAtEnd: true},
+            ],
         },
         inputs: {
             /* eslint-disable @stylistic/no-multi-spaces */
@@ -493,8 +493,8 @@ function createProfileOptionsUpdatedTestData1() {
                 {action: 'viewNotes',         argument: '',  key: 'KeyV',      modifiers: ['alt'],  scopes: ['popup', 'search'], enabled: true},
                 {action: 'copyHostSelection', argument: '',  key: 'KeyC',      modifiers: ['ctrl'], scopes: ['popup'], enabled: true},
                 {action: 'profilePrevious',   argument: '',  key: 'Minus',     modifiers: ['alt'],  scopes: ['popup', 'search'], enabled: true},
-                {action: 'profileNext',       argument: '',  key: 'Equal',     modifiers: ['alt'],  scopes: ['popup', 'search'], enabled: true}
-            ]
+                {action: 'profileNext',       argument: '',  key: 'Equal',     modifiers: ['alt'],  scopes: ['popup', 'search'], enabled: true},
+            ],
             /* eslint-enable @stylistic/no-multi-spaces */
         },
         popupWindow: {
@@ -505,17 +505,17 @@ function createProfileOptionsUpdatedTestData1() {
             useLeft: false,
             useTop: false,
             windowType: 'popup',
-            windowState: 'normal'
+            windowState: 'normal',
         },
         clipboard: {
             enableBackgroundMonitor: false,
             enableSearchPageMonitor: false,
             autoSearchContent: true,
-            maximumSearchLength: 1000
+            maximumSearchLength: 1000,
         },
         accessibility: {
-            forceGoogleDocsHtmlRendering: false
-        }
+            forceGoogleDocsHtmlRendering: false,
+        },
     };
 }
 
@@ -534,83 +534,83 @@ function createOptionsUpdatedTestData1() {
                             {
                                 type: 'popupLevel',
                                 operator: 'equal',
-                                value: '1'
+                                value: '1',
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'notEqual',
-                                value: '0'
+                                value: '0',
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'lessThan',
-                                value: '3'
+                                value: '3',
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'greaterThan',
-                                value: '0'
+                                value: '0',
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'lessThanOrEqual',
-                                value: '2'
+                                value: '2',
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'greaterThanOrEqual',
-                                value: '1'
-                            }
-                        ]
+                                value: '1',
+                            },
+                        ],
                     },
                     {
                         conditions: [
                             {
                                 type: 'url',
                                 operator: 'matchDomain',
-                                value: 'example.com'
+                                value: 'example.com',
                             },
                             {
                                 type: 'url',
                                 operator: 'matchRegExp',
-                                value: 'example\\.com'
-                            }
-                        ]
+                                value: 'example\\.com',
+                            },
+                        ],
                     },
                     {
                         conditions: [
                             {
                                 type: 'modifierKeys',
                                 operator: 'are',
-                                value: 'ctrl, shift'
+                                value: 'ctrl, shift',
                             },
                             {
                                 type: 'modifierKeys',
                                 operator: 'areNot',
-                                value: 'alt, shift'
+                                value: 'alt, shift',
                             },
                             {
                                 type: 'modifierKeys',
                                 operator: 'include',
-                                value: 'alt'
+                                value: 'alt',
                             },
                             {
                                 type: 'modifierKeys',
                                 operator: 'notInclude',
-                                value: 'ctrl'
-                            }
-                        ]
-                    }
-                ]
-            }
+                                value: 'ctrl',
+                            },
+                        ],
+                    },
+                ],
+            },
         ],
         profileCurrent: 0,
         version: 37,
         global: {
             database: {
-                prefixWildcardsSupported: false
-            }
-        }
+                prefixWildcardsSupported: false,
+            },
+        },
     };
 }
 
@@ -668,7 +668,7 @@ describe('OptionsUtil', () => {
             },
             (options) => {
                 options.profiles[0].options.audio.autoPlay = void 0;
-            }
+            },
         ];
 
         test.each(data)('default-test-%#', async (modify) => {
@@ -704,7 +704,7 @@ describe('OptionsUtil', () => {
             if (match !== null) {
                 updates.push({
                     version: Number.parseInt(match[1], 10),
-                    changes: loadDataFile(path.join(templatesDirPath, match[0]))
+                    changes: loadDataFile(path.join(templatesDirPath, match[0])),
                 });
             }
         }
@@ -742,7 +742,7 @@ describe('OptionsUtil', () => {
 {{/inline}}
 
 <<<UPDATE-ADDITIONS>>>
-{{~> (lookup . "marker") ~}}`.trimStart()
+{{~> (lookup . "marker") ~}}`.trimStart(),
             },
             // Non-standard marker format
             {
@@ -761,7 +761,7 @@ describe('OptionsUtil', () => {
 {{/inline}}
 
 {{~> (lookup . "marker2") ~}}
-<<<UPDATE-ADDITIONS>>>`.trimStart()
+<<<UPDATE-ADDITIONS>>>`.trimStart(),
             },
             // Empty test
             {
@@ -772,7 +772,7 @@ describe('OptionsUtil', () => {
 
                 expected: `
 <<<UPDATE-ADDITIONS>>>
-{{~> (lookup . "marker") ~}}`.trimStart()
+{{~> (lookup . "marker") ~}}`.trimStart(),
             },
             // Definition tags update
             {
@@ -845,7 +845,7 @@ describe('OptionsUtil', () => {
 
 <<<UPDATE-ADDITIONS>>>
 {{~> (lookup . "marker") ~}}
-`.trimStart()
+`.trimStart(),
             },
             // Glossary and glossary-brief update
             {
@@ -985,7 +985,7 @@ describe('OptionsUtil', () => {
 {{/inline}}
 
 <<<UPDATE-ADDITIONS>>>
-{{~> (lookup . "marker") ~}}`.trimStart()
+{{~> (lookup . "marker") ~}}`.trimStart(),
             },
             // formatGlossary update
             {
@@ -1016,7 +1016,7 @@ describe('OptionsUtil', () => {
 {{/inline}}
 
 <<<UPDATE-ADDITIONS>>>
-{{~> (lookup . "marker") ~}}`.trimStart()
+{{~> (lookup . "marker") ~}}`.trimStart(),
             },
             // hasMedia/getMedia update
             {
@@ -1069,7 +1069,7 @@ describe('OptionsUtil', () => {
 {{/inline}}
 
 <<<UPDATE-ADDITIONS>>>
-{{~> (lookup . "marker") ~}}`.trimStart()
+{{~> (lookup . "marker") ~}}`.trimStart(),
             },
             // hasMedia/getMedia update
             {
@@ -1237,7 +1237,7 @@ describe('OptionsUtil', () => {
 {{! End Pitch Accents }}
 
 <<<UPDATE-ADDITIONS>>>
-{{~> (lookup . "marker") ~}}`.trimStart()
+{{~> (lookup . "marker") ~}}`.trimStart(),
             },
             // Block helper update: furigana and furiganaPlain
             {
@@ -1325,7 +1325,7 @@ describe('OptionsUtil', () => {
     {{~/if~}}
 {{/inline}}
 
-{{~> (lookup . "marker") ~}}`.trimStart()
+{{~> (lookup . "marker") ~}}`.trimStart(),
             },
             // Block helper update: formatGlossary
             {
@@ -1399,7 +1399,7 @@ describe('OptionsUtil', () => {
     {{~set "previousDictionary" dictionary~}}
 {{/inline}}
 
-{{~> (lookup . "marker") ~}}`.trimStart()
+{{~> (lookup . "marker") ~}}`.trimStart(),
             },
             // Block helper update: set and get
             {
@@ -1501,7 +1501,7 @@ describe('OptionsUtil', () => {
     {{~/scope~}}
 {{/inline}}
 
-{{~> (lookup . "marker") ~}}`.trimStart()
+{{~> (lookup . "marker") ~}}`.trimStart(),
             },
             // Block helper update: hasMedia and getMedia
             {
@@ -1583,7 +1583,7 @@ describe('OptionsUtil', () => {
     {{~/if~}}
 {{/inline}}
 
-{{~> (lookup . "marker") ~}}`.trimStart()
+{{~> (lookup . "marker") ~}}`.trimStart(),
             },
             // Block helper update: pronunciation
             {
@@ -1601,7 +1601,7 @@ describe('OptionsUtil', () => {
     {{~pronunciation format=format reading=reading downstepPosition=position nasalPositions=nasalPositions devoicePositions=devoicePositions~}}
 {{/inline}}
 
-{{~> (lookup . "marker") ~}}`.trimStart()
+{{~> (lookup . "marker") ~}}`.trimStart(),
             },
             {
                 oldVersion: 21,
@@ -1695,7 +1695,7 @@ describe('OptionsUtil', () => {
 
 {{~#*inline "pitch-accent-categories"~}}
     {{~#each (pitchCategories @root)~}}{{~.~}}{{~#unless @last~}},{{~/unless~}}{{~/each~}}
-{{~/inline~}}`.trimStart()
+{{~/inline~}}`.trimStart(),
             },
             {
                 oldVersion: 24,
@@ -1722,7 +1722,7 @@ describe('OptionsUtil', () => {
         {{~/if~}}
     {{~/if~}}
 {{/inline}}
-`.trimStart()
+`.trimStart(),
             },
             {
                 oldVersion: 32,
@@ -1785,8 +1785,8 @@ describe('OptionsUtil', () => {
 {{#*inline "selection-text"}}
     {{~#if (hasMedia "selectionText")}}{{{getMedia "selectionText"}}}{{/if~}}
 {{/inline}}
-`.trimStart()
-            }
+`.trimStart(),
+            },
         ];
 
         const updatesPattern = /<<<UPDATE-ADDITIONS>>>/g;

--- a/test/playwright/integration.spec.js
+++ b/test/playwright/integration.spec.js
@@ -25,7 +25,7 @@ import {
     mockAnkiRouteHandler,
     root,
     test,
-    writeToClipboardFromPage
+    writeToClipboardFromPage,
 } from './playwright-util.js';
 
 test.beforeEach(async ({context}) => {
@@ -71,7 +71,7 @@ test('anki add', async ({context, page, extensionId}) => {
     await page.locator('input[id="dictionary-import-file-input"]').setInputFiles({
         name: 'valid-dictionary1.zip',
         mimeType: 'application/x-zip',
-        buffer: Buffer.from(dictionary)
+        buffer: Buffer.from(dictionary),
     });
     await expect(page.locator('id=dictionaries')).toHaveText('Dictionaries (1 installed, 1 enabled)', {timeout: 5 * 60 * 1000});
 

--- a/test/playwright/playwright-util.js
+++ b/test/playwright/playwright-util.js
@@ -32,8 +32,8 @@ export const test = base.extend({
             args: [
                 '--headless=new',
                 `--disable-extensions-except=${pathToExtension}`,
-                `--load-extension=${pathToExtension}`
-            ]
+                `--load-extension=${pathToExtension}`,
+            ],
         });
         await use(context);
         await context.close();
@@ -46,7 +46,7 @@ export const test = base.extend({
 
         const extensionId = background.url().split('/')[2];
         await use(extensionId);
-    }
+    },
 });
 
 export const expect = test.expect;
@@ -59,7 +59,7 @@ export function getMockModelFields() {
         ['Word', '{expression}'],
         ['Reading', '{furigana-plain}'],
         ['Sentence', '{clipboard-text}'],
-        ['Audio', '{audio}']
+        ['Audio', '{audio}'],
     ]);
 }
 
@@ -78,7 +78,7 @@ export async function mockAnkiRouteHandler(route) {
         const responseJson = {
             status: 200,
             contentType: 'text/json',
-            body: JSON.stringify(body)
+            body: JSON.stringify(body),
         };
         await route.fulfill(responseJson);
     } catch {
@@ -108,7 +108,7 @@ export function getExpectedAddNoteBody() {
                     Word: '読む',
                     Reading: '読[よ]む',
                     Audio: '[sound:mock_audio.mp3]',
-                    Sentence: '読むの例文'
+                    Sentence: '読むの例文',
                 },
                 tags: ['yomitan'],
                 deckName: 'Mock Deck',
@@ -119,11 +119,11 @@ export function getExpectedAddNoteBody() {
                     duplicateScopeOptions: {
                         deckName: null,
                         checkChildren: false,
-                        checkAllModels: false
-                    }
-                }
-            }
-        }
+                        checkAllModels: false,
+                    },
+                },
+            },
+        },
     };
 }
 

--- a/test/profile-conditions-util.test.js
+++ b/test/profile-conditions-util.test.js
@@ -26,26 +26,26 @@ describe('Profile conditions utilities', () => {
             // Empty
             {
                 context: {index: 0},
-                expected: {index: 0, flags: []}
+                expected: {index: 0, flags: []},
             },
 
             // Domain normalization
             {
                 context: {depth: 0, url: ''},
-                expected: {depth: 0, url: '', flags: []}
+                expected: {depth: 0, url: '', flags: []},
             },
             {
                 context: {depth: 0, url: 'http://example.com/'},
-                expected: {depth: 0, url: 'http://example.com/', domain: 'example.com', flags: []}
+                expected: {depth: 0, url: 'http://example.com/', domain: 'example.com', flags: []},
             },
             {
                 context: {depth: 0, url: 'http://example.com:1234/'},
-                expected: {depth: 0, url: 'http://example.com:1234/', domain: 'example.com', flags: []}
+                expected: {depth: 0, url: 'http://example.com:1234/', domain: 'example.com', flags: []},
             },
             {
                 context: {depth: 0, url: 'http://user@example.com:1234/'},
-                expected: {depth: 0, url: 'http://user@example.com:1234/', domain: 'example.com', flags: []}
-            }
+                expected: {depth: 0, url: 'http://user@example.com:1234/', domain: 'example.com', flags: []},
+            },
         ];
 
         test.each(data)('normalize-context-test-%#', ({context, expected}) => {
@@ -63,27 +63,27 @@ describe('Profile conditions utilities', () => {
                 conditionGroups: [],
                 expectedSchema: {},
                 inputs: [
-                    {expected: true, context: {depth: 0, url: 'http://example.com/'}}
-                ]
-            },
-            {
-                conditionGroups: [
-                    {conditions: []}
+                    {expected: true, context: {depth: 0, url: 'http://example.com/'}},
                 ],
-                expectedSchema: {},
-                inputs: [
-                    {expected: true, context: {depth: 0, url: 'http://example.com/'}}
-                ]
             },
             {
                 conditionGroups: [
                     {conditions: []},
-                    {conditions: []}
                 ],
                 expectedSchema: {},
                 inputs: [
-                    {expected: true, context: {depth: 0, url: 'http://example.com/'}}
-                ]
+                    {expected: true, context: {depth: 0, url: 'http://example.com/'}},
+                ],
+            },
+            {
+                conditionGroups: [
+                    {conditions: []},
+                    {conditions: []},
+                ],
+                expectedSchema: {},
+                inputs: [
+                    {expected: true, context: {depth: 0, url: 'http://example.com/'}},
+                ],
             },
 
             // popupLevel tests
@@ -94,22 +94,22 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'popupLevel',
                                 operator: 'equal',
-                                value: '0'
-                            }
-                        ]
-                    }
+                                value: '0',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
-                        depth: {const: 0}
+                        depth: {const: 0},
                     },
-                    required: ['depth']
+                    required: ['depth'],
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: 'http://example.com/'}},
                     {expected: false, context: {depth: 1, url: 'http://example.com/'}},
-                    {expected: false, context: {depth: -1, url: 'http://example.com/'}}
-                ]
+                    {expected: false, context: {depth: -1, url: 'http://example.com/'}},
+                ],
             },
             {
                 conditionGroups: [
@@ -118,28 +118,28 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'popupLevel',
                                 operator: 'notEqual',
-                                value: '0'
-                            }
-                        ]
-                    }
+                                value: '0',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     not: {
                         anyOf: [
                             {
                                 properties: {
-                                    depth: {const: 0}
+                                    depth: {const: 0},
                                 },
-                                required: ['depth']
-                            }
-                        ]
-                    }
+                                required: ['depth'],
+                            },
+                        ],
+                    },
                 },
                 inputs: [
                     {expected: false, context: {depth: 0, url: 'http://example.com/'}},
                     {expected: true,  context: {depth: 1, url: 'http://example.com/'}},
-                    {expected: true,  context: {depth: -1, url: 'http://example.com/'}}
-                ]
+                    {expected: true,  context: {depth: -1, url: 'http://example.com/'}},
+                ],
             },
             {
                 conditionGroups: [
@@ -148,25 +148,25 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'popupLevel',
                                 operator: 'lessThan',
-                                value: '0'
-                            }
-                        ]
-                    }
+                                value: '0',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
                         depth: {
                             type: 'number',
-                            exclusiveMaximum: 0
-                        }
+                            exclusiveMaximum: 0,
+                        },
                     },
-                    required: ['depth']
+                    required: ['depth'],
                 },
                 inputs: [
                     {expected: false, context: {depth: 0, url: 'http://example.com/'}},
                     {expected: false, context: {depth: 1, url: 'http://example.com/'}},
-                    {expected: true,  context: {depth: -1, url: 'http://example.com/'}}
-                ]
+                    {expected: true,  context: {depth: -1, url: 'http://example.com/'}},
+                ],
             },
             {
                 conditionGroups: [
@@ -175,25 +175,25 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'popupLevel',
                                 operator: 'greaterThan',
-                                value: '0'
-                            }
-                        ]
-                    }
+                                value: '0',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
                         depth: {
                             type: 'number',
-                            exclusiveMinimum: 0
-                        }
+                            exclusiveMinimum: 0,
+                        },
                     },
-                    required: ['depth']
+                    required: ['depth'],
                 },
                 inputs: [
                     {expected: false, context: {depth: 0, url: 'http://example.com/'}},
                     {expected: true,  context: {depth: 1, url: 'http://example.com/'}},
-                    {expected: false, context: {depth: -1, url: 'http://example.com/'}}
-                ]
+                    {expected: false, context: {depth: -1, url: 'http://example.com/'}},
+                ],
             },
             {
                 conditionGroups: [
@@ -202,25 +202,25 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'popupLevel',
                                 operator: 'lessThanOrEqual',
-                                value: '0'
-                            }
-                        ]
-                    }
+                                value: '0',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
                         depth: {
                             type: 'number',
-                            maximum: 0
-                        }
+                            maximum: 0,
+                        },
                     },
-                    required: ['depth']
+                    required: ['depth'],
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: 'http://example.com/'}},
                     {expected: false, context: {depth: 1, url: 'http://example.com/'}},
-                    {expected: true,  context: {depth: -1, url: 'http://example.com/'}}
-                ]
+                    {expected: true,  context: {depth: -1, url: 'http://example.com/'}},
+                ],
             },
             {
                 conditionGroups: [
@@ -229,25 +229,25 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'popupLevel',
                                 operator: 'greaterThanOrEqual',
-                                value: '0'
-                            }
-                        ]
-                    }
+                                value: '0',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
                         depth: {
                             type: 'number',
-                            minimum: 0
-                        }
+                            minimum: 0,
+                        },
                     },
-                    required: ['depth']
+                    required: ['depth'],
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: 'http://example.com/'}},
                     {expected: true,  context: {depth: 1, url: 'http://example.com/'}},
-                    {expected: false, context: {depth: -1, url: 'http://example.com/'}}
-                ]
+                    {expected: false, context: {depth: -1, url: 'http://example.com/'}},
+                ],
             },
 
             // Url tests
@@ -258,28 +258,28 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'url',
                                 operator: 'matchDomain',
-                                value: 'example.com'
-                            }
-                        ]
-                    }
+                                value: 'example.com',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
                         domain: {
                             oneOf: [
-                                {const: 'example.com'}
-                            ]
-                        }
+                                {const: 'example.com'},
+                            ],
+                        },
                     },
-                    required: ['domain']
+                    required: ['domain'],
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: 'http://example.com/'}},
                     {expected: false, context: {depth: 0, url: 'http://example1.com/'}},
                     {expected: false, context: {depth: 0, url: 'http://example2.com/'}},
                     {expected: true,  context: {depth: 0, url: 'http://example.com:1234/'}},
-                    {expected: true,  context: {depth: 0, url: 'http://user@example.com:1234/'}}
-                ]
+                    {expected: true,  context: {depth: 0, url: 'http://user@example.com:1234/'}},
+                ],
             },
             {
                 conditionGroups: [
@@ -288,10 +288,10 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'url',
                                 operator: 'matchDomain',
-                                value: 'example.com, example1.com, example2.com'
-                            }
-                        ]
-                    }
+                                value: 'example.com, example1.com, example2.com',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
@@ -299,11 +299,11 @@ describe('Profile conditions utilities', () => {
                             oneOf: [
                                 {const: 'example.com'},
                                 {const: 'example1.com'},
-                                {const: 'example2.com'}
-                            ]
-                        }
+                                {const: 'example2.com'},
+                            ],
+                        },
                     },
-                    required: ['domain']
+                    required: ['domain'],
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: 'http://example.com/'}},
@@ -311,8 +311,8 @@ describe('Profile conditions utilities', () => {
                     {expected: true,  context: {depth: 0, url: 'http://example2.com/'}},
                     {expected: false, context: {depth: 0, url: 'http://example3.com/'}},
                     {expected: true,  context: {depth: 0, url: 'http://example.com:1234/'}},
-                    {expected: true,  context: {depth: 0, url: 'http://user@example.com:1234/'}}
-                ]
+                    {expected: true,  context: {depth: 0, url: 'http://user@example.com:1234/'}},
+                ],
             },
             {
                 conditionGroups: [
@@ -321,20 +321,20 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'url',
                                 operator: 'matchRegExp',
-                                value: '^http://example\\d?\\.com/[\\w\\W]*$'
-                            }
-                        ]
-                    }
+                                value: '^http://example\\d?\\.com/[\\w\\W]*$',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
                         url: {
                             type: 'string',
                             pattern: '^http://example\\d?\\.com/[\\w\\W]*$',
-                            patternFlags: 'i'
-                        }
+                            patternFlags: 'i',
+                        },
                     },
-                    required: ['url']
+                    required: ['url'],
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: 'http://example.com/'}},
@@ -344,8 +344,8 @@ describe('Profile conditions utilities', () => {
                     {expected: true,  context: {depth: 0, url: 'http://example.com/example'}},
                     {expected: false, context: {depth: 0, url: 'http://example.com:1234/'}},
                     {expected: false, context: {depth: 0, url: 'http://user@example.com:1234/'}},
-                    {expected: false, context: {depth: 0, url: 'http://example-1.com/'}}
-                ]
+                    {expected: false, context: {depth: 0, url: 'http://example-1.com/'}},
+                ],
             },
 
             // modifierKeys tests
@@ -356,27 +356,27 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'modifierKeys',
                                 operator: 'are',
-                                value: ''
-                            }
-                        ]
-                    }
+                                value: '',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
                         modifierKeys: {
                             type: 'array',
                             maxItems: 0,
-                            minItems: 0
-                        }
+                            minItems: 0,
+                        },
                     },
-                    required: ['modifierKeys']
+                    required: ['modifierKeys'],
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: []}},
                     {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt']}},
                     {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift']}},
-                    {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}}
-                ]
+                    {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -385,10 +385,10 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'modifierKeys',
                                 operator: 'are',
-                                value: 'alt, shift'
-                            }
-                        ]
-                    }
+                                value: 'alt, shift',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
@@ -398,18 +398,18 @@ describe('Profile conditions utilities', () => {
                             minItems: 2,
                             allOf: [
                                 {contains: {const: 'alt'}},
-                                {contains: {const: 'shift'}}
-                            ]
-                        }
+                                {contains: {const: 'shift'}},
+                            ],
+                        },
                     },
-                    required: ['modifierKeys']
+                    required: ['modifierKeys'],
                 },
                 inputs: [
                     {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: []}},
                     {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt']}},
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift']}},
-                    {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}}
-                ]
+                    {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -418,10 +418,10 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'modifierKeys',
                                 operator: 'areNot',
-                                value: ''
-                            }
-                        ]
-                    }
+                                value: '',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     not: {
@@ -431,20 +431,20 @@ describe('Profile conditions utilities', () => {
                                     modifierKeys: {
                                         type: 'array',
                                         maxItems: 0,
-                                        minItems: 0
-                                    }
+                                        minItems: 0,
+                                    },
                                 },
-                                required: ['modifierKeys']
-                            }
-                        ]
-                    }
+                                required: ['modifierKeys'],
+                            },
+                        ],
+                    },
                 },
                 inputs: [
                     {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: []}},
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt']}},
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift']}},
-                    {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}}
-                ]
+                    {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -453,10 +453,10 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'modifierKeys',
                                 operator: 'areNot',
-                                value: 'alt, shift'
-                            }
-                        ]
-                    }
+                                value: 'alt, shift',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     not: {
@@ -469,21 +469,21 @@ describe('Profile conditions utilities', () => {
                                         minItems: 2,
                                         allOf: [
                                             {contains: {const: 'alt'}},
-                                            {contains: {const: 'shift'}}
-                                        ]
-                                    }
+                                            {contains: {const: 'shift'}},
+                                        ],
+                                    },
                                 },
-                                required: ['modifierKeys']
-                            }
-                        ]
-                    }
+                                required: ['modifierKeys'],
+                            },
+                        ],
+                    },
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: []}},
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt']}},
                     {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift']}},
-                    {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}}
-                ]
+                    {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -492,26 +492,26 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'modifierKeys',
                                 operator: 'include',
-                                value: ''
-                            }
-                        ]
-                    }
+                                value: '',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
                         modifierKeys: {
                             type: 'array',
-                            minItems: 0
-                        }
+                            minItems: 0,
+                        },
                     },
-                    required: ['modifierKeys']
+                    required: ['modifierKeys'],
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: []}},
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt']}},
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift']}},
-                    {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}}
-                ]
+                    {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -520,10 +520,10 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'modifierKeys',
                                 operator: 'include',
-                                value: 'alt, shift'
-                            }
-                        ]
-                    }
+                                value: 'alt, shift',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
@@ -532,18 +532,18 @@ describe('Profile conditions utilities', () => {
                             minItems: 2,
                             allOf: [
                                 {contains: {const: 'alt'}},
-                                {contains: {const: 'shift'}}
-                            ]
-                        }
+                                {contains: {const: 'shift'}},
+                            ],
+                        },
                     },
-                    required: ['modifierKeys']
+                    required: ['modifierKeys'],
                 },
                 inputs: [
                     {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: []}},
                     {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt']}},
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift']}},
-                    {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}}
-                ]
+                    {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -552,25 +552,25 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'modifierKeys',
                                 operator: 'notInclude',
-                                value: ''
-                            }
-                        ]
-                    }
+                                value: '',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
                         modifierKeys: {
-                            type: 'array'
-                        }
+                            type: 'array',
+                        },
                     },
-                    required: ['modifierKeys']
+                    required: ['modifierKeys'],
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: []}},
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt']}},
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift']}},
-                    {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}}
-                ]
+                    {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -579,10 +579,10 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'modifierKeys',
                                 operator: 'notInclude',
-                                value: 'alt, shift'
-                            }
-                        ]
-                    }
+                                value: 'alt, shift',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     properties: {
@@ -591,19 +591,19 @@ describe('Profile conditions utilities', () => {
                             not: {
                                 anyOf: [
                                     {contains: {const: 'alt'}},
-                                    {contains: {const: 'shift'}}
-                                ]
-                            }
-                        }
+                                    {contains: {const: 'shift'}},
+                                ],
+                            },
+                        },
                     },
-                    required: ['modifierKeys']
+                    required: ['modifierKeys'],
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: 'http://example.com/', modifierKeys: []}},
                     {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt']}},
                     {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift']}},
-                    {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}}
-                ]
+                    {expected: false, context: {depth: 0, url: 'http://example.com/', modifierKeys: ['alt', 'shift', 'ctrl']}},
+                ],
             },
 
             // Flags tests
@@ -614,10 +614,10 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'flags',
                                 operator: 'are',
-                                value: ''
-                            }
-                        ]
-                    }
+                                value: '',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     required: ['flags'],
@@ -625,9 +625,9 @@ describe('Profile conditions utilities', () => {
                         flags: {
                             type: 'array',
                             maxItems: 0,
-                            minItems: 0
-                        }
-                    }
+                            minItems: 0,
+                        },
+                    },
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: ''}},
@@ -636,8 +636,8 @@ describe('Profile conditions utilities', () => {
                     // @ts-expect-error - Ignore type for string flag for testing purposes
                     {expected: false, context: {depth: 0, url: '', flags: ['clipboard', 'test2']}},
                     // @ts-expect-error - Ignore type for string flag for testing purposes
-                    {expected: false, context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}}
-                ]
+                    {expected: false, context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -646,10 +646,10 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'flags',
                                 operator: 'are',
-                                value: 'clipboard, test2'
-                            }
-                        ]
-                    }
+                                value: 'clipboard, test2',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     required: ['flags'],
@@ -660,10 +660,10 @@ describe('Profile conditions utilities', () => {
                             minItems: 2,
                             allOf: [
                                 {contains: {const: 'clipboard'}},
-                                {contains: {const: 'test2'}}
-                            ]
-                        }
-                    }
+                                {contains: {const: 'test2'}},
+                            ],
+                        },
+                    },
                 },
                 inputs: [
                     {expected: false, context: {depth: 0, url: ''}},
@@ -672,8 +672,8 @@ describe('Profile conditions utilities', () => {
                     // @ts-expect-error - Ignore type for string flag for testing purposes
                     {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2']}},
                     // @ts-expect-error - Ignore type for string flag for testing purposes
-                    {expected: false, context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}}
-                ]
+                    {expected: false, context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -682,10 +682,10 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'flags',
                                 operator: 'areNot',
-                                value: ''
-                            }
-                        ]
-                    }
+                                value: '',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     not: {
@@ -696,12 +696,12 @@ describe('Profile conditions utilities', () => {
                                     flags: {
                                         type: 'array',
                                         maxItems: 0,
-                                        minItems: 0
-                                    }
-                                }
-                            }
-                        ]
-                    }
+                                        minItems: 0,
+                                    },
+                                },
+                            },
+                        ],
+                    },
                 },
                 inputs: [
                     {expected: false, context: {depth: 0, url: ''}},
@@ -710,8 +710,8 @@ describe('Profile conditions utilities', () => {
                     // @ts-expect-error - Ignore type for string flag for testing purposes
                     {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2']}},
                     // @ts-expect-error - Ignore type for string flag for testing purposes
-                    {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}}
-                ]
+                    {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -720,10 +720,10 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'flags',
                                 operator: 'areNot',
-                                value: 'clipboard, test2'
-                            }
-                        ]
-                    }
+                                value: 'clipboard, test2',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     not: {
@@ -737,13 +737,13 @@ describe('Profile conditions utilities', () => {
                                         minItems: 2,
                                         allOf: [
                                             {contains: {const: 'clipboard'}},
-                                            {contains: {const: 'test2'}}
-                                        ]
-                                    }
-                                }
-                            }
-                        ]
-                    }
+                                            {contains: {const: 'test2'}},
+                                        ],
+                                    },
+                                },
+                            },
+                        ],
+                    },
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: ''}},
@@ -752,8 +752,8 @@ describe('Profile conditions utilities', () => {
                     // @ts-expect-error - Ignore type for string flag for testing purposes
                     {expected: false, context: {depth: 0, url: '', flags: ['clipboard', 'test2']}},
                     // @ts-expect-error - Ignore type for string flag for testing purposes
-                    {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}}
-                ]
+                    {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -762,19 +762,19 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'flags',
                                 operator: 'include',
-                                value: ''
-                            }
-                        ]
-                    }
+                                value: '',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     required: ['flags'],
                     properties: {
                         flags: {
                             type: 'array',
-                            minItems: 0
-                        }
-                    }
+                            minItems: 0,
+                        },
+                    },
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: ''}},
@@ -783,8 +783,8 @@ describe('Profile conditions utilities', () => {
                     // @ts-expect-error - Ignore type for string flag for testing purposes
                     {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2']}},
                     // @ts-expect-error - Ignore type for string flag for testing purposes
-                    {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}}
-                ]
+                    {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -793,10 +793,10 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'flags',
                                 operator: 'include',
-                                value: 'clipboard, test2'
-                            }
-                        ]
-                    }
+                                value: 'clipboard, test2',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     required: ['flags'],
@@ -806,10 +806,10 @@ describe('Profile conditions utilities', () => {
                             minItems: 2,
                             allOf: [
                                 {contains: {const: 'clipboard'}},
-                                {contains: {const: 'test2'}}
-                            ]
-                        }
-                    }
+                                {contains: {const: 'test2'}},
+                            ],
+                        },
+                    },
                 },
                 inputs: [
                     {expected: false, context: {depth: 0, url: ''}},
@@ -818,8 +818,8 @@ describe('Profile conditions utilities', () => {
                     // @ts-expect-error - Ignore type for string flag for testing purposes
                     {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2']}},
                     // @ts-expect-error - Ignore type for string flag for testing purposes
-                    {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}}
-                ]
+                    {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -828,18 +828,18 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'flags',
                                 operator: 'notInclude',
-                                value: ''
-                            }
-                        ]
-                    }
+                                value: '',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     required: ['flags'],
                     properties: {
                         flags: {
-                            type: 'array'
-                        }
-                    }
+                            type: 'array',
+                        },
+                    },
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: ''}},
@@ -848,8 +848,8 @@ describe('Profile conditions utilities', () => {
                     // @ts-expect-error - Ignore type for string flag for testing purposes
                     {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2']}},
                     // @ts-expect-error - Ignore type for string flag for testing purposes
-                    {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}}
-                ]
+                    {expected: true,  context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}},
+                ],
             },
             {
                 conditionGroups: [
@@ -858,10 +858,10 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'flags',
                                 operator: 'notInclude',
-                                value: 'clipboard, test2'
-                            }
-                        ]
-                    }
+                                value: 'clipboard, test2',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     required: ['flags'],
@@ -871,11 +871,11 @@ describe('Profile conditions utilities', () => {
                             not: {
                                 anyOf: [
                                     {contains: {const: 'clipboard'}},
-                                    {contains: {const: 'test2'}}
-                                ]
-                            }
-                        }
-                    }
+                                    {contains: {const: 'test2'}},
+                                ],
+                            },
+                        },
+                    },
                 },
                 inputs: [
                     {expected: true,  context: {depth: 0, url: ''}},
@@ -884,8 +884,8 @@ describe('Profile conditions utilities', () => {
                     // @ts-expect-error - Ignore type for string flag for testing purposes
                     {expected: false, context: {depth: 0, url: '', flags: ['clipboard', 'test2']}},
                     // @ts-expect-error - Ignore type for string flag for testing purposes
-                    {expected: false, context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}}
-                ]
+                    {expected: false, context: {depth: 0, url: '', flags: ['clipboard', 'test2', 'test3']}},
+                ],
             },
 
             // Multiple conditions tests
@@ -896,15 +896,15 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'popupLevel',
                                 operator: 'greaterThan',
-                                value: '0'
+                                value: '0',
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'lessThan',
-                                value: '3'
-                            }
-                        ]
-                    }
+                                value: '3',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     allOf: [
@@ -912,21 +912,21 @@ describe('Profile conditions utilities', () => {
                             properties: {
                                 depth: {
                                     type: 'number',
-                                    exclusiveMinimum: 0
-                                }
+                                    exclusiveMinimum: 0,
+                                },
                             },
-                            required: ['depth']
+                            required: ['depth'],
                         },
                         {
                             properties: {
                                 depth: {
                                     type: 'number',
-                                    exclusiveMaximum: 3
-                                }
+                                    exclusiveMaximum: 3,
+                                },
                             },
-                            required: ['depth']
-                        }
-                    ]
+                            required: ['depth'],
+                        },
+                    ],
                 },
                 inputs: [
                     {expected: false, context: {depth: -2, url: 'http://example.com/'}},
@@ -934,8 +934,8 @@ describe('Profile conditions utilities', () => {
                     {expected: false, context: {depth: 0, url: 'http://example.com/'}},
                     {expected: true,  context: {depth: 1, url: 'http://example.com/'}},
                     {expected: true,  context: {depth: 2, url: 'http://example.com/'}},
-                    {expected: false, context: {depth: 3, url: 'http://example.com/'}}
-                ]
+                    {expected: false, context: {depth: 3, url: 'http://example.com/'}},
+                ],
             },
             {
                 conditionGroups: [
@@ -944,24 +944,24 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'popupLevel',
                                 operator: 'greaterThan',
-                                value: '0'
+                                value: '0',
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'lessThan',
-                                value: '3'
-                            }
-                        ]
+                                value: '3',
+                            },
+                        ],
                     },
                     {
                         conditions: [
                             {
                                 type: 'popupLevel',
                                 operator: 'equal',
-                                value: '0'
-                            }
-                        ]
-                    }
+                                value: '0',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     anyOf: [
@@ -971,29 +971,29 @@ describe('Profile conditions utilities', () => {
                                     properties: {
                                         depth: {
                                             type: 'number',
-                                            exclusiveMinimum: 0
-                                        }
+                                            exclusiveMinimum: 0,
+                                        },
                                     },
-                                    required: ['depth']
+                                    required: ['depth'],
                                 },
                                 {
                                     properties: {
                                         depth: {
                                             type: 'number',
-                                            exclusiveMaximum: 3
-                                        }
+                                            exclusiveMaximum: 3,
+                                        },
                                     },
-                                    required: ['depth']
-                                }
-                            ]
+                                    required: ['depth'],
+                                },
+                            ],
                         },
                         {
                             properties: {
-                                depth: {const: 0}
+                                depth: {const: 0},
                             },
-                            required: ['depth']
-                        }
-                    ]
+                            required: ['depth'],
+                        },
+                    ],
                 },
                 inputs: [
                     {expected: false, context: {depth: -2, url: 'http://example.com/'}},
@@ -1001,8 +1001,8 @@ describe('Profile conditions utilities', () => {
                     {expected: true,  context: {depth: 0, url: 'http://example.com/'}},
                     {expected: true,  context: {depth: 1, url: 'http://example.com/'}},
                     {expected: true,  context: {depth: 2, url: 'http://example.com/'}},
-                    {expected: false, context: {depth: 3, url: 'http://example.com/'}}
-                ]
+                    {expected: false, context: {depth: 3, url: 'http://example.com/'}},
+                ],
             },
             {
                 conditionGroups: [
@@ -1011,29 +1011,29 @@ describe('Profile conditions utilities', () => {
                             {
                                 type: 'popupLevel',
                                 operator: 'greaterThan',
-                                value: '0'
+                                value: '0',
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'lessThan',
-                                value: '3'
-                            }
-                        ]
+                                value: '3',
+                            },
+                        ],
                     },
                     {
                         conditions: [
                             {
                                 type: 'popupLevel',
                                 operator: 'lessThanOrEqual',
-                                value: '0'
+                                value: '0',
                             },
                             {
                                 type: 'popupLevel',
                                 operator: 'greaterThanOrEqual',
-                                value: '-1'
-                            }
-                        ]
-                    }
+                                value: '-1',
+                            },
+                        ],
+                    },
                 ],
                 expectedSchema: {
                     anyOf: [
@@ -1043,21 +1043,21 @@ describe('Profile conditions utilities', () => {
                                     properties: {
                                         depth: {
                                             type: 'number',
-                                            exclusiveMinimum: 0
-                                        }
+                                            exclusiveMinimum: 0,
+                                        },
                                     },
-                                    required: ['depth']
+                                    required: ['depth'],
                                 },
                                 {
                                     properties: {
                                         depth: {
                                             type: 'number',
-                                            exclusiveMaximum: 3
-                                        }
+                                            exclusiveMaximum: 3,
+                                        },
                                     },
-                                    required: ['depth']
-                                }
-                            ]
+                                    required: ['depth'],
+                                },
+                            ],
                         },
                         {
                             allOf: [
@@ -1065,23 +1065,23 @@ describe('Profile conditions utilities', () => {
                                     properties: {
                                         depth: {
                                             type: 'number',
-                                            maximum: 0
-                                        }
+                                            maximum: 0,
+                                        },
                                     },
-                                    required: ['depth']
+                                    required: ['depth'],
                                 },
                                 {
                                     properties: {
                                         depth: {
                                             type: 'number',
-                                            minimum: -1
-                                        }
+                                            minimum: -1,
+                                        },
                                     },
-                                    required: ['depth']
-                                }
-                            ]
-                        }
-                    ]
+                                    required: ['depth'],
+                                },
+                            ],
+                        },
+                    ],
                 },
                 inputs: [
                     {expected: false, context: {depth: -2, url: 'http://example.com/'}},
@@ -1089,9 +1089,9 @@ describe('Profile conditions utilities', () => {
                     {expected: true,  context: {depth: 0, url: 'http://example.com/'}},
                     {expected: true,  context: {depth: 1, url: 'http://example.com/'}},
                     {expected: true,  context: {depth: 2, url: 'http://example.com/'}},
-                    {expected: false, context: {depth: 3, url: 'http://example.com/'}}
-                ]
-            }
+                    {expected: false, context: {depth: 3, url: 'http://example.com/'}},
+                ],
+            },
         ];
         /* eslint-enable @stylistic/no-multi-spaces */
 

--- a/test/search-display-controller.test.js
+++ b/test/search-display-controller.test.js
@@ -66,7 +66,7 @@ describe('Keyboard Event Handling', () => {
     const validKeypressEvents = [
         new KeyboardEvent('keydown', {key: 'a', ctrlKey: false, metaKey: false, altKey: false}),
         new KeyboardEvent('keydown', {key: 'Backspace'}),
-        new KeyboardEvent('keydown', {key: 'Backspace', ctrlKey: true, metaKey: false, altKey: false})
+        new KeyboardEvent('keydown', {key: 'Backspace', ctrlKey: true, metaKey: false, altKey: false}),
     ];
 
     const invalidKeypressEvents = [
@@ -79,7 +79,7 @@ describe('Keyboard Event Handling', () => {
         new KeyboardEvent('keydown', {key: 'a', ctrlKey: false, metaKey: false, altKey: true}),
         new KeyboardEvent('keydown', {key: 'Backspace', ctrlKey: false, metaKey: true, altKey: false}),
         new KeyboardEvent('keydown', {key: 'Backspace', ctrlKey: false, metaKey: false, altKey: true}),
-        new KeyboardEvent('keydown', {key: 'ArrowDown'})
+        new KeyboardEvent('keydown', {key: 'ArrowDown'}),
     ];
 
     test('should test that onKeyDown function focuses input for valid keys', () => {

--- a/test/utilities/anki.js
+++ b/test/utilities/anki.js
@@ -53,9 +53,9 @@ export function createTestAnkiNoteData(dictionaryEntry, mode) {
             sentence: {text: '', offset: 0},
             documentTitle: 'title',
             query: 'query',
-            fullQuery: 'fullQuery'
+            fullQuery: 'fullQuery',
         },
-        media: {}
+        media: {},
     };
     return createAnkiNoteData(marker, data);
 }
@@ -91,11 +91,11 @@ export async function getTemplateRenderResults(dictionaryEntries, mode, template
             url: 'url:',
             sentence: {
                 text: `${clozePrefix}${source}${clozeSuffix}`,
-                offset: clozePrefix.length
+                offset: clozePrefix.length,
             },
             documentTitle: 'title',
             query: 'query',
-            fullQuery: 'fullQuery'
+            fullQuery: 'fullQuery',
         };
         /** @type {import('anki-note-builder').CreateNoteDetails} */
         const details = {
@@ -113,7 +113,7 @@ export async function getTemplateRenderResults(dictionaryEntries, mode, template
             glossaryLayoutMode: 'default',
             compactTags: false,
             requirements: [],
-            mediaOptions: null
+            mediaOptions: null,
         };
         const {note: {fields: noteFields}, errors} = await ankiNoteBuilder.createNote(details);
         for (const error of errors) {

--- a/test/utilities/translator.js
+++ b/test/utilities/translator.js
@@ -78,7 +78,7 @@ export function createFindKanjiOptions(dictionaryName, optionsPresets, optionsAr
 
     return {
         enabledDictionaryMap,
-        removeNonJapaneseCharacters: !!preset.removeNonJapaneseCharacters
+        removeNonJapaneseCharacters: !!preset.removeNonJapaneseCharacters,
     };
 }
 
@@ -126,7 +126,7 @@ export function createFindTermsOptions(dictionaryName, optionsPresets, optionsAr
         removeNonJapaneseCharacters,
         excludeDictionaryDefinitions,
         searchResolution,
-        language
+        language,
     } = preset;
 
     return {
@@ -140,6 +140,6 @@ export function createFindTermsOptions(dictionaryName, optionsPresets, optionsAr
         enabledDictionaryMap,
         excludeDictionaryDefinitions: Array.isArray(excludeDictionaryDefinitions) ? new Set(excludeDictionaryDefinitions) : null,
         searchResolution: typeof searchResolution !== 'undefined' ? searchResolution : 'letter',
-        language: typeof language !== 'undefined' ? language : 'ja'
+        language: typeof language !== 'undefined' ? language : 'ja',
     };
 }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -25,12 +25,12 @@ export default defineConfig({
             ...configDefaults.exclude,
             'dev/lib/**',
             'test/playwright/**',
-            'test/json.test.js'
+            'test/json.test.js',
         ],
         poolOptions: {
             threads: {
-                useAtomics: true
-            }
-        }
-    }
+                useAtomics: true,
+            },
+        },
+    },
 });


### PR DESCRIPTION
Set comma-dangle to `always-multiline` and then fix subsequent lint errors

Documentation referenced: https://eslint.style/rules/js/comma-dangle

Closes #1012 