### PR TITLE
Add toggle for debug settings

### DIFF
--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -638,6 +638,9 @@ a.heading-link-light {
 .settings-item-children.settings-item-children-group .settings-item-children {
     padding-left: 0;
 }
+:root:not([data-debug=true]) .debug-only {
+    display: none;
+}
 :root:not([data-advanced=true]) .advanced-only {
     display: none;
 }
@@ -769,6 +772,22 @@ select.short-height {
     --accent-color-transparent25: var(--advanced-color-transparent25);
 }
 
+/* Debug settings */
+.settings-group.debug-only>.settings-item::after,
+.settings-item.debug-only::after {
+    content: '';
+    background-color: var(--danger-color-lighter);
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: 100%;
+    width: 0.25em;
+}
+.debug-toggle {
+    --accent-color: var(--danger-color);
+    --accent-color-lighter: var(--danger-color-lighter);
+    --accent-color-transparent25: var(--danger-color-transparent25);
+}
 
 /* Modal */
 .modal {

--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -86,6 +86,7 @@
                                     "debugInfo",
                                     "maxResults",
                                     "showAdvanced",
+                                    "showDebug",
                                     "popupDisplayMode",
                                     "popupWidth",
                                     "popupHeight",
@@ -163,6 +164,10 @@
                                         "default": 32
                                     },
                                     "showAdvanced": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "showDebug": {
                                         "type": "boolean",
                                         "default": false
                                     },

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -559,6 +559,7 @@ export class OptionsUtil {
             this._updateVersion45,
             this._updateVersion46,
             this._updateVersion47,
+            this._updateVersion48,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1431,6 +1432,16 @@ export class OptionsUtil {
     async _updateVersion47(options) {
         for (const profile of options.profiles) {
             profile.options.scanning.scanWithoutMousemove = true;
+        }
+    }
+
+    /**
+     * - Added general.showDebug
+     * @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion48(options) {
+        for (const profile of options.profiles) {
+            profile.options.general.showDebug = false;
         }
     }
 

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -52,6 +52,15 @@
                     }'
                 ><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </span><span class="outline-item-label">Advanced</span></label>
+            <label class="button outline-item advanced-only"><span class="outline-item-left">
+                <label class="toggle debug-toggle"><input id="debug-checkbox" type="checkbox" data-setting="general.showDebug"
+                    data-transform='{
+                        "type": "setAttribute",
+                        "selector": ":root",
+                        "attribute": "data-debug"
+                    }'
+                ><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+            </span><span class="outline-item-label">Debug</span></label>
             <a href="/info.html" class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="question-mark"></span></span><span class="outline-item-label">About Yomitan</span></a>
         </div>
     </div></div>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -2521,7 +2521,7 @@
     </div>
     <div class="modal-footer">
         <button type="button" class="low-emphasis danger dictionary-database-mutating-input" id="dictionary-delete-all-button">Delete All</button>
-        <button type="button" class="low-emphasis dictionary-database-mutating-input advanced-only debug-only" id="dictionary-check-integrity">Check Integrity</button>
+        <button type="button" class="low-emphasis dictionary-database-mutating-input debug-only" id="dictionary-check-integrity">Check Integrity</button>
         <button type="button" class="low-emphasis dictionary-database-mutating-input" id="dictionary-check-updates">Check for Updates</button>
         <button type="button" class="low-emphasis dictionary-database-mutating-input" id="dictionary-import-button">Import</button>
         <button type="button" data-modal-action="hide">Close</button>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -861,7 +861,7 @@
                 <label class="toggle"><input type="checkbox" data-setting="scanning.enableSearchTags"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
-        <div class="settings-item advanced-only"><div class="settings-item-inner">
+        <div class="settings-item debug-only"><div class="settings-item-inner">
             <div class="settings-item-left">
                 <div class="settings-item-label">Show debug information</div>
                 <div class="settings-item-description">A menu option to log debugging information will be shown in the search results.</div>
@@ -2521,7 +2521,7 @@
     </div>
     <div class="modal-footer">
         <button type="button" class="low-emphasis danger dictionary-database-mutating-input" id="dictionary-delete-all-button">Delete All</button>
-        <button type="button" class="low-emphasis dictionary-database-mutating-input advanced-only" id="dictionary-check-integrity">Check Integrity</button>
+        <button type="button" class="low-emphasis dictionary-database-mutating-input advanced-only debug-only" id="dictionary-check-integrity">Check Integrity</button>
         <button type="button" class="low-emphasis dictionary-database-mutating-input" id="dictionary-check-updates">Check for Updates</button>
         <button type="button" class="low-emphasis dictionary-database-mutating-input" id="dictionary-import-button">Import</button>
         <button type="button" data-modal-action="hide">Close</button>

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -262,6 +262,7 @@ function createProfileOptionsUpdatedTestData1() {
             fontSize: 14,
             lineHeight: '1.5',
             showAdvanced: false,
+            showDebug: false,
             popupDisplayMode: 'default',
             popupWidth: 400,
             popupHeight: 250,
@@ -637,7 +638,7 @@ function createOptionsUpdatedTestData1() {
             },
         ],
         profileCurrent: 0,
-        version: 47,
+        version: 48,
         global: {
             database: {
                 prefixWildcardsSupported: false,


### PR DESCRIPTION
The base settings are reasonably chosen and only includes basic settings as is expected.

The advanced settings however, include both advanced settings as well as some settings that we should not expect even advanced users to use. These types of settings should not be considered "Advanced settings" and should be split out entirely.

Ive created "Debug settings" for this and only things that should almost never be touched by users should be included here. This toggle is only shown when advanced settings are enabled. Possibly this toggle shouldnt even be on the settings page and could be hidden away even further on the info page or something but I think it looks reasonable as I have it here.

The settings Ive put under debug for now isnt anything definitive. Theres probably more but just a super quick look these seem like obvious candidates.

Toggle:
![image](https://github.com/user-attachments/assets/d70f5635-22a8-44d7-89c9-4bdc1c2fd200)

Debug setting highlight:
![image](https://github.com/user-attachments/assets/70be263e-0771-4d0a-9a98-51c9e5f103a1)
