### PR TITLE
Allow enter button to search on android

### DIFF
--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -244,8 +244,8 @@ export class SearchDisplayController {
      */
     _onSearchKeydown(e) {
         if (e.isComposing) { return; }
-        const {code} = e;
-        if (!((code === 'Enter' || code === 'NumpadEnter') && !e.shiftKey)) { return; }
+        const {code, key} = e;
+        if (!((code === 'Enter' || key === 'Enter' || code === 'NumpadEnter') && !e.shiftKey)) { return; }
 
         // Search
         const element = /** @type {HTMLElement} */ (e.currentTarget);


### PR DESCRIPTION
Fixes #1182

On android it is impossible for a textarea element to show the "Go" or "Search" button on the keyboard instead of the newline. It requires having an input element and doing so would break the multiline capabilities of the search box.

The android newline button also does not send any keycode but it does send enter as the key name and that can be intercepted.

Tested on Firefox android and Kiwi browser.