### PR TITLE
Disconnect IPA text and "Downstep notation" appearance setting

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -1966,7 +1966,7 @@ button.footer-notification-close-button {
 :root[data-show-pronunciation-text=true] .pronunciation-disambiguation[data-type=reading] {
     display: none;
 }
-:root[data-show-pronunciation-text=false] .pronunciation-text-container {
+:root[data-show-pronunciation-text=false] .pronunciation[data-pronunciation-type=pitch-accent]>.pronunciation-representation-list>.pronunciation-text-container {
     display: none;
 }
 :root[data-show-pronunciation-downstep-position=false] .pronunciation-downstep-notation-container {

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -716,6 +716,7 @@ export class DisplayGenerator {
 
         const node = this._instantiate('pronunciation');
 
+        node.dataset.pronunciationType = pronunciation.type;
         node.dataset.tagCount = `${tags.length}`;
 
         let n = this._querySelector(node, '.pronunciation-tag-list');
@@ -744,6 +745,7 @@ export class DisplayGenerator {
         const node = this._instantiate('pronunciation');
 
         node.dataset.pitchAccentDownstepPosition = `${position}`;
+        node.dataset.pronunciationType = pitchAccent.type;
         if (nasalPositions.length > 0) { node.dataset.nasalMoraPosition = nasalPositions.join(' '); }
         if (devoicePositions.length > 0) { node.dataset.devoiceMoraPosition = devoicePositions.join(' '); }
         node.dataset.tagCount = `${tags.length}`;


### PR DESCRIPTION
Fixes #1262

Prevents pitch accent styles settings from touching IPA appearance.

Opted not to hide the setting for non-jp languages since theres some usage of pitch dicts in other languages and I'd rather not make the call of which languages this should apply to at the moment.