### PR TITLE
Fix audio menu z-index

### DIFF
--- a/ext/css/material.css
+++ b/ext/css/material.css
@@ -1241,7 +1241,7 @@ button.icon-button>.icon-button-inner {
     top: 0;
     right: 0;
     bottom: 0;
-    z-index: 101;
+    z-index: 1001;
     outline: none;
     overflow: hidden;
 }


### PR DESCRIPTION
Fixes #1238

The sticky header uses z-index 1000 and this needs to display over it.