### PR TITLE
Remove flashbangs on page transition

### DIFF
--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -2655,3 +2655,11 @@ input[type=number].dictionary-priority {
         width: 36px;
     }
 }
+
+/* Dark mode before themes are applied
+   DO NOT use this for normal theming */
+@media (prefers-color-scheme: dark) {
+    :root:not([data-loaded=true]) {
+        background-color: #1e1e1e;
+    }
+}


### PR DESCRIPTION
When opening a page, browsers default to thinking the page is in light mode. No background = white background.

This creates flashbangs when opening yomitan pages due the pages being hidden and thus having no background before they are loaded. Due to our themes being applied after the browser's page load (js modules can't be blocking) these pages don't fall back on the browser's background which does do light and dark properly.

But we can set the background explicitly for the browser to use during the downtime between the page being loaded in the browser and it being loaded in Yomitan.