### PR TITLE
Auto resize search textbox when removing lines

### DIFF
--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -82,7 +82,7 @@ h1 {
     height: calc(var(--textarea-line-height) + var(--textarea-padding) * 2);
     min-height: calc(var(--textarea-line-height) + var(--textarea-padding) * 2);
     max-height: calc(var(--textarea-line-height) * 10 + var(--textarea-padding) * 2);
-    resize: vertical;
+    resize: none;
     font-size: var(--font-size);
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     white-space: pre-wrap;

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -236,7 +236,7 @@ export class SearchDisplayController {
 
     /** */
     _onSearchInput() {
-        this._updateSearchHeight(false);
+        this._updateSearchHeight(true);
     }
 
     /**


### PR DESCRIPTION
Also disallows users to edit the size of the textbox by grabbing the handle and dragging it around which breaks the layout a bit.