### PR TITLE
Remove Hardcoded `font-family` in `search.css`

### DIFF
--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -49,7 +49,6 @@ body {
     background-color: var(--background-color);
     margin: 0;
     padding: 0;
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     color: var(--text-color);
     height: 100%;
     overflow: hidden;


### PR DESCRIPTION
Justification: the font is already set in `material.css`.
This fixes an issue where the user-selected font is not displayed in the Yomitan search page. ([discussion](https://discord.com/channels/617136488840429598/1081538711742844980/1265454716331229184))