### PR TITLE
Add canary benchmark

### DIFF
--- a/benches/canary.bench.js
+++ b/benches/canary.bench.js
@@ -19,7 +19,7 @@ import {bench, describe} from 'vitest';
 
 
 describe('Canary', () => {
-    bench('Loop 1 through 10,000', async () => {
+    bench('Loop 1 through 100,000', async () => {
         for (let i = 0; i < 10000; i++) {
             // Do nothing
         }

--- a/benches/canary.bench.js
+++ b/benches/canary.bench.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {bench, describe} from 'vitest';
+
+
+describe('Canary', () => {
+    bench('Loop 1 through 10,000', async () => {
+        for (let i = 0; i < 10000; i++) {
+            // Do nothing
+        }
+    });
+});

--- a/benches/canary.bench.js
+++ b/benches/canary.bench.js
@@ -20,8 +20,10 @@ import {bench, describe} from 'vitest';
 
 describe('Canary', () => {
     bench('Loop 1 through 100,000', async () => {
+        let sum = 0;
         for (let i = 0; i < 10000; i++) {
-            // Do nothing
+            sum += i;
         }
+        console.debug(sum);
     });
 });


### PR DESCRIPTION
Add a canary benchmark to detect if there is noisy in our testing environment. This should not change or fluctuate too much or it would indicate flakiness.

Closes #892 