### PR TITLE
Use browser theme for loading on action popup

### DIFF
--- a/ext/css/action-popup.css
+++ b/ext/css/action-popup.css
@@ -532,3 +532,12 @@ select.profile-select {
         overflow-wrap: break-word;
     }
 }
+
+/* Dark mode before themes are applied
+   DO NOT use this for normal theming */
+@media (prefers-color-scheme: dark) {
+    body:not([data-loaded=true]) {
+        color: #cccccc;
+        background-color: #1e1e1e;
+    }
+}


### PR DESCRIPTION
On pc the loading is so small this doesnt really matter but on mobile the action popup is full page. This removes the flashbang upon opening action popup on mobile when dark theme is selected in browser settings.