### PR TITLE
Make search sizing more sensible due to search textbox and query now being sticky

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -605,6 +605,7 @@ button.sidebar-button.sidebar-button-highlight {
     margin-top: 0.5em;
     font-size: var(--query-parser-font-size);
     white-space: pre-wrap;
+    max-height: calc(var(--query-parser-font-size) * 2);
 }
 #query-parser-content[data-term-spacing=true] .query-parser-term {
     margin-right: 0.2em;

--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -30,7 +30,7 @@
 
     --search-textbox-height: calc(var(--textarea-line-height) + var(--textarea-padding) * 2);
     --search-textbox-min-height: calc(var(--textarea-line-height) + var(--textarea-padding) * 2);
-    --search-textbox-max-height: calc(var(--textarea-line-height) * 10 + var(--textarea-padding) * 2);
+    --search-textbox-max-height: calc(var(--textarea-line-height) * 5 + var(--textarea-padding) * 2);
 }
 :root:not([data-loaded=true]) {
     --animation-duration: 0s;

--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -27,6 +27,10 @@
 
     --background-color: #ffffff;
     --separator-color1: #cccccc;
+
+    --search-textbox-height: calc(var(--textarea-line-height) + var(--textarea-padding) * 2);
+    --search-textbox-min-height: calc(var(--textarea-line-height) + var(--textarea-padding) * 2);
+    --search-textbox-max-height: calc(var(--textarea-line-height) * 10 + var(--textarea-padding) * 2);
 }
 :root:not([data-loaded=true]) {
     --animation-duration: 0s;
@@ -79,9 +83,9 @@ h1 {
     border: 0;
     outline: none;
     width: 100%;
-    height: calc(var(--textarea-line-height) + var(--textarea-padding) * 2);
-    min-height: calc(var(--textarea-line-height) + var(--textarea-padding) * 2);
-    max-height: calc(var(--textarea-line-height) * 10 + var(--textarea-padding) * 2);
+    height: var(--search-textbox-height);
+    min-height: var(--search-textbox-min-height);
+    max-height: var(--search-textbox-max-height);
     resize: none;
     font-size: var(--font-size);
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -92,9 +96,9 @@ h1 {
     flex: 0 0 auto;
     position: relative;
     width: 2.5em;
-    height: calc(var(--textarea-line-height) + var(--textarea-padding) * 2);
-    min-height: calc(var(--textarea-line-height) + var(--textarea-padding) * 2);
-    max-height: calc(var(--textarea-line-height) * 10 + var(--textarea-padding) * 2);
+    height: var(--search-textbox-height);
+    min-height: var(--search-textbox-min-height);
+    max-height: var(--search-textbox-max-height);
     background-color: var(--input-background-color);
     border: 0;
     padding: 0;


### PR DESCRIPTION
Fixes an issue where the search text could get so big when scanning large amounts of text that due to it being sticky it was impossible to scroll down and see all the search results.

Screenshot:
![image](https://github.com/themoeway/yomitan/assets/61125188/0146ba70-3b60-41e9-b709-4dd13abacc63)
