### PR TITLE
Enable `jsonc/sort-keys` on `recommended-dictionaries.json`, Update `recommended-dictionaries-schema.json`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -678,7 +678,20 @@
                 "ext/data/recommended-dictionaries.json"
             ],
             "rules": {
-                "jsonc/sort-keys": ["error", "asc"]
+                "jsonc/sort-keys": ["error", {
+                    "pathPattern": "^\\w+.\\w+\\[\\d+\\]$",
+                    "order": [
+                        "name",
+                        "description",
+                        "homepage",
+                        "downloadUrl"
+                    ]
+                }, {
+                    "pathPattern": ".*",
+                    "order": {
+                        "type": "asc"
+                    }
+                }]
             }
         }
     ]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -672,6 +672,14 @@
                 "crypto": "readonly",
                 "AbortController": "readonly"
             }
+        },
+        {
+            "files": [
+                "ext/data/recommended-dictionaries.json"
+            ],
+            "rules": {
+                "jsonc/sort-keys": ["error", "asc"]
+            }
         }
     ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -679,7 +679,8 @@
             ],
             "rules": {
                 "jsonc/sort-keys": ["error", {
-                    "pathPattern": "^\\w+.\\w+\\[\\d+\\]$",
+                    "pathPattern": ".*",
+                    "hasProperties": ["name"],
                     "order": [
                         "name",
                         "description",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,5 +30,13 @@
     "files.trimTrailingWhitespace": true,
     "html-validate.validate": [
         "html"
+    ],
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "/ext/data/recommended-dictionaries.json"
+            ],
+            "url": "/ext/data/schemas/recommended-dictionaries-schema.json"
+        }
     ]
 }

--- a/ext/data/recommended-dictionaries.json
+++ b/ext/data/recommended-dictionaries.json
@@ -6,10 +6,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-afb-en",
                 "description": "Gulf Arabic to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-afb-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-afb-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-afb-en.zip"
             }
         ]
     },
@@ -20,10 +20,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-ang-en",
                 "description": "Old English to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ang-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-ang-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ang-en.zip"
             }
         ]
     },
@@ -34,10 +34,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-ar-en",
                 "description": "Arabic to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ar-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-ar-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ar-en.zip"
             }
         ]
     },
@@ -48,10 +48,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-cs-en",
                 "description": "Czech to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-cs-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-cs-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-cs-en.zip"
             }
         ]
     },
@@ -62,10 +62,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-de-en",
                 "description": "German to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-de-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-de-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-de-en.zip"
             }
         ]
     },
@@ -76,10 +76,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-el-en",
                 "description": "Greek to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-el-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-el-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-el-en.zip"
             }
         ]
     },
@@ -90,10 +90,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-enm-en",
                 "description": "Middle English to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-enm-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-enm-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-enm-en.zip"
             }
         ]
     },
@@ -104,10 +104,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-eo-en",
                 "description": "Esperanto to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-eo-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-eo-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-eo-en.zip"
             }
         ]
     },
@@ -118,10 +118,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-es-en",
                 "description": "Spanish to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-es-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-es-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-es-en.zip"
             }
         ]
     },
@@ -132,10 +132,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-fa-en",
                 "description": "Persian  to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-fa-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-fa-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-fa-en.zip"
             }
         ]
     },
@@ -146,10 +146,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-fi-en",
                 "description": "Finnish to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-fi-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-fi-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-fi-en.zip"
             }
         ]
     },
@@ -160,10 +160,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-fr-en",
                 "description": "French to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-fr-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-fr-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-fr-en.zip"
             }
         ]
     },
@@ -174,10 +174,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-grc-en",
                 "description": "Ancient Greek to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-grc-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-grc-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-grc-en.zip"
             }
         ]
     },
@@ -188,10 +188,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-hi-en",
                 "description": "Hindi to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-hi-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-hi-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-hi-en.zip"
             }
         ]
     },
@@ -202,10 +202,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-hu-en",
                 "description": "Hungarian to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-hu-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-hu-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-hu-en.zip"
             }
         ]
     },
@@ -216,10 +216,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-id-en",
                 "description": "Indonesian to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-id-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-id-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-id-en.zip"
             }
         ]
     },
@@ -230,38 +230,38 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-it-en",
                 "description": "Italian to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-it-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-it-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-it-en.zip"
             }
         ]
     },
     "ja": {
         "frequency": [
             {
+                "name": "BCCWJ",
                 "description": "Based on the Balanced Corpus of Contemporary Written Japanese covering books, magazines, newspapers, blogs, forums, textbooks, and legal documents among others.",
-                "downloadUrl": "https://github.com/Kuuuube/yomitan-dictionaries/releases/download/yomitan-permalink/BCCWJ_SUW_LUW_combined.zip",
                 "homepage": "https://github.com/Kuuuube/yomitan-dictionaries?tab=readme-ov-file#bccwj-suw-luw-combined",
-                "name": "BCCWJ"
+                "downloadUrl": "https://github.com/Kuuuube/yomitan-dictionaries/releases/download/yomitan-permalink/BCCWJ_SUW_LUW_combined.zip"
             }
         ],
         "grammar": [],
         "kanji": [
             {
+                "name": "KANJIDIC",
                 "description": "An English dictionary with readings, meanings, stroke order diagrams, frequency, grade level, JLPT level and frequency of kanji characters.",
-                "downloadUrl": "https://github.com/themoeway/jmdict-yomitan/releases/latest/download/KANJIDIC_english.zip",
                 "homepage": "https://github.com/themoeway/jmdict-yomitan?tab=readme-ov-file#kanjidic-for-yomitan",
-                "name": "KANJIDIC"
+                "downloadUrl": "https://github.com/themoeway/jmdict-yomitan/releases/latest/download/KANJIDIC_english.zip"
             }
         ],
         "pronunciation": [],
         "terms": [
             {
+                "name": "Jitendex",
                 "description": "A free and openly licensed Japanese-to-English dictionary with example sentences, usage notes, etymology notes, cross references, antonyms, definition notes.",
-                "downloadUrl": "https://github.com/stephenmk/stephenmk.github.io/releases/latest/download/jitendex-yomitan.zip",
                 "homepage": "https://jitendex.org",
-                "name": "Jitendex"
+                "downloadUrl": "https://github.com/stephenmk/stephenmk.github.io/releases/latest/download/jitendex-yomitan.zip"
             }
         ]
     },
@@ -272,10 +272,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-km-en",
                 "description": "Khmer to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-km-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-km-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-km-en.zip"
             }
         ]
     },
@@ -286,10 +286,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-kn-en",
                 "description": "Kannada to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-kn-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-kn-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-kn-en.zip"
             }
         ]
     },
@@ -300,10 +300,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-ko-en",
                 "description": "Korean to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ko-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-ko-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ko-en.zip"
             }
         ]
     },
@@ -314,10 +314,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-la-en",
                 "description": "Latin to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-la-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-la-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-la-en.zip"
             }
         ]
     },
@@ -328,10 +328,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-lv-en",
                 "description": "Latvian to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-lv-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-lv-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-lv-en.zip"
             }
         ]
     },
@@ -342,10 +342,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-mn-en",
                 "description": "Mongolian to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-mn-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-mn-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-mn-en.zip"
             }
         ]
     },
@@ -356,10 +356,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-nl-en",
                 "description": "Dutch to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-nl-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-nl-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-nl-en.zip"
             }
         ]
     },
@@ -370,10 +370,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-pl-en",
                 "description": "Polish to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-pl-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-pl-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-pl-en.zip"
             }
         ]
     },
@@ -384,10 +384,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-pt-en",
                 "description": "Portuguese to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-pt-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-pt-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-pt-en.zip"
             }
         ]
     },
@@ -398,10 +398,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-ro-en",
                 "description": "Romanian to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ro-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-ro-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ro-en.zip"
             }
         ]
     },
@@ -412,10 +412,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-ru-en",
                 "description": "Russian to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ru-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-ru-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ru-en.zip"
             }
         ]
     },
@@ -426,10 +426,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-scn-en",
                 "description": "Sicillian to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-scn-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-scn-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-scn-en.zip"
             }
         ]
     },
@@ -440,10 +440,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-sga-en",
                 "description": "Old Irish to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sga-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-sga-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sga-en.zip"
             }
         ]
     },
@@ -454,10 +454,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-sh-en",
                 "description": "Serbo-Croatian to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sh-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-sh-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sh-en.zip"
             }
         ]
     },
@@ -468,10 +468,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-sq-en",
                 "description": "Albanian to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sq-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-sq-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sq-en.zip"
             }
         ]
     },
@@ -482,10 +482,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-sv-en",
                 "description": "Swedish to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sv-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-sv-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sv-en.zip"
             }
         ]
     },
@@ -496,10 +496,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-th-en",
                 "description": "Thai to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-th-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-th-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-th-en.zip"
             }
         ]
     },
@@ -510,10 +510,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-tl-en",
                 "description": "Tagalog to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-tl-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-tl-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-tl-en.zip"
             }
         ]
     },
@@ -524,10 +524,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-tr-en",
                 "description": "Turkish to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-tr-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-tr-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-tr-en.zip"
             }
         ]
     },
@@ -538,10 +538,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-uk-en",
                 "description": "Ukranian to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-uk-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-uk-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-uk-en.zip"
             }
         ]
     },
@@ -552,10 +552,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-vi-en",
                 "description": "Vietnamese to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-vi-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-vi-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-vi-en.zip"
             }
         ]
     },
@@ -566,10 +566,10 @@
         "pronunciation": [],
         "terms": [
             {
+                "name": "kty-zh-en",
                 "description": "Chinese to English dictionary created from Wiktionary data.",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-zh-en.zip",
                 "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
-                "name": "kty-zh-en"
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-zh-en.zip"
             }
         ]
     }

--- a/ext/data/recommended-dictionaries.json
+++ b/ext/data/recommended-dictionaries.json
@@ -1,576 +1,576 @@
 {
     "afb": {
-        "terms": [
-            {
-                "name": "kty-afb-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-afb-en.zip",
-                "description": "Gulf Arabic to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Gulf Arabic to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-afb-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-afb-en"
+            }
+        ]
     },
     "ang": {
-        "terms": [
-            {
-                "name": "kty-ang-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ang-en.zip",
-                "description": "Old English to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Old English to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ang-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-ang-en"
+            }
+        ]
     },
     "ar": {
-        "terms": [
-            {
-                "name": "kty-ar-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ar-en.zip",
-                "description": "Arabic to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Arabic to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ar-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-ar-en"
+            }
+        ]
     },
     "cs": {
-        "terms": [
-            {
-                "name": "kty-cs-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-cs-en.zip",
-                "description": "Czech to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Czech to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-cs-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-cs-en"
+            }
+        ]
     },
     "de": {
-        "terms": [
-            {
-                "name": "kty-de-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-de-en.zip",
-                "description": "German to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "German to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-de-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-de-en"
+            }
+        ]
     },
     "el": {
-        "terms": [
-            {
-                "name": "kty-el-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-el-en.zip",
-                "description": "Greek to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Greek to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-el-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-el-en"
+            }
+        ]
     },
     "enm": {
-        "terms": [
-            {
-                "name": "kty-enm-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-enm-en.zip",
-                "description": "Middle English to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Middle English to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-enm-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-enm-en"
+            }
+        ]
     },
     "eo": {
-        "terms": [
-            {
-                "name": "kty-eo-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-eo-en.zip",
-                "description": "Esperanto to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Esperanto to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-eo-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-eo-en"
+            }
+        ]
     },
     "es": {
-        "terms": [
-            {
-                "name": "kty-es-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-es-en.zip",
-                "description": "Spanish to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Spanish to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-es-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-es-en"
+            }
+        ]
     },
     "fa": {
-        "terms": [
-            {
-                "name": "kty-fa-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-fa-en.zip",
-                "description": "Persian  to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Persian  to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-fa-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-fa-en"
+            }
+        ]
     },
     "fi": {
+        "frequency": [],
+        "grammar": [],
+        "kanji": [],
+        "pronunciation": [],
         "terms": [
             {
-                "name": "kty-fi-en",
                 "description": "Finnish to English dictionary created from Wiktionary data.",
                 "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-fi-en.zip",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-fi-en"
             }
-        ],
-        "kanji": [],
-        "frequency": [],
-        "grammar": [],
-        "pronunciation": []
+        ]
     },
     "fr": {
-        "terms": [
-            {
-                "name": "kty-fr-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-fr-en.zip",
-                "description": "French to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "French to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-fr-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-fr-en"
+            }
+        ]
     },
     "grc": {
-        "terms": [
-            {
-                "name": "kty-grc-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-grc-en.zip",
-                "description": "Ancient Greek to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Ancient Greek to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-grc-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-grc-en"
+            }
+        ]
     },
     "hi": {
-        "terms": [
-            {
-                "name": "kty-hi-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-hi-en.zip",
-                "description": "Hindi to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Hindi to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-hi-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-hi-en"
+            }
+        ]
     },
     "hu": {
-        "terms": [
-            {
-                "name": "kty-hu-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-hu-en.zip",
-                "description": "Hungarian to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Hungarian to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-hu-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-hu-en"
+            }
+        ]
     },
     "id": {
-        "terms": [
-            {
-                "name": "kty-id-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-id-en.zip",
-                "description": "Indonesian to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Indonesian to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-id-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-id-en"
+            }
+        ]
     },
     "it": {
-        "terms": [
-            {
-                "name": "kty-it-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-it-en.zip",
-                "description": "Italian to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Italian to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-it-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-it-en"
+            }
+        ]
     },
     "ja": {
-        "terms": [
-            {
-                "name": "Jitendex",
-                "downloadUrl": "https://github.com/stephenmk/stephenmk.github.io/releases/latest/download/jitendex-yomitan.zip",
-                "description": "A free and openly licensed Japanese-to-English dictionary with example sentences, usage notes, etymology notes, cross references, antonyms, definition notes.",
-                "homepage": "https://jitendex.org"
-            }
-        ],
-        "kanji": [
-            {
-                "name": "KANJIDIC",
-                "downloadUrl": "https://github.com/themoeway/jmdict-yomitan/releases/latest/download/KANJIDIC_english.zip",
-                "description": "An English dictionary with readings, meanings, stroke order diagrams, frequency, grade level, JLPT level and frequency of kanji characters.",
-                "homepage": "https://github.com/themoeway/jmdict-yomitan?tab=readme-ov-file#kanjidic-for-yomitan"
-            }
-        ],
         "frequency": [
             {
-                "name": "BCCWJ",
-                "downloadUrl": "https://github.com/Kuuuube/yomitan-dictionaries/releases/download/yomitan-permalink/BCCWJ_SUW_LUW_combined.zip",
                 "description": "Based on the Balanced Corpus of Contemporary Written Japanese covering books, magazines, newspapers, blogs, forums, textbooks, and legal documents among others.",
-                "homepage": "https://github.com/Kuuuube/yomitan-dictionaries?tab=readme-ov-file#bccwj-suw-luw-combined"
+                "downloadUrl": "https://github.com/Kuuuube/yomitan-dictionaries/releases/download/yomitan-permalink/BCCWJ_SUW_LUW_combined.zip",
+                "homepage": "https://github.com/Kuuuube/yomitan-dictionaries?tab=readme-ov-file#bccwj-suw-luw-combined",
+                "name": "BCCWJ"
             }
         ],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [
+            {
+                "description": "An English dictionary with readings, meanings, stroke order diagrams, frequency, grade level, JLPT level and frequency of kanji characters.",
+                "downloadUrl": "https://github.com/themoeway/jmdict-yomitan/releases/latest/download/KANJIDIC_english.zip",
+                "homepage": "https://github.com/themoeway/jmdict-yomitan?tab=readme-ov-file#kanjidic-for-yomitan",
+                "name": "KANJIDIC"
+            }
+        ],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "A free and openly licensed Japanese-to-English dictionary with example sentences, usage notes, etymology notes, cross references, antonyms, definition notes.",
+                "downloadUrl": "https://github.com/stephenmk/stephenmk.github.io/releases/latest/download/jitendex-yomitan.zip",
+                "homepage": "https://jitendex.org",
+                "name": "Jitendex"
+            }
+        ]
     },
     "km": {
-        "terms": [
-            {
-                "name": "kty-km-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-km-en.zip",
-                "description": "Khmer to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Khmer to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-km-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-km-en"
+            }
+        ]
     },
     "kn": {
-        "terms": [
-            {
-                "name": "kty-kn-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-kn-en.zip",
-                "description": "Kannada to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Kannada to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-kn-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-kn-en"
+            }
+        ]
     },
     "ko": {
-        "terms": [
-            {
-                "name": "kty-ko-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ko-en.zip",
-                "description": "Korean to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Korean to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ko-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-ko-en"
+            }
+        ]
     },
     "la": {
-        "terms": [
-            {
-                "name": "kty-la-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-la-en.zip",
-                "description": "Latin to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Latin to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-la-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-la-en"
+            }
+        ]
     },
     "lv": {
-        "terms": [
-            {
-                "name": "kty-lv-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-lv-en.zip",
-                "description": "Latvian to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Latvian to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-lv-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-lv-en"
+            }
+        ]
     },
     "mn": {
-        "terms": [
-            {
-                "name": "kty-mn-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-mn-en.zip",
-                "description": "Mongolian to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Mongolian to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-mn-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-mn-en"
+            }
+        ]
     },
     "nl": {
-        "terms": [
-            {
-                "name": "kty-nl-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-nl-en.zip",
-                "description": "Dutch to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Dutch to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-nl-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-nl-en"
+            }
+        ]
     },
     "pl": {
-        "terms": [
-            {
-                "name": "kty-pl-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-pl-en.zip",
-                "description": "Polish to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Polish to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-pl-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-pl-en"
+            }
+        ]
     },
     "pt": {
-        "terms": [
-            {
-                "name": "kty-pt-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-pt-en.zip",
-                "description": "Portuguese to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Portuguese to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-pt-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-pt-en"
+            }
+        ]
     },
     "ro": {
-        "terms": [
-            {
-                "name": "kty-ro-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ro-en.zip",
-                "description": "Romanian to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Romanian to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ro-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-ro-en"
+            }
+        ]
     },
     "ru": {
-        "terms": [
-            {
-                "name": "kty-ru-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ru-en.zip",
-                "description": "Russian to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Russian to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-ru-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-ru-en"
+            }
+        ]
     },
     "scn": {
-        "terms": [
-            {
-                "name": "kty-scn-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-scn-en.zip",
-                "description": "Sicillian to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Sicillian to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-scn-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-scn-en"
+            }
+        ]
     },
     "sga": {
-        "terms": [
-            {
-                "name": "kty-sga-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sga-en.zip",
-                "description": "Old Irish to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Old Irish to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sga-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-sga-en"
+            }
+        ]
     },
     "sh": {
-        "terms": [
-            {
-                "name": "kty-sh-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sh-en.zip",
-                "description": "Serbo-Croatian to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Serbo-Croatian to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sh-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-sh-en"
+            }
+        ]
     },
     "sq": {
-        "terms": [
-            {
-                "name": "kty-sq-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sq-en.zip",
-                "description": "Albanian to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Albanian to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sq-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-sq-en"
+            }
+        ]
     },
     "sv": {
-        "terms": [
-            {
-                "name": "kty-sv-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sv-en.zip",
-                "description": "Swedish to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Swedish to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-sv-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-sv-en"
+            }
+        ]
     },
     "th": {
-        "terms": [
-            {
-                "name": "kty-th-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-th-en.zip",
-                "description": "Thai to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Thai to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-th-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-th-en"
+            }
+        ]
     },
     "tl": {
-        "terms": [
-            {
-                "name": "kty-tl-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-tl-en.zip",
-                "description": "Tagalog to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Tagalog to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-tl-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-tl-en"
+            }
+        ]
     },
     "tr": {
-        "terms": [
-            {
-                "name": "kty-tr-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-tr-en.zip",
-                "description": "Turkish to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Turkish to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-tr-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-tr-en"
+            }
+        ]
     },
     "uk": {
-        "terms": [
-            {
-                "name": "kty-uk-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-uk-en.zip",
-                "description": "Ukranian to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Ukranian to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-uk-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-uk-en"
+            }
+        ]
     },
     "vi": {
-        "terms": [
-            {
-                "name": "kty-vi-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-vi-en.zip",
-                "description": "Vietnamese to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Vietnamese to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-vi-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-vi-en"
+            }
+        ]
     },
     "zh": {
-        "terms": [
-            {
-                "name": "kty-zh-en",
-                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-zh-en.zip",
-                "description": "Chinese to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md"
-            }
-        ],
-        "kanji": [],
         "frequency": [],
         "grammar": [],
-        "pronunciation": []
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "description": "Chinese to English dictionary created from Wiktionary data.",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-zh-en.zip",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "name": "kty-zh-en"
+            }
+        ]
     }
 }

--- a/ext/data/recommended-dictionaries.json
+++ b/ext/data/recommended-dictionaries.json
@@ -83,6 +83,20 @@
             }
         ]
     },
+    "en": {
+        "frequency": [],
+        "grammar": [],
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "name": "kty-en-en",
+                "description": "English to English dictionary created from Wiktionary data.",
+                "homepage": "https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md",
+                "downloadUrl": "https://github.com/themoeway/kaikki-to-yomitan/releases/latest/download/kty-en-en.zip"
+            }
+        ]
+    },
     "enm": {
         "frequency": [],
         "grammar": [],

--- a/ext/data/schemas/recommended-dictionaries-schema.json
+++ b/ext/data/schemas/recommended-dictionaries-schema.json
@@ -10,146 +10,31 @@
                 "terms": {
                     "type": "array",
                     "items": {
-                        "type": "object",
-                        "required": [
-                            "name",
-                            "downloadUrl",
-                            "description"
-                        ],
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "downloadUrl": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "description": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "homepage": {
-                                "type": "string",
-                                "minLength": 2
-                            }
-                        }
+                        "$ref": "#/definitions/Dictionary"
                     }
                 },
                 "kanji": {
                     "type": "array",
                     "items": {
-                        "type": "object",
-                        "required": [
-                            "name",
-                            "downloadUrl",
-                            "description"
-                        ],
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "downloadUrl": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "description": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "homepage": {
-                                "type": "string",
-                                "minLength": 2
-                            }
-                        }
+                        "$ref": "#/definitions/Dictionary"
                     }
                 },
                 "frequency": {
                     "type": "array",
                     "items": {
-                        "type": "object",
-                        "required": [
-                            "name",
-                            "downloadUrl",
-                            "description"
-                        ],
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "downloadUrl": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "description": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "homepage": {
-                                "type": "string",
-                                "minLength": 2
-                            }
-                        }
+                        "$ref": "#/definitions/Dictionary"
                     }
                 },
                 "grammar": {
                     "type": "array",
                     "items": {
-                        "type": "object",
-                        "required": [
-                            "name",
-                            "downloadUrl",
-                            "description"
-                        ],
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "downloadUrl": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "description": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "homepage": {
-                                "type": "string",
-                                "minLength": 2
-                            }
-                        }
+                        "$ref": "#/definitions/Dictionary"
                     }
                 },
                 "pronunciation": {
                     "type": "array",
                     "items": {
-                        "type": "object",
-                        "required": [
-                            "name",
-                            "downloadUrl",
-                            "description"
-                        ],
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "downloadUrl": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "description": {
-                                "type": "string",
-                                "minLength": 2
-                            },
-                            "homepage": {
-                                "type": "string",
-                                "minLength": 2
-                            }
-                        }
+                        "$ref": "#/definitions/Dictionary"
                     }
                 }
             },
@@ -160,6 +45,34 @@
                 "grammar"
             ],
             "additionalProperties": false
+        }
+    },
+    "definitions": {
+        "Dictionary": {
+            "type": "object",
+            "required": [
+                "name",
+                "downloadUrl",
+                "description"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 2
+                },
+                "downloadUrl": {
+                    "type": "string",
+                    "minLength": 2
+                },
+                "description": {
+                    "type": "string",
+                    "minLength": 2
+                },
+                "homepage": {
+                    "type": "string",
+                    "minLength": 2
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves #1402

I do wonder if there's something that can be done so the dictionaries themselves are sorted by name instead of by description.