### PR TITLE
use only longest substring that deinflects to headword

### DIFF
--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -260,19 +260,16 @@ export class Translator {
                     if (transformedText.length < existingTransformedLength) {
                         continue;
                     }
-
                     if (transformedText.length > existingTransformedLength) {
                         dictionaryEntries.splice(existingIndex, 1, this._createTermDictionaryEntryFromDatabaseEntry(databaseEntry, originalText, transformedText, deinflectedText, inflectionRuleChainCandidates, true, enabledDictionaryMap, tagAggregator));
-                        continue;
+                    } else {
+                        this._mergeInflectionRuleChains(existingEntry, inflectionRuleChainCandidates);
                     }
-
-                    this._mergeInflectionRuleChains(existingEntry, inflectionRuleChainCandidates);
-                    continue;
+                } else {
+                    const dictionaryEntry = this._createTermDictionaryEntryFromDatabaseEntry(databaseEntry, originalText, transformedText, deinflectedText, inflectionRuleChainCandidates, true, enabledDictionaryMap, tagAggregator);
+                    dictionaryEntries.push(dictionaryEntry);
+                    ids.add(id);
                 }
-
-                const dictionaryEntry = this._createTermDictionaryEntryFromDatabaseEntry(databaseEntry, originalText, transformedText, deinflectedText, inflectionRuleChainCandidates, true, enabledDictionaryMap, tagAggregator);
-                dictionaryEntries.push(dictionaryEntry);
-                ids.add(id);
             }
         }
         return {dictionaryEntries, originalTextLength};


### PR DESCRIPTION
| Before      | After |
| ----------- | ----------- |
| ![Screenshot from 2024-06-15 23-49-10](https://github.com/themoeway/yomitan/assets/24891609/84879c77-8ce2-45e1-b638-655067c0706c)      | ![Screenshot from 2024-06-15 23-49-33](https://github.com/themoeway/yomitan/assets/24891609/18b13eb7-0aa8-4636-9721-23d327b0a597)       |

In the shown example, deinflections from both `oppidorum` and the substring `oppido` to the headword `oppidum` were shown, which was confusing, cluttered and also messed with the sorting.