### PR TITLE
Don't move offset when disallowExpandSelection is true

### DIFF
--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -138,6 +138,7 @@ export class TextSourceRange {
      * @returns {number} The actual number of codepoints that were read.
      */
     setEndOffset(length, fromEnd, layoutAwareScan) {
+        if (this._disallowExpandSelection) { return 0; }
         let node;
         let offset;
         if (fromEnd) {
@@ -150,9 +151,14 @@ export class TextSourceRange {
         const state = new DOMTextScanner(node, offset, !layoutAwareScan, layoutAwareScan).seek(length);
         this._range.setEnd(state.node, state.offset);
         const expandedContent = fromEnd ? this._content + state.content : state.content;
+<<<<<<< HEAD
         this._content = this._disallowExpandSelection ? this._content : expandedContent;
+=======
+        this._content = expandedContent;
+>>>>>>> 5e47324bb (Don't move offset when disallowExpandSelection is true)
         return length - state.remainder;
     }
+
 
     /**
      * Moves the start offset of the text by a set amount of unicode codepoints.
@@ -162,6 +168,7 @@ export class TextSourceRange {
      * @returns {number} The actual number of codepoints that were read.
      */
     setStartOffset(length, layoutAwareScan) {
+        if (this._disallowExpandSelection) { return 0; }
         const state = new DOMTextScanner(this._range.startContainer, this._range.startOffset, !layoutAwareScan, layoutAwareScan).seek(-length);
         this._range.setStart(state.node, state.offset);
         this._rangeStartOffset = this._range.startOffset;

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -151,11 +151,7 @@ export class TextSourceRange {
         const state = new DOMTextScanner(node, offset, !layoutAwareScan, layoutAwareScan).seek(length);
         this._range.setEnd(state.node, state.offset);
         const expandedContent = fromEnd ? this._content + state.content : state.content;
-<<<<<<< HEAD
-        this._content = this._disallowExpandSelection ? this._content : expandedContent;
-=======
         this._content = expandedContent;
->>>>>>> 5e47324bb (Don't move offset when disallowExpandSelection is true)
         return length - state.remainder;
     }
 


### PR DESCRIPTION
Fixes: #1030 

In the context in which `this._disallowExpandSelection` is `true` (for example when we use the context menu scan or the shortcut), we don't concatenate the existing `TextSourceRange` content with what the `DOMTextScanner` scans, but in either case we return the number of characters scanned as if we expanded the selection, resulting in `TextSourceRange` being internally consistent and having a `this._content.length` being smaller than what `setEndOffset` returns, causing indexing into the `TextSourceRange` string to be undefined.