### PR TITLE
Update theme after search update in popup preview

### DIFF
--- a/ext/js/pages/settings/popup-preview-frame.js
+++ b/ext/js/pages/settings/popup-preview-frame.js
@@ -296,5 +296,7 @@ export class PopupPreviewFrame {
         }
 
         this._setInfoVisible(!this._popupShown);
+
+        this._themeController.updateTheme();
     }
 }


### PR DESCRIPTION
Due to the text scanner setting the theme to theme the popup based on the webpage when the body theme is set to auto, this causes the theme override for the search text in the settings page for the popup preview to be updated to the wrong theme when the search text is edited because the popup preview's "page theme" is always light due to it being 0% opacity.

This change makes search text on the popup preview get themed correctly after editing. The popup preview frame sets its own theme back to what it should be after the text scanner tries to mess it up.

This should all happen before the next draw of this element so there shouldnt be any flickering between themes.
