### PR TITLE
Set overscroll to contain for popup

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -384,6 +384,7 @@ a:has(rt) {
     overflow-y: scroll;
     align-items: stretch;
     justify-content: flex-start;
+    overscroll-behavior: contain;
 }
 .content-body {
     flex: 1 1 auto;


### PR DESCRIPTION
Fixes #1154

When the popup is scrolled to the very bottom and you continue to scroll this is overscroll. The default overscroll behavior is to start scrolling the parent scrollbar (in this case the parent page outside the popup) after the focused scroll element is at the bottom.

For the yomitan popup this doesn't make sense. Setting it to contain makes it so overscroll will do nothing and not propogate to the parent page.

(This change doesn't actually limit itself to the popup but all of our scrollable settings modals already use `overscroll: contain` anyways so theres no conflict)