### PR TITLE
Add wiktionary commons audio source

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -401,6 +401,7 @@
                                                         "jpod101-alternate",
                                                         "jisho",
                                                         "lingua-libre",
+                                                        "wiktionary",
                                                         "text-to-speech",
                                                         "text-to-speech-reading",
                                                         "custom",

--- a/ext/js/display/display-audio.js
+++ b/ext/js/display/display-audio.js
@@ -58,6 +58,7 @@ export class DisplayAudio {
             ['jpod101-alternate', 'JapanesePod101 (Alternate)'],
             ['jisho', 'Jisho.org'],
             ['lingua-libre', 'Lingua Libre'],
+            ['wiktionary', 'Wiktionary'],
             ['text-to-speech', 'Text-to-speech'],
             ['text-to-speech-reading', 'Text-to-speech (Kana reading)'],
             ['custom', 'Custom URL'],

--- a/ext/js/media/media-util.js
+++ b/ext/js/media/media-util.js
@@ -113,6 +113,7 @@ export function getFileExtensionFromAudioMediaType(mediaType) {
             return '.mp4';
         case 'audio/ogg':
         case 'audio/vorbis':
+        case 'application/ogg':
             return '.ogg';
         case 'audio/vnd.wav':
         case 'audio/wave':

--- a/ext/js/pages/settings/audio-controller.js
+++ b/ext/js/pages/settings/audio-controller.js
@@ -222,6 +222,7 @@ export class AudioController extends EventDispatcher {
             'jpod101-alternate',
             'jisho',
             'lingua-libre',
+            'wiktionary',
             'custom',
         ];
         for (const type of typesAvailable) {
@@ -490,6 +491,7 @@ class AudioSourceEntry {
             case 'jpod101-alternate':
             case 'jisho':
             case 'lingua-libre':
+            case 'wiktionary':
             case 'text-to-speech':
             case 'text-to-speech-reading':
             case 'custom':

--- a/ext/templates-settings.html
+++ b/ext/templates-settings.html
@@ -116,7 +116,8 @@
             <option value="jpod101">JapanesePod101</option>
             <option value="jpod101-alternate">JapanesePod101 (Alternate)</option>
             <option value="jisho">Jisho.org</option>
-            <option value="lingua-libre">Lingua Libre</option>
+            <option value="lingua-libre">(Commons) Lingua Libre</option>
+            <option value="wiktionary">(Commons) Wiktionary</option>
             <option value="text-to-speech">Text-to-speech</option>
             <option value="text-to-speech-reading">Text-to-speech (Kana reading)</option>
             <option value="custom">Custom URL</option>
@@ -431,6 +432,7 @@
         <option value="jpod101-alternate">JapanesePod101 (Alternate)</option>
         <option value="jisho">Jisho.org</option>
         <option value="lingua-libre">Lingua Libre</option>
+        <option value="wiktionary">Wiktionary</option>
         <option value="text-to-speech">Text-to-speech</option>
         <option value="text-to-speech-reading">Text-to-speech (Kana reading)</option>
         <option value="custom">Custom</option>

--- a/types/ext/audio-downloader.d.ts
+++ b/types/ext/audio-downloader.d.ts
@@ -55,28 +55,28 @@ export type CustomAudioListSource = {
     name?: string;
 };
 
-export type LinguaLibreLookupResponse = {
+export type WikimediaCommonsLookupResponse = {
     query: {
-        search: LinguaLibreLookupResult[];
+        search: WikimediaCommonsLookupResult[];
     };
 };
 
-export type LinguaLibreFileResponse = {
+export type WikimediaCommonsFileResponse = {
     query: {
-        pages: Record<string, LinguaLibreFileResult>;
+        pages: Record<string, WikimediaCommonsFileResult>;
     };
 };
 
-export type LinguaLibreLookupResult = {
+export type WikimediaCommonsLookupResult = {
     title: string;
 };
 
-export type LinguaLibreFileResult = {
+export type WikimediaCommonsFileResult = {
     title: string;
-    imageinfo: LinguaLibreFileResultImageInfo[];
+    imageinfo: WikimediaCommonsFileResultImageInfo[];
 };
 
-export type LinguaLibreFileResultImageInfo = {
+export type WikimediaCommonsFileResultImageInfo = {
     url: string;
     user: string;
 };

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -383,7 +383,7 @@ export type PopupWindowType = 'normal' | 'popup';
 
 export type PopupWindowState = 'normal' | 'maximized' | 'fullscreen';
 
-export type AudioSourceType = 'jpod101' | 'jpod101-alternate' | 'jisho' | 'lingua-libre' | 'text-to-speech' | 'text-to-speech-reading' | 'custom' | 'custom-json';
+export type AudioSourceType = 'jpod101' | 'jpod101-alternate' | 'jisho' | 'lingua-libre' | 'wiktionary' | 'text-to-speech' | 'text-to-speech-reading' | 'custom' | 'custom-json';
 
 export type TranslationConvertType = 'false' | 'true' | 'variant';
 


### PR DESCRIPTION
In some cases the vast majority of commons audio for a language is not from lingua libre but in the format `en-example2.ogg`, which seems to me to come from users recording audio for wiktionary in an outdated way. Sometimes the filenames also have a region code like `en-us-read.ogg`.