### PR TITLE
Add forvo to lycheeignore

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm ci
       - name: Build Legal
         run: npm run license-report:html
-      - uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621
+      - uses: lycheeverse/lychee-action@v1.10.0
         with:
           fail: true
           jobSummary: false

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -8,3 +8,4 @@
 ^https://chrome\.google\.com/webstore/detail/rikaikun/jipdnfibhldikgcjhfnomkfpcebammhp$
 ^https://chrome\.google\.com/webstore/detail/yomitan/likgccmbimhjbgkjambclfkhldnlhbnn$
 ^https://chrome\.google\.com/webstore/detail/yomitan-development-build/glnaenfapkkecknnmginabpmgkenenml$
+^https://forvo\.com/$

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Yomitan comes in two flavors: _stable_ and _testing_. New changes are initially 
 
 - **Microsoft Edge**
   - [stable](https://microsoftedge.microsoft.com/addons/detail/yomitan/idelnfbbmikgfiejhgmddlbkfgiifnnn)
+  - Testing: Coming soon
 
 ※ Unlike Chrome, Firefox does not allow extensions meant for testing to be hosted in the marketplace. You will have to download the desired version and side-load it yourself. You only need to do this once, and you will get updates automatically.
 


### PR DESCRIPTION
Broken link checker keeps failing for forvo even though it works when we manually check it. Let's ignore it I think forvo is blocking requests from GH

Reference: https://github.com/lycheeverse/lychee-action?tab=readme-ov-file#excluding-links-from-getting-checked