### PR TITLE
Paste on search page will trigger search

### DIFF
--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -292,8 +292,11 @@ export class SearchDisplayController {
         if (!text) {
             return;
         }
-        this._queryInput.value = text;
-        this._searchButton.click();
+        if (this._queryInput.value !== text) {
+            this._queryInput.value = text;
+            this._updateSearchHeight(true);
+            this._searchButton.click();
+        }
     }
 
     /** @type {import('application').ApiHandler<'searchDisplayControllerUpdateSearchQuery'>} */

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -107,6 +107,7 @@ export class SearchDisplayController {
         this._searchBackButton.addEventListener('click', this._onSearchBackButtonClick.bind(this), false);
         this._wanakanaEnableCheckbox.addEventListener('change', this._onWanakanaEnableChange.bind(this));
         window.addEventListener('copy', this._onCopy.bind(this));
+        window.addEventListener('paste', this._onPaste.bind(this));
         this._clipboardMonitor.on('change', this._onClipboardMonitorChange.bind(this));
         this._clipboardMonitorEnableCheckbox.addEventListener('change', this._onClipboardMonitorEnableChange.bind(this));
         this._stickyHeaderEnableCheckbox.addEventListener('change', this._onStickyHeaderEnableChange.bind(this));
@@ -276,6 +277,23 @@ export class SearchDisplayController {
     async _onCopy() {
         // Ignore copy from search page
         this._clipboardMonitor.setPreviousText(document.hasFocus() ? await this._clipboardReaderLike.getText(false) : '');
+    }
+
+    /**
+     * @param {ClipboardEvent} e
+     */
+    _onPaste(e) {
+        if (e.target === this._queryInput) {
+            return;
+        }
+        e.stopPropagation();
+        e.preventDefault();
+        const text = e.clipboardData?.getData('text');
+        if (!text) {
+            return;
+        }
+        this._queryInput.value = text;
+        this._searchButton.click();
     }
 
     /** @type {import('application').ApiHandler<'searchDisplayControllerUpdateSearchQuery'>} */


### PR DESCRIPTION
Fixes #1346

Paste on everywhere (except on input field) will update the search input and trigger search. 
Should this be default behavior or we need to make it as an option?
