### PR TITLE
Fix CodeQL Workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,9 +21,6 @@ on:
   schedule:
     - cron: '31 13 * * 3'
 
-permissions:
-  contents: read
-
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Fix by removing duplicate `permissions`