### PR TITLE
Remove search page flashbang on page transition

### DIFF
--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -177,3 +177,11 @@ h1 {
     width: 640px;
     height: 480px;
 }
+
+/* Dark mode before themes are applied
+   DO NOT use this for normal theming */
+@media (prefers-color-scheme: dark) {
+    :root:not([data-loaded=true]) {
+        background-color: #1e1e1e;
+    }
+}


### PR DESCRIPTION
Missed this in #1101. Search page doesnt use settings.css like all the other pages.