### PR TITLE
Prevent popup scaling from throwing errors constantly

### DIFF
--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -330,7 +330,9 @@ export class Popup extends EventDispatcher {
     async setContentScale(scale) {
         this._contentScale = scale;
         this._frame.style.fontSize = `${scale}px`;
-        await this._invokeSafe('displaySetContentScale', {scale});
+        if (this._frameClient !== null && this._frameClient.isConnected() && this._frame.contentWindow !== null) {
+            await this._invokeSafe('displaySetContentScale', {scale});
+        }
     }
 
     /**


### PR DESCRIPTION
The invoke is guaranteed to fail if anything in this if isn't true. And that state occurs on every page load and frequently when scanning with a popup (maybe every 5-10 scans).
