### PR TITLE
Move search parser option under settings modal

### DIFF
--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -174,20 +174,6 @@ h1 {
 .search-option-label {
     padding-left: 0.5em;
 }
-.search-option-pre-label {
-    padding-right: 0.5em;
-}
-#query-parser-mode-container {
-    flex: 1 1 auto;
-}
-#query-parser-mode-container:not([hidden]) {
-    display: flex;
-}
-#query-parser-mode-select {
-    flex: 1 1 auto;
-    max-width: 220px;
-    min-width: 100px;
-}
 
 /* Search styles */
 #intro {

--- a/ext/search.html
+++ b/ext/search.html
@@ -44,10 +44,6 @@
                                         <label class="toggle"><input type="checkbox" id="clipboard-monitor-enable"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
                                         <span class="search-option-label">Clipboard monitor</span>
                                     </label>
-                                    <div class="search-option" id="query-parser-mode-container" hidden>
-                                        <span class="search-option-pre-label">Parser:</span>
-                                        <select id="query-parser-mode-select"></select>
-                                    </div>
                                 </div>
                                 <div class="search-option" id="search-settings-button" data-modal-action="show,search-settings"><span class="icon" data-icon="cog"></span></div>
                             </div>
@@ -102,6 +98,17 @@
         <div class="modal-title">Search Settings</div>
     </div>
     <div class="modal-body">
+        <div class="settings-item" id="query-parser-mode-container" hidden><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label">
+                    Parser
+                </div>
+            </div>
+            <div class="settings-item-right">
+                <select id="query-parser-mode-select"></select>
+            </div>
+        </div></div>
+
         <div class="settings-item" id="search-option-wanakana"><div class="settings-item-inner">
             <div class="settings-item-left">
                 <div class="settings-item-label">


### PR DESCRIPTION
Fixes #1258

How it looks now (parser setting is hidden for users who have not set up mecab parsing):
![image](https://github.com/user-attachments/assets/bdd7ae04-044b-4234-9cb1-46c22d9cd465)
