### PR TITLE
Fix auto popup theme shadow not applying

### DIFF
--- a/ext/js/app/theme-controller.js
+++ b/ext/js/app/theme-controller.js
@@ -171,7 +171,7 @@ export class ThemeController {
      */
     _resolveThemeValue(theme, computedSiteTheme) {
         switch (theme) {
-            case 'auto': return computedSiteTheme;
+            case 'site': return computedSiteTheme;
             case 'browser': return this._browserTheme;
             default: return theme;
         }


### PR DESCRIPTION
`auto` was renamed to `site` internally in update18. This switch arm was matching the wrong value.