### PR TITLE
Remove JSON test from static analysis

### DIFF
--- a/docs/development/npm-scripts.md
+++ b/docs/development/npm-scripts.md
@@ -19,7 +19,7 @@ Scripts can be executed by running `npm run <name>`.
   Runs most of the tests that are used more frequently in the typical development process.
 
 - `test:static-analysis`
-  Runs all of the static analysis tests.
+  Runs all of the static analysis tests (excluding JSON).
 
 - `test:js`
   Runs [eslint](https://eslint.org/) on all of the JavaScript and TypeScript files in the project.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "build:libs": "node ./dev/bin/build-libs.js",
         "test": "npm run test:js && npm run test:ts && npm run test:css && npm run test:html && npm run test:unit && npm run test:unit:options && npm run test:json && npm run test:md && npm run test:build",
         "test:fast": "npm run test:js && npm run test:ts && npm run test:unit && npm run test:json:format",
-        "test:static-analysis": "npm run test:js && npm run test:ts && npm run test:css && npm run test:html && npm run test:json && npm run test:md",
+        "test:static-analysis": "npm run test:js && npm run test:ts && npm run test:css && npm run test:html && npm run test:md",
         "test:js": "npx eslint . --ignore-pattern **/*.json",
         "test:json": "npm run test:json:format && npm run test:json:types",
         "test:json:format": "npx eslint **/*.json",


### PR DESCRIPTION
#1206 
- Remove JSON test from `test:static-analysis`

Fix duplicate JSON test issue on GitHub Actions. Not sure if we want to keep the current command and make a new command without the JSON test for running on GitHub Actions only.
