### PR TITLE
Add text length check to isTextLookupWorthy

### DIFF
--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -1619,7 +1619,7 @@ export class TextScanner extends EventDispatcher {
      */
     async _isTextLookupWorthy(text) {
         try {
-            return this._language !== null && await this._api.isTextLookupWorthy(text, this._language);
+            return this._language !== null && text.length > 0 && await this._api.isTextLookupWorthy(text, this._language);
         } catch (e) {
             return false;
         }


### PR DESCRIPTION
Fixes #1011 

Japanese was working because of [this line](https://github.com/themoeway/yomitan/blob/b6341f312d8332ccff0d928d936e9290da0e9584/ext/js/language/ja/japanese.js#L340). Other languages haven't implemented `isTextLookupWorthy` so it pops up for other languages

Tested on youtube by holding the modifier key and hovering over buttons -> no popup

Tested normal functionality by scanning to false positives.