### PR TITLE
Fix DOMTextScanner entering initial div on backwards seeks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
@@ -11,7 +8,7 @@
                 "run",
                 "test:unit",
                 "--",
-                "test/text-source-range.test.js" // Replace and uncomment this line to run a single test file
+                // "test/text-source-range.test.js" // Replace and uncomment this line to run a single test file
             ],
             "runtimeExecutable": "npm",
             "skipFiles": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch via NPM",
+            "request": "launch",
+            "runtimeArgs": [
+                "run",
+                "test:unit",
+                "--",
+                "test/text-source-range.test.js" // Replace and uncomment this line to run a single test file
+            ],
+            "runtimeExecutable": "npm",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        }
+    ]
+}

--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -131,14 +131,14 @@ export class DOMTextScanner {
                 }
             } else if (nodeType === ELEMENT_NODE) {
                 lastNode = node;
-                // If we're at the beginning of a node and going backwards, don't enter the node
-                const skipNode = node === this._initialNode && this._offset === 0 && !forward;
+                const initialNodeAtBeginningOfNodeGoingBackwards = node === this._initialNode && this._offset === 0 && !forward;
+                const initialNodeAtEndOfNodeGoingForwards = node === this._initialNode && this._offset === node.childNodes.length && forward;
                 this._offset = 0;
                 ({enterable, newlines} = DOMTextScanner.getElementSeekInfo(/** @type {Element} */ (node)));
                 if (newlines > this._newlines && generateLayoutContent) {
                     this._newlines = newlines;
                 }
-                if (skipNode) {
+                if (initialNodeAtBeginningOfNodeGoingBackwards || initialNodeAtEndOfNodeGoingForwards) {
                     enterable = false;
                 }
             }

--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -37,6 +37,8 @@ export class DOMTextScanner {
         if (resetOffset) { node = ruby; }
 
         /** @type {Node} */
+        this._initialNode = node;
+        /** @type {Node} */
         this._node = node;
         /** @type {number} */
         this._offset = offset;
@@ -129,10 +131,15 @@ export class DOMTextScanner {
                 }
             } else if (nodeType === ELEMENT_NODE) {
                 lastNode = node;
+                // If we're at the beginning of a node and going backwards, don't enter the node
+                const skipNode = node === this._initialNode && this._offset === 0 && !forward;
                 this._offset = 0;
                 ({enterable, newlines} = DOMTextScanner.getElementSeekInfo(/** @type {Element} */ (node)));
                 if (newlines > this._newlines && generateLayoutContent) {
                     this._newlines = newlines;
+                }
+                if (skipNode) {
+                    enterable = false;
                 }
             }
 

--- a/test/data/html/text-source-range.html
+++ b/test/data/html/text-source-range.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+    <title>TextSourceRange Tests</title>
+</head>
+    <body>
+        <h1>TextSourceRange Tests</h1>
+        <test-case id="text-source-range-lazy">
+            <p>人</p>
+        </test-case>
+
+        <test-case id="text-source-range">
+<p>山</p>
+        </test-case>
+    </body>
+</html>

--- a/test/data/json.json
+++ b/test/data/json.json
@@ -8,6 +8,7 @@
         {"path": ".eslintrc.json", "ignore": true},
         {"path": ".vscode/settings.json", "ignore": true},
         {"path": ".vscode/extensions.json", "ignore": true},
+        {"path": ".vscode/launch.json", "ignore": true},
         {"path": "dev/jsconfig.json", "ignore": true},
         {"path": "ext/manifest.json", "ignore": true},
         {"path": "test/data/dictionaries/invalid-dictionary1/index.json", "ignore": true},

--- a/test/dom-text-scanner.test.js
+++ b/test/dom-text-scanner.test.js
@@ -112,56 +112,57 @@ function createAbsoluteGetComputedStyle(window) {
 
 const domTestEnv = await setupDomTest(path.join(dirname, 'data/html/dom-text-scanner.html'));
 
-describe('DOMTextScanner', () => {
+describe('DOMTextScanner seek tests', () => {
     const {window, teardown} = domTestEnv;
     afterAll(() => teardown(global));
 
-    test('Seek tests', () => {
-        const {document} = window;
-        window.getComputedStyle = createAbsoluteGetComputedStyle(window);
+    const {document} = window;
+    window.getComputedStyle = createAbsoluteGetComputedStyle(window);
 
-        for (const testElement of /** @type {NodeListOf<HTMLElement>} */ (document.querySelectorAll('test-case'))) {
-            /** @type {import('test/dom-text-scanner').TestData|import('test/dom-text-scanner').TestData[]} */
-            let testData = parseJson(/** @type {string} */ (testElement.dataset.testData));
-            if (!Array.isArray(testData)) {
-                testData = [testData];
-            }
-            for (const testDataItem of testData) {
-                const {
-                    node: nodeSelector,
-                    offset,
-                    length,
-                    forcePreserveWhitespace,
-                    generateLayoutContent,
-                    reversible,
-                    expected: {
-                        node: expectedNodeSelector,
-                        offset: expectedOffset,
-                        content: expectedContent,
-                        remainder: expectedRemainder,
-                    },
-                } = testDataItem;
+    for (const testElement of /** @type {NodeListOf<HTMLElement>} */ (document.querySelectorAll('test-case'))) {
+        const testDescription = testElement.querySelector('test-description')?.textContent || 'Test description not found.';
 
-                const node = querySelectorTextNode(testElement, nodeSelector);
-                const expectedNode = querySelectorTextNode(testElement, expectedNodeSelector);
+        /** @type {import('test/dom-text-scanner').TestData|import('test/dom-text-scanner').TestData[]} */
+        let testData = parseJson(/** @type {string} */ (testElement.dataset.testData));
+        if (!Array.isArray(testData)) {
+            testData = [testData];
+        }
 
-                expect(node).not.toEqual(null);
-                expect(expectedNode).not.toEqual(null);
-                if (node === null || expectedNode === null) { continue; }
+        for (const testDataItem of testData) {
+            const {
+                node: nodeSelector,
+                offset,
+                length,
+                forcePreserveWhitespace,
+                generateLayoutContent,
+                reversible,
+                expected: {
+                    node: expectedNodeSelector,
+                    offset: expectedOffset,
+                    content: expectedContent,
+                    remainder: expectedRemainder,
+                },
+            } = testDataItem;
 
-                // Standard test
-                {
-                    const scanner = new DOMTextScanner(node, offset, forcePreserveWhitespace, generateLayoutContent);
-                    scanner.seek(length);
+            const node = querySelectorTextNode(testElement, nodeSelector);
+            const expectedNode = querySelectorTextNode(testElement, expectedNodeSelector);
 
-                    const {node: actualNode1, offset: actualOffset1, content: actualContent1, remainder: actualRemainder1} = scanner;
-                    expect(actualContent1).toStrictEqual(expectedContent);
-                    expect(actualOffset1).toStrictEqual(expectedOffset);
-                    expect(actualNode1).toStrictEqual(expectedNode);
-                    expect(actualRemainder1).toStrictEqual(expectedRemainder || 0);
-                }
+            expect(node).not.toEqual(null);
+            expect(expectedNode).not.toEqual(null);
+            if (node === null || expectedNode === null) { continue; }
 
-                // Substring tests
+            test(`${testDescription} standard test`, () => {
+                const scanner = new DOMTextScanner(node, offset, forcePreserveWhitespace, generateLayoutContent);
+                scanner.seek(length);
+
+                const {node: actualNode1, offset: actualOffset1, content: actualContent1, remainder: actualRemainder1} = scanner;
+                expect(actualContent1).toStrictEqual(expectedContent);
+                expect(actualOffset1).toStrictEqual(expectedOffset);
+                expect(actualNode1).toStrictEqual(expectedNode);
+                expect(actualRemainder1).toStrictEqual(expectedRemainder || 0);
+            });
+
+            test(`${testDescription} substring test`, () => {
                 for (let i = 1; i <= length; ++i) {
                     const scanner = new DOMTextScanner(node, offset, forcePreserveWhitespace, generateLayoutContent);
                     scanner.seek(length - i);
@@ -169,19 +170,17 @@ describe('DOMTextScanner', () => {
                     const {content: actualContent} = scanner;
                     expect(actualContent).toStrictEqual(expectedContent.substring(0, expectedContent.length - i));
                 }
+            });
 
-                if (reversible === false) { continue; }
+            test.runIf(reversible)(`${testDescription} reversed test`, () => {
+                const scanner = new DOMTextScanner(expectedNode, expectedOffset, forcePreserveWhitespace, generateLayoutContent);
+                scanner.seek(-length);
 
-                // Reversed test
-                {
-                    const scanner = new DOMTextScanner(expectedNode, expectedOffset, forcePreserveWhitespace, generateLayoutContent);
-                    scanner.seek(-length);
+                const {content: actualContent} = scanner;
+                expect(actualContent).toStrictEqual(expectedContent);
+            });
 
-                    const {content: actualContent} = scanner;
-                    expect(actualContent).toStrictEqual(expectedContent);
-                }
-
-                // Reversed substring tests
+            test.runIf(reversible)(`${testDescription} reversed substring test`, () => {
                 for (let i = 1; i <= length; ++i) {
                     const scanner = new DOMTextScanner(expectedNode, expectedOffset, forcePreserveWhitespace, generateLayoutContent);
                     scanner.seek(-(length - i));
@@ -189,7 +188,7 @@ describe('DOMTextScanner', () => {
                     const {content: actualContent} = scanner;
                     expect(actualContent).toStrictEqual(expectedContent.substring(i));
                 }
-            }
+            });
         }
-    });
+    }
 });

--- a/test/text-source-range.test.js
+++ b/test/text-source-range.test.js
@@ -31,7 +31,7 @@ describe('TextSourceRange', () => {
     const {window, teardown} = textSourceRangeTestEnv;
     afterAll(() => teardown(global));
 
-    test('lazy TextSourceRange', () => {
+    test('lazy', () => {
         const {document} = window;
         const testElement /** @type {NodeListOf<HTMLElement>} */ = document.getElementById('text-source-range-lazy');
         if (testElement === null) {
@@ -54,7 +54,7 @@ describe('TextSourceRange', () => {
         expect(count).toEqual(1);
     });
 
-    test('standard TextSourceRange', () => {
+    test('standard', () => {
         const {document} = window;
         const testElement /** @type {NodeListOf<HTMLElement>} */ = document.getElementById('text-source-range');
         if (testElement === null) {
@@ -67,7 +67,7 @@ describe('TextSourceRange', () => {
 
         const source = TextSourceRange.create(range);
         const startLength = source.setStartOffset(15, false);
-        const endLength = source.setEndOffset(1, true, false);
+        const endLength = source.setEndOffset(15, true, false);
 
         const text = source.text();
         const textLength = text.length;

--- a/test/text-source-range.test.js
+++ b/test/text-source-range.test.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2024  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {fail} from 'node:assert';
+import {fileURLToPath} from 'node:url';
+import path from 'path';
+import {afterAll, describe, expect, test} from 'vitest';
+import {TextSourceRange} from '../ext/js/dom/text-source-range.js';
+import {setupDomTest} from './fixtures/dom-test.js';
+
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const textSourceRangeTestEnv = await setupDomTest(path.join(dirname, 'data/html/text-source-range.html'));
+
+
+describe('TextSourceRange', () => {
+    const {window, teardown} = textSourceRangeTestEnv;
+    afterAll(() => teardown(global));
+
+    test('lazy TextSourceRange', () => {
+        const {document} = window;
+        const testElement /** @type {NodeListOf<HTMLElement>} */ = document.getElementById('text-source-range-lazy');
+        if (testElement === null) {
+            fail('test element not found');
+        }
+
+        const range = new Range();
+        range.selectNodeContents(testElement);
+
+        const source = TextSourceRange.createLazy(range);
+        const startLength = source.setStartOffset(200, false);
+        const endLength = source.setEndOffset(200, true, false);
+
+        const text = source.text();
+        const textLength = text.length;
+
+        expect(startLength).toBeLessThanOrEqual(textLength);
+        expect(endLength).toBeLessThan(textLength);
+        const count = (text.match(/人/g) || []).length;
+        expect(count).toEqual(1);
+    });
+
+    test('standard TextSourceRange', () => {
+        const {document} = window;
+        const testElement /** @type {NodeListOf<HTMLElement>} */ = document.getElementById('text-source-range');
+        if (testElement === null) {
+            fail('test element not found');
+        }
+
+        const range = new Range();
+
+        range.selectNodeContents(testElement);
+
+        const source = TextSourceRange.create(range);
+        const startLength = source.setStartOffset(15, false);
+        const endLength = source.setEndOffset(1, true, false);
+
+        const text = source.text();
+        const textLength = text.length;
+
+        expect(startLength).toBeLessThan(textLength);
+        expect(endLength).toBeLessThan(textLength);
+        const count = (text.match(/山/g) || []).length;
+        expect(count).toEqual(1);
+    });
+});


### PR DESCRIPTION
Our DOMTextScanner will enter the first `ELEMENT_NODE` upon a backwards seek, even if we're initializing our DOMTextScanner with an offset of `0`. This can cause duplicate content to be produced.

Example in the `text-source-range.test.js`:
```html
<test-case id="text-source-range">
<p>山</p>
</test-case>
```
I'm starting from `text-source-range.js` to create a `TextSourceRange` object from a constructed range. I'm creating a `Range` object that has `<test-case id="text-source-range">` as its `startContainer` and `</test-case>` as its `endContainer`.

The range object has a `startOffset` of `0` and `endOffset` of `3`. The `3` represents that the end range is set at `<test-case id="text-source-range">` + 3 nodes. In this case this would be:
Node 1: `#text` of value `\n`
Node 2: `<p>`
Node 3: `#text` of value `\n`

The current contents of this `TextSourceRange` is `\n山\n`.

When I execute `setStartOffset`, I'm noticing that even though we're passing in the `this._range.startContainer`, it starts at the end of `<test-case>` to the left of `</test-case>`, then it will scan backwards, first reaching Node 3, then Node 2, and if there's sufficient length, Node 1.

The outcome of running `setStartOffset` results in the contents of my `TextSourceRange` to be `\n山\n山\n`, which is not correct.

The fix is to simply check whether our DOMTextScanner starts at the beginning of an `ELEMENT_NODE` and if we're going backwards. If so, then we'll not enter the node and instead of add it to the `exitedNodes`

TODO: 
- [x] : I wonder if the other problem is true too. Forward seek if the initial node has an offset equivalent to being in the end of the node