### PR TITLE
Fix font settings defaults not appearing in settings ui

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -122,7 +122,10 @@
                                     "termDisplayMode",
                                     "sortFrequencyDictionary",
                                     "sortFrequencyDictionaryOrder",
-                                    "stickySearchHeader"
+                                    "stickySearchHeader",
+                                    "fontFamily",
+                                    "fontSize",
+                                    "lineHeight"
                                 ],
                                 "properties": {
                                     "enable": {


### PR DESCRIPTION
Directly user facing settings must be added to the required properties or they will not be updated in the settings page when they are unset.