### PR TITLE
Add modal-body to scrollbar styling

### DIFF
--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -104,25 +104,32 @@
 }
 
 /* Scrollbars */
-:root:not([data-theme=light]) .scrollbar {
+:root:not([data-theme=light]) .scrollbar,
+:root:not([data-theme=light]) .modal-body {
     scrollbar-color: var(--scrollbar-thumb-color) var(--scrollbar-track-color);
 }
-:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar {
+:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar,
+:root:not([data-theme=light]) .modal-body::-webkit-scrollbar {
     width: auto;
 }
-:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-button {
+:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-button,
+:root:not([data-theme=light]) .modal-body::-webkit-scrollbar-button {
     height: 0;
 }
-:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-thumb {
+:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-thumb,
+:root:not([data-theme=light]) .modal-body::-webkit-scrollbar-thumb {
     background-color: var(--scrollbar-thumb-color);
 }
-:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-track {
+:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-track,
+:root:not([data-theme=light]) .modal-body::-webkit-scrollbar-track {
     background-color: var(--scrollbar-thumb-color);
 }
-:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-track-piece {
+:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-track-piece,
+:root:not([data-theme=light]) .modal-::-webkit-scrollbar-track-piece {
     background-color: var(--scrollbar-track-color);
 }
-:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-corner {
+:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-corner,
+:root:not([data-theme=light]) .modal-body::-webkit-scrollbar-corner {
     background-color: var(--scrollbar-track-color);
 }
 


### PR DESCRIPTION
These got missed in the theming updates. Affects scrollbars in modals such as the dictionary listing when a user has enough dicts to make it scroll.