### PR TITLE
Reduce anki audio error level to log

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -2187,7 +2187,7 @@ export class Backend {
             const error = this._getAudioDownloadError(e);
             if (error !== null) { throw error; }
             // No audio
-            log.error(e);
+            log.logGenericError(e, 'log');
             return null;
         }
 


### PR DESCRIPTION
Users probably almost never need to see this, it may trigger too often when a user is adding uncommon words, and the error on the extension can be annoying (#1307). Changing this to a warning also puts a warning symbol on the extension icon so I've opted against that as well.

Not using `log.log` here since I want the full error details of `log.error` to be kept (`log.log` just aliases `console.log`).