### PR TITLE
[es] Change example word to 'leer'

### DIFF
--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -80,7 +80,7 @@ const languageDescriptors = [
     {
         iso: 'es',
         name: 'Spanish',
-        exampleText: 'acabar de',
+        exampleText: 'leer',
         textPreprocessors: capitalizationPreprocessors,
         languageTransforms: spanishTransforms,
     },


### PR DESCRIPTION
### Summary
This PR updates the spanish dictionary sample word from "acabar de" to "leer".

### Changes
- Updated language-descriptors.js line 83

### Related Issues
- Fixes #1052

### Context and Motivation
Reports of "leer" being a better more standardized example