### PR TITLE
Allow add Anki cards on search page when Yomitan is disabled

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1299,7 +1299,7 @@ export class Backend {
         let apiKey = options.anki.apiKey;
         if (apiKey === '') { apiKey = null; }
         this._anki.server = options.anki.server;
-        this._anki.enabled = options.anki.enable && enabled;
+        this._anki.enabled = options.anki.enable;
         this._anki.apiKey = apiKey;
 
         this._mecab.setEnabled(options.parsing.enableMecabParser && enabled);


### PR DESCRIPTION
Currently `anki.enabled` is always `false` if Yomitan is disabled, which makes Anki not working when using search page
Any problem if we keep Anki enabled even though Yomitan is disabled?

Fixes #1008

@Kuuuube thoughts?