### PR TITLE
Add Multilang Support Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## What is Yomitan?
 
-Yomitan turns your web browser into a tool for building Japanese language literacy by helping you **read** texts that would otherwise be too difficult to tackle.
+Yomitan turns your web browser into a tool for building language literacy by helping you **read** texts that would otherwise be too difficult to tackle in [many languages](#multilanguage-support).
 
 Yomitan provides powerful features not available in other browser-based dictionaries:
 
@@ -48,6 +48,10 @@ Yomitan provides powerful features not available in other browser-based dictiona
   - 🕷️ [Known browser bugs](./docs/browser-bugs.md)
   - ❓ [Frequently asked questions](./docs/faq.md)
 - 🔒 [Browser Permissions](./docs/permissions.md)
+
+## Multilanguage Support
+
+Yomitan was originally developed for Japanese language learning, but it now supports multiple languages. For more information, see the [Supported Languages](./docs/supported-languages.md) file.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## What is Yomitan?
 
-Yomitan turns your web browser into a tool for building language literacy by helping you **read** texts that would otherwise be too difficult to tackle in [many languages](#multilanguage-support).
+Yomitan turns your web browser into a tool for building language literacy by helping you **read** texts that would otherwise be too difficult to tackle in [a variety of supported languages](#multilanguage-support).
 
 Yomitan provides powerful features not available in other browser-based dictionaries:
 
@@ -48,10 +48,6 @@ Yomitan provides powerful features not available in other browser-based dictiona
   - 🕷️ [Known browser bugs](./docs/browser-bugs.md)
   - ❓ [Frequently asked questions](./docs/faq.md)
 - 🔒 [Browser Permissions](./docs/permissions.md)
-
-## Multilanguage Support
-
-Yomitan was originally developed for Japanese language learning, but it now supports multiple languages. For more information, see the [Supported Languages](./docs/supported-languages.md) file.
 
 ## Installation
 

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -1,0 +1,45 @@
+# Supported Languages
+
+Based on the extent to which deinflections and text transforms have been implemented, support levels are categorized as follows:
+
+- **Full**: Comprehensive support with all features available.
+- **Partial**: Limited support with some features available.
+
+For more information on how to add or improve support for a language, please refer to the [language features documentation](./development/language-features.md).
+
+Yomitan now supports the following languages:
+
+| Language       | Code | Support Level |
+| -------------- | ---- | ------------- |
+| Albanian       | sq   |               |
+| Ancient Greek  | grc  |               |
+| Arabic         | ar   |               |
+| Cantonese      | yue  | Full          |
+| Chinese        | zh   | Full          |
+| Dutch          | nl   |               |
+| English        | en   |               |
+| Finnish        | fi   |               |
+| French         | fr   |               |
+| German         | de   |               |
+| Greek          | el   |               |
+| Hungarian      | hu   |               |
+| Indonesian     | id   |               |
+| Italian        | it   |               |
+| Japanese       | ja   | Full          |
+| Khmer          | km   |               |
+| Korean         | ko   | Full          |
+| Lao            | lo   |               |
+| Latin          | la   |               |
+| Mongolian      | mn   |               |
+| Old Irish      | sga  |               |
+| Persian        | fa   |               |
+| Polish         | pl   |               |
+| Portuguese     | pt   |               |
+| Romanian       | ro   |               |
+| Russian        | ru   |               |
+| Serbo-Croatian | sh   |               |
+| Spanish        | es   |               |
+| Swedish        | sv   |               |
+| Thai           | th   |               |
+| Turkish        | tr   |               |
+| Vietnamese     | vi   |               |

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -1,45 +1,42 @@
 # Supported Languages
 
-Based on the extent to which deinflections and text transforms have been implemented, support levels are categorized as follows:
+Yomitan supports a variety of languages, although the level of support may vary depending on the extent to which deinflections and text transforms have been implemented.
 
-- **Full**: Comprehensive support with all features available.
-- **Partial**: Limited support with some features available.
+These are the languages currently supported by Yomitan:
+
+| Language       | Code |
+| -------------- | ---- |
+| Albanian       | sq   |
+| Ancient Greek  | grc  |
+| Arabic         | ar   |
+| Cantonese      | yue  |
+| Chinese        | zh   |
+| Dutch          | nl   |
+| English        | en   |
+| Finnish        | fi   |
+| French         | fr   |
+| German         | de   |
+| Greek          | el   |
+| Hungarian      | hu   |
+| Indonesian     | id   |
+| Italian        | it   |
+| Japanese       | ja   |
+| Khmer          | km   |
+| Korean         | ko   |
+| Lao            | lo   |
+| Latin          | la   |
+| Mongolian      | mn   |
+| Old Irish      | sga  |
+| Persian        | fa   |
+| Polish         | pl   |
+| Portuguese     | pt   |
+| Romanian       | ro   |
+| Russian        | ru   |
+| Serbo-Croatian | sh   |
+| Spanish        | es   |
+| Swedish        | sv   |
+| Thai           | th   |
+| Turkish        | tr   |
+| Vietnamese     | vi   |
 
 For more information on how to add or improve support for a language, please refer to the [language features documentation](./development/language-features.md).
-
-Yomitan now supports the following languages:
-
-| Language       | Code | Support Level |
-| -------------- | ---- | ------------- |
-| Albanian       | sq   |               |
-| Ancient Greek  | grc  |               |
-| Arabic         | ar   |               |
-| Cantonese      | yue  | Full          |
-| Chinese        | zh   | Full          |
-| Dutch          | nl   |               |
-| English        | en   |               |
-| Finnish        | fi   |               |
-| French         | fr   |               |
-| German         | de   |               |
-| Greek          | el   |               |
-| Hungarian      | hu   |               |
-| Indonesian     | id   |               |
-| Italian        | it   |               |
-| Japanese       | ja   | Full          |
-| Khmer          | km   |               |
-| Korean         | ko   | Full          |
-| Lao            | lo   |               |
-| Latin          | la   |               |
-| Mongolian      | mn   |               |
-| Old Irish      | sga  |               |
-| Persian        | fa   |               |
-| Polish         | pl   |               |
-| Portuguese     | pt   |               |
-| Romanian       | ro   |               |
-| Russian        | ru   |               |
-| Serbo-Croatian | sh   |               |
-| Spanish        | es   |               |
-| Swedish        | sv   |               |
-| Thai           | th   |               |
-| Turkish        | tr   |               |
-| Vietnamese     | vi   |               |


### PR DESCRIPTION
I feel like the supported languages doc could be improved here. And maybe it should go in the readme instead (under a `details`)?