### PR TITLE
Fix Overly Broad Font Family Selector

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -18,8 +18,6 @@
 
 /* Variables */
 :root {
-    /* Fonts */
-    --font-family: 'sans-serif';
     /* Strings */
     --compact-list-separator: ' | ';
 
@@ -250,9 +248,6 @@
 
 
 /* Fonts */
-* {
-    font-family: var(--font-family);
-}
 @font-face {
     font-family: kanji-stroke-orders;
     src: url('/data/fonts/kanji-stroke-orders.ttf');

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -535,9 +535,9 @@ export class Display extends EventDispatcher {
      * @param {string} lineHeight
      */
     setFontOptions(fontFamily, fontSize, lineHeight) {
-        document.documentElement.style.setProperty('--font-family', fontFamily);
         // Setting these directly rather than using the existing CSS variables
         // minimizes problems and ensures everything scales correctly
+        document.documentElement.style.fontFamily = fontFamily;
         document.documentElement.style.fontSize = `${fontSize}px`;
         document.documentElement.style.lineHeight = lineHeight;
     }


### PR DESCRIPTION
![msedge_Yomitan_Settings_and_1_more_page_-_Dev_-_Microsoft_2024-07-15_17-32-47](https://github.com/user-attachments/assets/7eb80f9a-b4c4-41c4-b42b-04f0de399c1d)

This allows users to modify css of things without using `!important`.