### PR TITLE
Remove preparing themecontroller on parent page to avoid css collisions changing themes on the parent page

### DIFF
--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -481,7 +481,6 @@ export class TextScanner extends EventDispatcher {
 
                 /** @type {ThemeController} */
                 this._themeController = new ThemeController(document.documentElement);
-                this._themeController.prepare();
                 const pageTheme = this._themeController.computeSiteTheme();
 
                 this.trigger('searchSuccess', {


### PR DESCRIPTION
Fixes #1166

Themecontroller doesnt actually need to be prepared here. `computeSiteTheme` doesn't use any of the prepared values.