### PR TITLE
Focus document focus controller element on the search page after body is unhidden

### DIFF
--- a/ext/js/display/search-main.js
+++ b/ext/js/display/search-main.js
@@ -53,6 +53,8 @@ await Application.main(true, async (application) => {
 
     document.body.hidden = false;
 
+    documentFocusController.focusElement();
+
     display.initializeState();
 
     document.documentElement.dataset.loaded = 'true';

--- a/ext/js/dom/document-focus-controller.js
+++ b/ext/js/dom/document-focus-controller.js
@@ -41,9 +41,7 @@ export class DocumentFocusController {
     prepare() {
         window.addEventListener('focus', this._onWindowFocus.bind(this), false);
         this._updateFocusedElement(false);
-        if (this._autofocusElement !== null && document.activeElement !== this._autofocusElement) {
-            this._autofocusElement.focus({preventScroll: true});
-        }
+        this.focusElement();
     }
 
     /**
@@ -54,6 +52,13 @@ export class DocumentFocusController {
         if (document.activeElement !== element) { return; }
         element.blur();
         this._updateFocusedElement(false);
+    }
+
+    /** */
+    focusElement() {
+        if (this._autofocusElement !== null && document.activeElement !== this._autofocusElement) {
+            this._autofocusElement.focus({preventScroll: true});
+        }
     }
 
     // Private

--- a/ext/js/dom/document-focus-controller.js
+++ b/ext/js/dom/document-focus-controller.js
@@ -41,7 +41,6 @@ export class DocumentFocusController {
     prepare() {
         window.addEventListener('focus', this._onWindowFocus.bind(this), false);
         this._updateFocusedElement(false);
-        this.focusElement();
     }
 
     /**


### PR DESCRIPTION
Fixes #1192

Due to the changes where pages are hidden until the load finishes this broke autofocus on the search bar. Browsers dont allow hidden elements to be focused. It needs to be explicitly focused after the page is unhidden.

Also removing the focus on prepare since the search page was the only page that used it.