### PR TITLE
Fix firefox search button 1px off of search textbox

### DIFF
--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -63,7 +63,7 @@ h1 {
     display: flex;
     flex-flow: row nowrap;
     width: 100%;
-    align-items: stretch;
+    align-items: center;
     margin: 0;
     padding: 0;
     border: 0;
@@ -92,6 +92,9 @@ h1 {
     flex: 0 0 auto;
     position: relative;
     width: 2.5em;
+    height: calc(var(--textarea-line-height) + var(--textarea-padding) * 2);
+    min-height: calc(var(--textarea-line-height) + var(--textarea-padding) * 2);
+    max-height: calc(var(--textarea-line-height) * 10 + var(--textarea-padding) * 2);
     background-color: var(--input-background-color);
     border: 0;
     padding: 0;

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -566,14 +566,20 @@ export class SearchDisplayController {
      * @param {boolean} shrink
      */
     _updateSearchHeight(shrink) {
-        const node = this._queryInput;
+        const searchTextbox = this._queryInput;
+        const searchItems = [this._queryInput, this._searchButton, this._searchBackButton];
+
         if (shrink) {
-            node.style.height = '0';
+            for (const searchButton of searchItems) {
+                searchButton.style.height = '0';
+            }
         }
-        const {scrollHeight} = node;
-        const currentHeight = node.getBoundingClientRect().height;
+        const {scrollHeight} = searchTextbox;
+        const currentHeight = searchTextbox.getBoundingClientRect().height;
         if (shrink || scrollHeight >= currentHeight - 1) {
-            node.style.height = `${scrollHeight}px`;
+            for (const searchButton of searchItems) {
+                searchButton.style.height = `${scrollHeight}px`;
+            }
         }
     }
 


### PR DESCRIPTION
Only occurs on firefox, something with the button size is calculated differently from chromium. We can fix it by setting an explicit height for the button. Included in SearchDisplayController to allow the button to grow at the same scale as the search box when newlines are added.

| Before      | After      |
| ------------- | ------------- |
| ![before](https://github.com/themoeway/yomitan/assets/61125188/afe7eeb0-f386-449d-9755-da4311a70e41) | ![after](https://github.com/themoeway/yomitan/assets/61125188/aa09f882-bdea-4c57-9e77-e4ef55335890) |


