### PR TITLE
Fix infinite event listener ping-pong destroying settings page

### DIFF
--- a/ext/js/dom/dom-data-binder.js
+++ b/ext/js/dom/dom-data-binder.js
@@ -212,6 +212,9 @@ export class DOMDataBinder {
         if (!observer.hasValue) {
             return;
         }
+        if (this._getNormalizedElementType(element) === 'element') {
+            return;
+        }
         this._setElementValue(element, observer.value);
     }
 

--- a/ext/js/dom/dom-data-binder.js
+++ b/ext/js/dom/dom-data-binder.js
@@ -209,13 +209,9 @@ export class DOMDataBinder {
      * @param {import('dom-data-binder').ElementObserver<T>} observer
      */
     _onObserverChildrenUpdated(element, observer) {
-        if (!observer.hasValue) {
-            return;
+        if (observer.hasValue && this._getNormalizedElementType(element) !== 'element') {
+            this._setElementValue(element, observer.value);
         }
-        if (this._getNormalizedElementType(element) === 'element') {
-            return;
-        }
-        this._setElementValue(element, observer.value);
     }
 
     /**


### PR DESCRIPTION
Regression introduced in #1270 (ecd9ffc3).

The newly introduced `'element'` type for dom data binder to update things which are not any type of input (checkboxes, text inputs, etc) can cause an infinite loop when updating the value.

There is a potential ping-pong between https://github.com/themoeway/yomitan/blob/ecd9ffc3d1965c4835686b814cbae8309ad0f398/ext/js/dom/dom-data-binder.js#L149-L168 and https://github.com/themoeway/yomitan/blob/ecd9ffc3d1965c4835686b814cbae8309ad0f398/ext/js/dom/dom-data-binder.js#L211-L216

When the value is updated by one of them, the other triggers, updating it again, triggering the other, and so on. This can occur any time the dictionary aliases in the settings page are updated, including when it is initially loaded.

I've added a guard against `'element'` being updated by `_onObserverChildrenUpdated`. The `'element'` type can be expected to have special handling in all cases and should not need to use this.

I've also reverted the styling change that was applied to `_onObserverChildrenUpdated` in the dictionary aliases pr to make calling `this._setElementValue(element, observer.value);` appear as a more explicit action instead of a default action.

Tested on Firefox and Chromium.