### PR TITLE
Disable download button when dictionary is already installed

### DIFF
--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -532,7 +532,7 @@ export class DictionaryController {
         const dictionaryMoveButton = querySelectorNotNull(document, '#dictionary-move-button');
 
         /** @type {HTMLButtonElement} */
-        const dictiontaryResetAliasButton = querySelectorNotNull(document, '#dictionary-reset-alias-button');
+        const dictionaryResetAliasButton = querySelectorNotNull(document, '#dictionary-reset-alias-button');
         /** @type {HTMLButtonElement} */
         const dictionarySetAliasButton = querySelectorNotNull(document, '#dictionary-set-alias-button');
 
@@ -545,7 +545,7 @@ export class DictionaryController {
         dictionaryMoveButton.addEventListener('click', this._onDictionaryMoveButtonClick.bind(this), false);
 
         dictionarySetAliasButton.addEventListener('click', this._onDictionarySetAliasButtonClick.bind(this), false);
-        dictiontaryResetAliasButton.addEventListener('click', this._onDictionaryResetAliasButtonClick.bind(this), false);
+        dictionaryResetAliasButton.addEventListener('click', this._onDictionaryResetAliasButtonClick.bind(this), false);
 
         if (this._checkUpdatesButton !== null) {
             this._checkUpdatesButton.addEventListener('click', this._onCheckUpdatesButtonClick.bind(this), false);

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -177,10 +177,17 @@ export class DictionaryImportController {
         }
 
         const installedDictionaries = await this._settingsController.getDictionaryInfo();
-        const installedDictionaryNames = new Set(installedDictionaries.map((dictionary) => dictionary.title));
+        const installedDictionaryNames = new Set();
+        const installedDictionaryDownloadUrls = new Set();
+        for (const dictionary of installedDictionaries) {
+            installedDictionaryNames.add(dictionary.title);
+            if (dictionary.downloadUrl) {
+                installedDictionaryDownloadUrls.add(dictionary.downloadUrl);
+            }
+        }
 
         for (const {property, element} of recommendedDictionaryCategories) {
-            this._renderRecommendedDictionaryGroup(recommendedDictionaries[language][property], element, installedDictionaryNames);
+            this._renderRecommendedDictionaryGroup(recommendedDictionaries[language][property], element, installedDictionaryNames, installedDictionaryDownloadUrls);
         }
 
         /** @type {NodeListOf<HTMLElement>} */
@@ -195,8 +202,9 @@ export class DictionaryImportController {
      * @param {import('dictionary-recommended.js').Dictionary[]} recommendedDictionaries
      * @param {HTMLElement} dictionariesList
      * @param {Set<string>} installedDictionaryNames
+     * @param {Set<string>} installedDictionaryDownloadUrls
      */
-    _renderRecommendedDictionaryGroup(recommendedDictionaries, dictionariesList, installedDictionaryNames) {
+    _renderRecommendedDictionaryGroup(recommendedDictionaries, dictionariesList, installedDictionaryNames, installedDictionaryDownloadUrls) {
         const dictionariesListParent = dictionariesList.parentElement;
         dictionariesList.innerHTML = '';
         for (const dictionary of recommendedDictionaries) {
@@ -208,7 +216,7 @@ export class DictionaryImportController {
                 const label = querySelectorNotNull(template, '.settings-item-label');
                 /** @type {HTMLButtonElement} */
                 const button = querySelectorNotNull(template, '.action-button[data-action=import-recommended-dictionary]');
-                button.disabled = installedDictionaryNames.has(dictionary.name);
+                button.disabled = installedDictionaryNames.has(dictionary.name) || installedDictionaryDownloadUrls.has(dictionary.url);
 
                 const urlAttribute = document.createAttribute('data-import-url');
                 urlAttribute.value = dictionary.url;

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -176,8 +176,11 @@ export class DictionaryImportController {
             return;
         }
 
+        const installedDictionaries = await this._settingsController.getDictionaryInfo();
+        const installedDictionaryNames = new Set(installedDictionaries.map((dictionary) => dictionary.title));
+
         for (const {property, element} of recommendedDictionaryCategories) {
-            this._renderRecommendedDictionaryGroup(recommendedDictionaries[language][property], element);
+            this._renderRecommendedDictionaryGroup(recommendedDictionaries[language][property], element, installedDictionaryNames);
         }
 
         /** @type {NodeListOf<HTMLElement>} */
@@ -191,8 +194,9 @@ export class DictionaryImportController {
      *
      * @param {import('dictionary-recommended.js').Dictionary[]} recommendedDictionaries
      * @param {HTMLElement} dictionariesList
+     * @param {Set<string>} installedDictionaryNames
      */
-    _renderRecommendedDictionaryGroup(recommendedDictionaries, dictionariesList) {
+    _renderRecommendedDictionaryGroup(recommendedDictionaries, dictionariesList, installedDictionaryNames) {
         const dictionariesListParent = dictionariesList.parentElement;
         dictionariesList.innerHTML = '';
         for (const dictionary of recommendedDictionaries) {
@@ -202,7 +206,9 @@ export class DictionaryImportController {
                 }
                 const template = this._settingsController.instantiateTemplate('recommended-dictionaries-list-item');
                 const label = querySelectorNotNull(template, '.settings-item-label');
+                /** @type {HTMLButtonElement} */
                 const button = querySelectorNotNull(template, '.action-button[data-action=import-recommended-dictionary]');
+                button.disabled = installedDictionaryNames.has(dictionary.name);
 
                 const urlAttribute = document.createAttribute('data-import-url');
                 urlAttribute.value = dictionary.url;

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -177,7 +177,9 @@ export class DictionaryImportController {
         }
 
         const installedDictionaries = await this._settingsController.getDictionaryInfo();
+        /** @type {Set<string>} */
         const installedDictionaryNames = new Set();
+        /** @type {Set<string>} */
         const installedDictionaryDownloadUrls = new Set();
         for (const dictionary of installedDictionaries) {
             installedDictionaryNames.add(dictionary.title);


### PR DESCRIPTION
Currently works for KANJIDIC and BCCWJ.
In `recommended-dictionaries.json`, Jitendex has its title hardcoded as `Jitendex`, but the title of it after installed from the recommended section is `Jitendex.org [2024-08-11]`. Don't know if we have control over the title of Jitendex,

![image](https://github.com/user-attachments/assets/db6c5f2f-18de-41fb-a304-843fe2f47f4d)

Fixes #1333