### PR TITLE
[sh] preprocess accent marks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -660,6 +660,7 @@
                 "ext/js/language/multi-language-transformer.js",
                 "ext/js/language/ru/russian-text-preprocessors.js",
                 "ext/js/language/sga/old-irish-transforms.js",
+                "ext/js/language/sh/serbo-croatian-text-preprocessors.js",
                 "ext/js/language/sq/albanian-transforms.js",
                 "ext/js/language/text-processors.js",
                 "ext/js/language/translator.js",

--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -34,6 +34,7 @@ import {koreanTransforms} from './ko/korean-transforms.js';
 import {latinTransforms} from './la/latin-transforms.js';
 import {removeRussianDiacritics, yoToE} from './ru/russian-text-preprocessors.js';
 import {oldIrishTransforms} from './sga/old-irish-transforms.js';
+import {removeSerboCroatianAccentMarks} from './sh/serbo-croatian-text-preprocessors.js';
 import {albanianTransforms} from './sq/albanian-transforms.js';
 import {capitalizeFirstLetter, decapitalize, removeAlphabeticDiacritics} from './text-processors.js';
 import {isStringPartiallyChinese} from './zh/chinese.js';
@@ -224,7 +225,10 @@ const languageDescriptors = [
         iso: 'sh',
         name: 'Serbo-Croatian',
         exampleText: 'čitaše',
-        textPreprocessors: capitalizationPreprocessors,
+        textPreprocessors: {
+            ...capitalizationPreprocessors,
+            removeSerboCroatianAccentMarks,
+        },
     },
     {
         iso: 'sq',

--- a/ext/js/language/sh/serbo-croatian-text-preprocessors.js
+++ b/ext/js/language/sh/serbo-croatian-text-preprocessors.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {basicTextProcessorOptions} from '../text-processors.js';
+
+/** @type {import('language').TextProcessor<boolean>} */
+export const removeSerboCroatianAccentMarks = {
+    name: 'Remove diacritics',
+    description: 'A\u0301 → A, a\u0301 → a',
+    options: basicTextProcessorOptions,
+    process: (str, setting) => (
+        setting ?
+            str.normalize('NFD').replace(/[aeiourAEIOUR][\u0300-\u036f]/g, (match) => match[0]) :
+            str
+    ),
+
+};

--- a/types/ext/language-descriptors.d.ts
+++ b/types/ext/language-descriptors.d.ts
@@ -157,7 +157,9 @@ type AllTextProcessors = {
         };
     };
     sh: {
-        pre: CapitalizationPreprocessors;
+        pre: CapitalizationPreprocessors & {
+            removeSerboCroatianAccentMarks: TextProcessor<boolean>;
+        };
     };
     sq: {
         pre: CapitalizationPreprocessors;


### PR DESCRIPTION
This differs from the existing latin diacritics prepocessors in that čćžš and maybe some others need to be kept, but vowel accent marks need to be removed.