### PR TITLE
[en] fix phrasal verbs with interposed 'it' or 'one'

### DIFF
--- a/ext/js/language/en/english-transforms.js
+++ b/ext/js/language/en/english-transforms.js
@@ -59,7 +59,7 @@ const thirdPersonSgPresentSuffixInflections = [
 ];
 
 const phrasalVerbParticles = ['aboard', 'about', 'above', 'across', 'ahead', 'alongside', 'apart', 'around', 'aside', 'astray', 'away', 'back', 'before', 'behind', 'below', 'beneath', 'besides', 'between', 'beyond', 'by', 'close', 'down', 'east', 'west', 'north', 'south', 'eastward', 'westward', 'northward', 'southward', 'forward', 'backward', 'backwards', 'forwards', 'home', 'in', 'inside', 'instead', 'near', 'off', 'on', 'opposite', 'out', 'outside', 'over', 'overhead', 'past', 'round', 'since', 'through', 'throughout', 'together', 'under', 'underneath', 'up', 'within', 'without'];
-const phrasalVerbPrepositions = ['aback', 'about', 'above', 'across', 'after', 'against', 'ahead', 'along', 'among', 'apart', 'around', 'as', 'aside', 'at', 'away', 'back', 'before', 'behind', 'below', 'between', 'beyond', 'by', 'down', 'even', 'for', 'forth', 'forward', 'from', 'in', 'into', 'it', 'of', 'off', 'on', 'one', 'onto', 'open', 'out', 'over', 'past', 'round', 'through', 'to', 'together', 'toward', 'towards', 'under', 'up', 'upon', 'way', 'with', 'without'];
+const phrasalVerbPrepositions = ['aback', 'about', 'above', 'across', 'after', 'against', 'ahead', 'along', 'among', 'apart', 'around', 'as', 'aside', 'at', 'away', 'back', 'before', 'behind', 'below', 'between', 'beyond', 'by', 'down', 'even', 'for', 'forth', 'forward', 'from', 'in', 'into', 'of', 'off', 'on', 'onto', 'open', 'out', 'over', 'past', 'round', 'through', 'to', 'together', 'toward', 'towards', 'under', 'up', 'upon', 'way', 'with', 'without'];
 
 const particlesDisjunction = phrasalVerbParticles.join('|');
 const phrasalVerbWordSet = new Set([...phrasalVerbParticles, ...phrasalVerbPrepositions]);

--- a/test/language/english-transforms.test.js
+++ b/test/language/english-transforms.test.js
@@ -104,6 +104,8 @@ const tests = [
         valid: true,
         tests: [
             {term: 'look up', source: 'look something up',  rule: 'v_phr', reasons: ['interposed object']},
+            {term: 'look up', source: 'look it up',  rule: 'v_phr', reasons: ['interposed object']},
+            {term: 'look up', source: 'look one up',  rule: 'v_phr', reasons: ['interposed object']},
             {term: 'look up', source: 'looking up',  rule: 'v_phr', reasons: ['ing']},
             {term: 'look up', source: 'looked up',  rule: 'v_phr', reasons: ['past']},
             {term: 'look up', source: 'looks up',  rule: 'v_phr', reasons: ['3rd pers. sing. pres']},


### PR DESCRIPTION
This allows the `interposed object` deinflection when the object of a phrasal verb includes the words 'it' or 'one'.