### PR TITLE
Fix Search Page Kanji Entry Results

### DIFF
--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1212,9 +1212,10 @@ export class Display extends EventDispatcher {
      * @param {string} source
      * @param {boolean} wildcardsEnabled
      * @param {import('settings').OptionsContext} optionsContext
+     * @param {boolean} [isRetry=false]
      * @returns {Promise<import('dictionary').DictionaryEntry[]>}
      */
-    async _findDictionaryEntries(isKanji, source, wildcardsEnabled, optionsContext) {
+    async _findDictionaryEntries(isKanji, source, wildcardsEnabled, optionsContext, isRetry = false) {
         if (isKanji) {
             return await this._application.api.kanjiFind(source, optionsContext);
         } else {
@@ -1235,7 +1236,12 @@ export class Display extends EventDispatcher {
             }
 
             const {dictionaryEntries} = await this._application.api.termsFind(source, findDetails, optionsContext);
-            return dictionaryEntries;
+            // If no results found then retry with kanji search
+            if (dictionaryEntries && dictionaryEntries.length > 0) {
+                return dictionaryEntries;
+            } else {
+                return isRetry ? [] : await this._findDictionaryEntries(true, source, wildcardsEnabled, optionsContext, true);
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #1137

When you search a kanji and only kanji dictionaries have the term, the search page will then display kanji results instead of "No results found."

![msedge_読_-_Yomitan_Search_and_2_more_pages_-_Dev_Ext_Test_2024-06-26_12-15-47](https://github.com/themoeway/yomitan/assets/17340496/f6cd566d-c1f5-49ae-bea3-767a06ab89d0)
