### PR TITLE
Remove unneeded PointerEvent check in _onRecommendedImportClick

### DIFF
--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -108,7 +108,6 @@ export class DictionaryImportController {
      * @param {MouseEvent} e
      */
     async _onRecommendedImportClick(e) {
-        if (!(e instanceof PointerEvent)) { return; }
         if (!e.target || !(e.target instanceof HTMLButtonElement)) { return; }
 
         const import_url = e.target.attributes.getNamedItem('data-import-url');


### PR DESCRIPTION
It is already validated that this wont trigger on something insane due to this being attached to a `click` event listener. Explicitly checkout for PointerEvent creates issues for users tabbing around and for users trying to use touchscreens.

Fixes #1350