### PR TITLE
Only contain overscroll in popup

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -382,7 +382,6 @@ a:has(rt) {
     overflow-y: scroll;
     align-items: stretch;
     justify-content: flex-start;
-    overscroll-behavior: contain;
 }
 .content-body {
     flex: 1 1 auto;
@@ -416,6 +415,9 @@ a:has(rt) {
 .content-footer {
     width: var(--content-width);
     max-width: 100%;
+}
+.contain-overscroll {
+    overscroll-behavior: contain;
 }
 
 

--- a/ext/popup.html
+++ b/ext/popup.html
@@ -21,7 +21,7 @@
 
 <div class="content-outer">
     <div class="content">
-        <div class="content-scroll scrollbar" id="content-scroll">
+        <div class="content-scroll contain-overscroll scrollbar" id="content-scroll">
             <div class="content-body" id="content-body">
                 <div class="top-progress-bar-container"><div class="progress-bar-indeterminant" id="progress-indicator" hidden></div></div>
                 <div class="content-body-inner">


### PR DESCRIPTION
This is a simple fix to #1257. It properly contains overscroll in the popup (which was the point of #1155), but leaves it untouched in the search page allowing the user to navigate back/forward using two-finger scrolling. 

Tested in Firefox 128.0.2