### PR TITLE
Fix recommended dictionary download queue

### DIFF
--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -125,7 +125,7 @@ export class DictionaryImportController {
 
                 const importProgressTracker = new ImportProgressTracker(this._getUrlImportSteps(), 1);
                 const onProgress = importProgressTracker.onProgress.bind(importProgressTracker);
-                void this._importDictionaries(
+                void await this._importDictionaries(
                     this._generateFilesFromUrls([url], onProgress),
                     importProgressTracker,
                 );

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -125,7 +125,7 @@ export class DictionaryImportController {
 
                 const importProgressTracker = new ImportProgressTracker(this._getUrlImportSteps(), 1);
                 const onProgress = importProgressTracker.onProgress.bind(importProgressTracker);
-                void await this._importDictionaries(
+                await this._importDictionaries(
                     this._generateFilesFromUrls([url], onProgress),
                     importProgressTracker,
                 );

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -120,7 +120,7 @@ export class DictionaryImportController {
         while (this._recommendedDictionaryQueue.length > 0) {
             this._recommendedDictionaryActiveImport = true;
             try {
-                const url = this._recommendedDictionaryQueue.shift();
+                const url = this._recommendedDictionaryQueue[0];
                 if (!url) { continue; }
 
                 const importProgressTracker = new ImportProgressTracker(this._getUrlImportSteps(), 1);
@@ -129,6 +129,7 @@ export class DictionaryImportController {
                     this._generateFilesFromUrls([url], onProgress),
                     importProgressTracker,
                 );
+                void this._recommendedDictionaryQueue.shift();
             } catch (error) {
                 log.error(error);
             }
@@ -219,7 +220,11 @@ export class DictionaryImportController {
                 const homepage = querySelectorNotNull(template, '.homepage');
                 /** @type {HTMLButtonElement} */
                 const button = querySelectorNotNull(template, '.action-button[data-action=import-recommended-dictionary]');
-                button.disabled = installedDictionaryNames.has(dictionary.name) || installedDictionaryDownloadUrls.has(dictionary.downloadUrl);
+                button.disabled = (
+                    installedDictionaryNames.has(dictionary.name) ||
+                    installedDictionaryDownloadUrls.has(dictionary.downloadUrl) ||
+                    this._recommendedDictionaryQueue.includes(dictionary.downloadUrl)
+                );
 
                 const urlAttribute = document.createAttribute('data-import-url');
                 urlAttribute.value = dictionary.downloadUrl;


### PR DESCRIPTION
- The download queue does not work because the `_importDictionaries` call is not awaited so the function ends immediately without checking any other item in queue.
- When the dictionary is in queue, disable its download button. Currently, if the user reopens the recommended dictionary modal, the download button is still active.
