### PR TITLE
Set better defaults for themes

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -226,12 +226,12 @@
                                     "popupTheme": {
                                         "type": "string",
                                         "enum": ["light", "dark", "browser"],
-                                        "default": "light"
+                                        "default": "browser"
                                     },
                                     "popupOuterTheme": {
                                         "type": "string",
                                         "enum": ["light", "dark", "browser", "site"],
-                                        "default": "light"
+                                        "default": "site"
                                     },
                                     "customPopupCss": {
                                         "type": "string",

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -134,6 +134,7 @@
                 <select data-setting="general.popupTheme" class="short-width">
                     <option value="light">Light</option>
                     <option value="dark">Dark</option>
+                    <option value="browser">Browser</option>
                 </select>
             </div>
         </div></div>


### PR DESCRIPTION
Now that we have proper support for dark mode it makes sense to set the theme based on browser theme. And it would be best to have popupOuterTheme auto set based on site.

And some reason the welcome page didnt have an option on the theme selector for browser. Fixed that.