### PR TITLE
Expand "search non-Japanese characters" to Chinese and Cantonese

### DIFF
--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -647,7 +647,7 @@ a.heading-link-light {
 :root:not([data-advanced=false]) .basic-only {
     display: none;
 }
-:root:not([data-language=ja]) .japanese-only {
+:root:not([data-language=ja]):not([data-language=zh]):not([data-language=yue]) .jpzhyue-only {
     display: none;
 }
 .settings-item.settings-item-button,

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -219,7 +219,7 @@ export class Translator {
      */
     async _findTermsInternal(text, options, tagAggregator) {
         const {removeNonJapaneseCharacters, enabledDictionaryMap} = options;
-        if (removeNonJapaneseCharacters && options.language === 'ja') {
+        if (removeNonJapaneseCharacters && (['ja', 'zh', 'yue'].includes(options.language))) {
             text = this._getJapaneseOnlyText(text);
         }
         if (text.length === 0) {

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -21,6 +21,7 @@ import {isCodePointJapanese} from './ja/japanese.js';
 import {LanguageTransformer} from './language-transformer.js';
 import {getAllLanguageReadingNormalizers, getAllLanguageTextProcessors} from './languages.js';
 import {MultiLanguageTransformer} from './multi-language-transformer.js';
+import {isCodePointChinese} from './zh/chinese.js';
 
 /**
  * Class which finds term and kanji dictionary entries for text.
@@ -135,7 +136,7 @@ export class Translator {
      */
     async findKanji(text, options) {
         if (options.removeNonJapaneseCharacters) {
-            text = this._getJapaneseOnlyText(text);
+            text = this._getJapaneseChineseOnlyText(text);
         }
         const {enabledDictionaryMap} = options;
         /** @type {Set<string>} */
@@ -220,7 +221,7 @@ export class Translator {
     async _findTermsInternal(text, options, tagAggregator) {
         const {removeNonJapaneseCharacters, enabledDictionaryMap} = options;
         if (removeNonJapaneseCharacters && (['ja', 'zh', 'yue'].includes(options.language))) {
-            text = this._getJapaneseOnlyText(text);
+            text = this._getJapaneseChineseOnlyText(text);
         }
         if (text.length === 0) {
             return {dictionaryEntries: [], originalTextLength: 0};
@@ -636,10 +637,11 @@ export class Translator {
      * @param {string} text
      * @returns {string}
      */
-    _getJapaneseOnlyText(text) {
+    _getJapaneseChineseOnlyText(text) {
         let length = 0;
         for (const c of text) {
-            if (!isCodePointJapanese(/** @type {number} */ (c.codePointAt(0)))) {
+            const codePoint = /** @type {number} */ (c.codePointAt(0));
+            if (!isCodePointJapanese(codePoint) && !isCodePointChinese(codePoint)) {
                 return text.substring(0, length);
             }
             length += c.length;

--- a/ext/js/language/zh/chinese.js
+++ b/ext/js/language/zh/chinese.js
@@ -61,6 +61,14 @@ export function isStringPartiallyChinese(str) {
     return false;
 }
 
+/**
+ * @param {number} codePoint
+ * @returns {boolean}
+ */
+export function isCodePointChinese(codePoint) {
+    return isCodePointInRanges(codePoint, CHINESE_RANGES);
+}
+
 /** @type {import('language').ReadingNormalizer} */
 export function normalizePinyin(str) {
     return str.normalize('NFC').toLowerCase().replace(/[\s・:]|\/\//g, '');

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -413,10 +413,10 @@
                 <label class="toggle"><input type="checkbox" data-setting="scanning.selectText"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
-        <div class="settings-item japanese-only"><div class="settings-item-inner">
+        <div class="settings-item jpzhyue-only"><div class="settings-item-inner">
             <div class="settings-item-left">
-                <div class="settings-item-label">Search text with non-Japanese characters</div>
-                <div class="settings-item-description">Only applies when language is set to Japanese.</div>
+                <div class="settings-item-label">Search text with non-Japanese, Chinese, or Cantonese characters</div>
+                <div class="settings-item-description">Only applies when language is set to Japanese, Chinese, or Cantonese.</div>
             </div>
             <div class="settings-item-right">
                 <label class="toggle"><input type="checkbox" data-setting="scanning.alphanumeric"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>


### PR DESCRIPTION
Fixes #1283

The entire CJK block is searched for this so the logic already applies and theres no need for an extra setting.