### PR TITLE
[tl] Add diacritics removal preprocessors

### DIFF
--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -293,7 +293,10 @@ const languageDescriptors = [
         iso639_3: 'tgl',
         name: 'Tagalog',
         exampleText: 'basahin',
-        textPreprocessors: capitalizationPreprocessors,
+        textPreprocessors: {
+            ...capitalizationPreprocessors,
+            removeAlphabeticDiacritics,
+        },
     },
     {
         iso: 'tr',

--- a/types/ext/language-descriptors.d.ts
+++ b/types/ext/language-descriptors.d.ts
@@ -177,7 +177,9 @@ type AllTextProcessors = {
     };
     th: Record<string, never>;
     tl: {
-        pre: CapitalizationPreprocessors;
+        pre: CapitalizationPreprocessors & {
+            removeAlphabeticDiacritics: TextProcessor<boolean>;
+        };
     };
     tr: {
         pre: CapitalizationPreprocessors;


### PR DESCRIPTION
Normal everyday Tagalog does not use diacritics, so Yomitan fails to find any match for words which has diacritics in the dictionary. According to https://en.wikibooks.org/wiki/Tagalog/Lesson_13:
> Diacritics are normally not written in everyday usage, be it in publications or personal correspondence. The teaching of diacritics is inconsistent in Filipino schools and many Filipinos do not know how to use them. However, diacritics are normally used in dictionaries and in textbooks aimed at teaching the languages to foreigners.

![image](https://github.com/user-attachments/assets/62366b16-d514-495e-ab91-4ec33ad2560a)

Needs to be followed by diacritics removal at the dictionary level (e.g at [KTY](https://github.com/themoeway/kaikki-to-yomitan))