### PR TITLE
Set up down buttons to default button size when on mobile

### DIFF
--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -2638,3 +2638,13 @@ input[type=number].dictionary-priority {
         box-shadow: var(--shadow-right);
     }
 }
+
+/* Mobile overrides */
+
+/* Treat devices that can't hover as mobile devices */
+@media (hover: none) {
+    #dictionary-move-up>span.icon-button-inner,
+    #dictionary-move-down>span.icon-button-inner {
+        width: 36px;
+    }
+}


### PR DESCRIPTION
These get squeezed in a bit because it looks worse to have them spread apart and on pc theres no issue but on touchscreens it could be a bit rough.

On mobile:
| Before      | After      |
| ------------- | ------------- |
| ![image](https://github.com/themoeway/yomitan/assets/61125188/137ffe9c-99d2-43bf-a9f2-9278528ff9bd) | ![image](https://github.com/themoeway/yomitan/assets/61125188/3211aa63-fab6-4636-97c6-282bb87dc056) |

