### PR TITLE
remove regex for iso 639 code in dictionary index

### DIFF
--- a/ext/data/schemas/dictionary-index-schema.json
+++ b/ext/data/schemas/dictionary-index-schema.json
@@ -4,8 +4,7 @@
     "definitions": {
         "isoLanguageCode": {
             "type": "string",
-            "description": "ISO language code (ISO 639-1 where possible, ISO 639-3 otherwise).",
-            "pattern": "^(aa|ab|ae|af|afb|ak|am|an|ar|as|av|ay|az|az|ba|be|bg|bh|bi|bm|bn|bo|br|bs|ca|ce|ch|co|cr|cs|cu|cv|cy|da|de|dv|dz|ee|el|en|eo|es|et|eu|fa|ff|fi|fj|fo|fr|fy|ga|gd|gl|gn|grc|gu|gv|ha|he|hi|ho|hr|ht|hu|hy|hz|ia|id|ie|ig|ii|ik|io|is|it|iu|ja|jv|ka|kg|ki|kj|kk|kl|km|kn|ko|kr|ks|ku|kv|kw|ky|la|lb|lg|li|ln|lo|lt|lu|lv|mg|mh|mi|mk|ml|mn|mr|ms|mt|my|na|nb|nd|ne|ng|nl|nn|no|nr|nv|ny|oc|oj|om|or|os|pa|pi|pl|ps|pt|qu|rm|rn|ro|ru|rw|sa|sc|sd|se|sg|sga|sh|si|sk|sl|sm|sn|so|sq|sr|ss|st|su|sv|sw|ta|te|tg|th|ti|tk|tl|tn|to|tr|ts|tt|tw|ty|ug|uk|ur|uz|ve|vi|vo|wa|wo|xh|yi|yo|yue|za|zh|zu)$"
+            "description": "ISO language code (ISO 639-1 where possible, ISO 639-3 otherwise)."
         }
     },
     "type": "object",


### PR DESCRIPTION
Closes #1338
This regex requires constant updating to not cause dictionaries to fail, and I don't think there is any benefit from it right now. 