### PR TITLE
romanian text preprocessors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -658,6 +658,7 @@
                 "ext/js/language/language-transforms.js",
                 "ext/js/language/languages.js",
                 "ext/js/language/multi-language-transformer.js",
+                "ext/js/language/ro/romanian-text-preprocessors.js",
                 "ext/js/language/ru/russian-text-preprocessors.js",
                 "ext/js/language/sga/old-irish-transforms.js",
                 "ext/js/language/sh/serbo-croatian-text-preprocessors.js",

--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -32,6 +32,7 @@ import {isStringPartiallyJapanese} from './ja/japanese.js';
 import {disassembleHangul, reassembleHangul} from './ko/korean-text-processors.js';
 import {koreanTransforms} from './ko/korean-transforms.js';
 import {latinTransforms} from './la/latin-transforms.js';
+import {removeRomanianDiacritics} from './ro/romanian-text-preprocessors.js';
 import {removeRussianDiacritics, yoToE} from './ru/russian-text-preprocessors.js';
 import {oldIrishTransforms} from './sga/old-irish-transforms.js';
 import {removeSerboCroatianAccentMarks} from './sh/serbo-croatian-text-preprocessors.js';
@@ -199,7 +200,10 @@ const languageDescriptors = [
         iso: 'ro',
         name: 'Romanian',
         exampleText: 'citit',
-        textPreprocessors: capitalizationPreprocessors,
+        textPreprocessors: {
+            ...capitalizationPreprocessors,
+            removeRomanianDiacritics,
+        },
     },
     {
         iso: 'ru',

--- a/ext/js/language/ro/romanian-text-preprocessors.js
+++ b/ext/js/language/ro/romanian-text-preprocessors.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {basicTextProcessorOptions} from '../text-processors.js';
+
+/** @type {import('language').TextProcessor<boolean>} */
+export const removeRomanianDiacritics = {
+    name: 'Remove diacritics',
+    description: 'ĂăÂâÎîȚțȘș → AaAaIiTtSs',
+    options: basicTextProcessorOptions,
+    process: (str, setting) => (
+        setting ?
+        str.normalize('NFD').replace(/[\u0300-\u036f]/g, ''):
+            str
+    ),
+
+};

--- a/types/ext/language-descriptors.d.ts
+++ b/types/ext/language-descriptors.d.ts
@@ -143,7 +143,9 @@ type AllTextProcessors = {
         pre: CapitalizationPreprocessors;
     };
     ro: {
-        pre: CapitalizationPreprocessors;
+        pre: CapitalizationPreprocessors & {
+            removeRomanianDiacritics: TextProcessor<boolean>;
+        };
     };
     ru: {
         pre: CapitalizationPreprocessors & {


### PR DESCRIPTION
Added text preprocessors for Romanian language.
This turns ĂăÂâÎîȚțȘș into AaAaIiTtSs.