### PR TITLE
Remove disambiguation prefix and suffix from css

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -21,8 +21,6 @@
     /* Strings */
     --compact-list-separator: ' | ';
 
-    --disambiguation-prefix: '(';
-    --disambiguation-suffix: ' only)';
     --disambiguation-separator: ', ';
     --disambiguation-reading-separator: ':';
 
@@ -1167,12 +1165,6 @@ button.action-button:active {
 .definition-disambiguation-list[data-count='0'] {
     display: none;
 }
-.definition-disambiguation-list::before {
-    content: var(--disambiguation-prefix);
-}
-.definition-disambiguation-list::after {
-    content: var(--disambiguation-suffix);
-}
 .definition-disambiguation+.definition-disambiguation::before {
     content: var(--disambiguation-separator);
 }
@@ -1270,12 +1262,6 @@ button.definition-item-expansion-button:focus:focus-visible+.definition-item-con
 }
 .frequency-disambiguation-separator::before {
     content: var(--disambiguation-reading-separator);
-}
-.frequency-disambiguation::before {
-    content: var(--disambiguation-prefix);
-}
-.frequency-disambiguation::after {
-    content: var(--disambiguation-suffix);
 }
 .frequency-disambiguation-reading {
     display: inline;
@@ -1495,12 +1481,6 @@ button.definition-item-expansion-button:focus:focus-visible+.definition-item-con
 .pronunciation-disambiguation-list {
     color: var(--text-color-light3);
     padding-right: var(--disambiguation-space);
-}
-.pronunciation-disambiguation-list::before {
-    content: var(--disambiguation-prefix);
-}
-.pronunciation-disambiguation-list::after {
-    content: var(--disambiguation-suffix);
 }
 .pronunciation-disambiguation+.pronunciation-disambiguation::before {
     content: var(--disambiguation-separator);


### PR DESCRIPTION
This can create a lot of clutter (ex: #1236).
Before:
![image](https://github.com/user-attachments/assets/d8bd2f31-5091-4fe4-ab13-d38fd7fd2e47)
After:
![image](https://github.com/user-attachments/assets/c7d1ef09-12d0-4cc1-aeac-357725c1aa99)
