### PR TITLE
Override Search text with non-Japanese characters when language is not Japanese

### DIFF
--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -19,7 +19,7 @@
 import {applyTextReplacement} from '../general/regex-util.js';
 import {isCodePointJapanese} from './ja/japanese.js';
 import {LanguageTransformer} from './language-transformer.js';
-import {getAllLanguageTextProcessors, getAllLanguageReadingNormalizers} from './languages.js';
+import {getAllLanguageReadingNormalizers, getAllLanguageTextProcessors} from './languages.js';
 import {MultiLanguageTransformer} from './multi-language-transformer.js';
 
 /**
@@ -219,7 +219,7 @@ export class Translator {
      */
     async _findTermsInternal(text, options, tagAggregator) {
         const {removeNonJapaneseCharacters, enabledDictionaryMap} = options;
-        if (removeNonJapaneseCharacters) {
+        if (removeNonJapaneseCharacters && options.language === 'ja') {
             text = this._getJapaneseOnlyText(text);
         }
         if (text.length === 0) {


### PR DESCRIPTION
Theres also a place for this when searching kanji but I've opted to not add this check there since it should be irrelevant.