### PR TITLE
Fix note generator audio

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -2187,6 +2187,7 @@ export class Backend {
             const error = this._getAudioDownloadError(e);
             if (error !== null) { throw error; }
             // No audio
+            log.error(e);
             return null;
         }
 

--- a/ext/js/pages/settings/anki-deck-generator-controller.js
+++ b/ext/js/pages/settings/anki-deck-generator-controller.js
@@ -21,6 +21,7 @@ import {toError} from '../../core/to-error.js';
 import {AnkiNoteBuilder} from '../../data/anki-note-builder.js';
 import {getDynamicTemplates} from '../../data/anki-template-util.js';
 import {querySelectorNotNull} from '../../dom/query-selector.js';
+import {getLanguageSummaries} from '../../language/languages.js';
 import {TemplateRendererProxy} from '../../templates/template-renderer-proxy.js';
 
 export class AnkiDeckGeneratorController {
@@ -443,7 +444,8 @@ export class AnkiDeckGeneratorController {
             }
         }
         const idleTimeout = (Number.isFinite(options.anki.downloadTimeout) && options.anki.downloadTimeout > 0 ? options.anki.downloadTimeout : null);
-        const mediaOptions = addMedia ? {audio: {sources: options.audio.sources, preferredAudioIndex: null, idleTimeout: idleTimeout}} : null;
+        const languageSummary = getLanguageSummaries().find(({iso}) => iso === options.general.language);
+        const mediaOptions = addMedia ? {audio: {sources: options.audio.sources, preferredAudioIndex: null, idleTimeout: idleTimeout, languageSummary: languageSummary}} : null;
         const requirements = addMedia ? [...this._getDictionaryEntryMedia(dictionaryEntry), {type: 'audio'}] : [];
         const dictionaryStylesMap = this._ankiNoteBuilder.getDictionaryStylesMap(options.dictionaries);
         const {note} = await this._ankiNoteBuilder.createNote(/** @type {import('anki-note-builder').CreateNoteDetails} */ ({


### PR DESCRIPTION
Fixes a regression causing the anki note generator to fail downloading audio. This regression was introduced in #1152 and snuck in primarily through changes made in #1129 which did not cause any direct issue.

Also added a log for when audio fails to download. This never triggers when the user does not have the `{audio}` in their card template.