### PR TITLE
Revert scorecard version

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@dc50aa9510b46c811795eb24b2f1ba02a914e534 # v2.3.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
v2.4.0 was broken for supply-chain dependency scanning. Not sure what the reason is and I couldn't figure out why.

The installation instructions for `scorecard-action` still use 2.3.3 so I figured maybe it's not stable/mature enough to use via a GH workflow

Run
https://github.com/themoeway/yomitan/actions/runs/10479905710/job/29026505322