### PR TITLE
Change placeholder info to different color in dark mode

### DIFF
--- a/ext/css/popup-preview.css
+++ b/ext/css/popup-preview.css
@@ -137,6 +137,7 @@ body {
     transition: opacity var(--animation-duration) linear 0s, visibility 0s linear var(--animation-duration);
 }
 .placeholder-info.placeholder-info-visible {
+    color: var(--example-text-color);
     visibility: visible;
     opacity: 1;
     transition: opacity var(--animation-duration) linear 0s, visibility 0s linear 0s;


### PR DESCRIPTION
I saw that the color was a bit hard to read in dark mode, so I just updated it to use the example text color in popup-preview.css.
I don't know if I did this right, but it seemed to work for me... (light and dark mode works as intended for me)

Before:
![image](https://github.com/themoeway/yomitan/assets/149911531/c1485bd7-1105-46e0-a3a4-2548da67a22c)

After:
![image](https://github.com/themoeway/yomitan/assets/149911531/f0304fe3-6283-43fa-859b-b6aae920927f)

Light mode:
![image](https://github.com/themoeway/yomitan/assets/149911531/c5a6970e-7683-403e-ab11-f81f3c28533f)
