### PR TITLE
Fix links to Extension Settings not working on Firefox

### DIFF
--- a/ext/issues.html
+++ b/ext/issues.html
@@ -35,9 +35,14 @@
                 This may be due to a permissions issue where Yomitan hasn't been granted access to
                 the sites hosting the audio files.
             </p>
-            <p>
+            <p data-hide-for-browser="firefox firefox-mobile">
                 Check the <em>Site access</em> section of the
                 <a tabindex="0" class="extension-settings-link" data-special-url="chrome://extensions/?id={id}">extension settings pages</a>
+                and grant the extension access to <em>all sites</em> or add the specific audio host URLs.
+            </p>
+            <p data-show-for-browser="firefox firefox-mobile">
+                From your browser's address bar, go to <code>about:addons</code> and navigate to the settings for Yomitan.
+                Check the <em>Site access</em> section of the extension settings pages
                 and grant the extension access to <em>all sites</em> or add the specific audio host URLs.
             </p>
         </div></div></div></div>

--- a/ext/permissions.html
+++ b/ext/permissions.html
@@ -124,8 +124,11 @@
                     <p>
                         When enabled, Yomitan is able to scan text and show definitions in private/incognito web browser windows.
                     </p>
-                    <p>
+                    <p data-hide-for-browser="firefox firefox-mobile">
                         This option can be configured from the web browser's <a tabindex="0" class="extension-settings-link" data-special-url="chrome://extensions/?id={id}">extension settings pages</a>.
+                    </p>
+                    <p data-show-for-browser="firefox firefox-mobile">
+                        This option can be configured from the web browser's extension settings pages. From your browser's address bar, go to <code>about:addons</code> and navigate to the settings for Yomitan.
                     </p>
                 </div>
             </div>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -48,7 +48,8 @@
         </div></div>
         <div class="settings-item"><div class="settings-item-inner">
             <div class="settings-item-left">
-                <div class="settings-item-description">Further configuration is available on the <a href="/permissions.html" rel="noopener">Permissions page</a> and the web browser's <a tabindex="0" class="extension-settings-link" data-special-url="chrome://extensions/?id={id}">extension settings page</a>.</div>
+                <div class="settings-item-description" data-hide-for-browser="firefox firefox-mobile">Further configuration is available on the <a href="/permissions.html" rel="noopener">Permissions page</a> and the web browser's <a tabindex="0" class="extension-settings-link" data-special-url="chrome://extensions/?id={id}">extension settings page</a>.</div>
+                <div class="settings-item-description" data-show-for-browser="firefox firefox-mobile">Further configuration is available on the <a href="/permissions.html" rel="noopener">Permissions page</a> and the web browser's extension settings page.</div>
                 <div class="danger-text margin-above" id="permissions-disabled" hidden><strong>Yomitan features will be limited if the recommended permissions are not enabled.</strong></div>
                 <div class="success-text margin-above" id="recommended-permissions-enabled" hidden><strong>Essential Yomitan features are available.</strong></div>
                 <div class="success-text margin-above" id="full-permissions-enabled" hidden><strong>All Yomitan features are available.</strong></div>


### PR DESCRIPTION
Fixes #1327 .

Firefox does not allow to go to any priviledged (`about:`) pages without manually typing it in the address bar.
