### PR TITLE
Refactor `short causative -> passive` form

### DIFF
--- a/ext/js/language/ja/japanese-transforms.js
+++ b/ext/js/language/ja/japanese-transforms.js
@@ -126,6 +126,27 @@ const conditions = {
             },
         ],
         isDictionaryForm: false,
+        subConditions: ['v5ss', 'v5sp'],
+    },
+    'v5ss': {
+        name: 'Godan verb, short causative form having さす ending (cannot conjugate with passive form)',
+        i18n: [
+            {
+                language: 'ja',
+                name: '五段動詞、～さす',
+            },
+        ],
+        isDictionaryForm: false,
+    },
+    'v5sp': {
+        name: 'Godan verb, short causative form not having さす ending (can conjugate with passive form)',
+        i18n: [
+            {
+                language: 'ja',
+                name: '五段動詞、～す',
+            },
+        ],
+        isDictionaryForm: false,
     },
     'vk': {
         name: 'Kuru verb',
@@ -943,23 +964,23 @@ export const japaneseTransforms = {
                 },
             ],
             rules: [
-                suffixInflection('さす', 'る', ['v5s'], ['v1']),
-                suffixInflection('かす', 'く', ['v5s'], ['v5']),
-                suffixInflection('がす', 'ぐ', ['v5s'], ['v5']),
-                suffixInflection('さす', 'す', ['v5s'], ['v5']),
-                suffixInflection('たす', 'つ', ['v5s'], ['v5']),
-                suffixInflection('なす', 'ぬ', ['v5s'], ['v5']),
-                suffixInflection('ばす', 'ぶ', ['v5s'], ['v5']),
-                suffixInflection('ます', 'む', ['v5s'], ['v5']),
-                suffixInflection('らす', 'る', ['v5s'], ['v5']),
-                suffixInflection('わす', 'う', ['v5s'], ['v5']),
-                suffixInflection('じさす', 'ずる', ['v5s'], ['vz']),
-                suffixInflection('ぜさす', 'ずる', ['v5s'], ['vz']),
-                suffixInflection('さす', 'する', ['v5s'], ['vs']),
-                suffixInflection('為す', '為る', ['v5s'], ['vs']),
-                suffixInflection('こさす', 'くる', ['v5s'], ['vk']),
-                suffixInflection('来さす', '来る', ['v5s'], ['vk']),
-                suffixInflection('來さす', '來る', ['v5s'], ['vk']),
+                suffixInflection('さす', 'る', ['v5ss'], ['v1']),
+                suffixInflection('かす', 'く', ['v5sp'], ['v5']),
+                suffixInflection('がす', 'ぐ', ['v5sp'], ['v5']),
+                suffixInflection('さす', 'す', ['v5ss'], ['v5']),
+                suffixInflection('たす', 'つ', ['v5sp'], ['v5']),
+                suffixInflection('なす', 'ぬ', ['v5sp'], ['v5']),
+                suffixInflection('ばす', 'ぶ', ['v5sp'], ['v5']),
+                suffixInflection('ます', 'む', ['v5sp'], ['v5']),
+                suffixInflection('らす', 'る', ['v5sp'], ['v5']),
+                suffixInflection('わす', 'う', ['v5sp'], ['v5']),
+                suffixInflection('じさす', 'ずる', ['v5ss'], ['vz']),
+                suffixInflection('ぜさす', 'ずる', ['v5ss'], ['vz']),
+                suffixInflection('さす', 'する', ['v5ss'], ['vs']),
+                suffixInflection('為す', '為る', ['v5ss'], ['vs']),
+                suffixInflection('こさす', 'くる', ['v5ss'], ['vk']),
+                suffixInflection('来さす', '来る', ['v5ss'], ['vk']),
+                suffixInflection('來さす', '來る', ['v5ss'], ['vk']),
             ],
         },
         'imperative': {
@@ -1107,7 +1128,7 @@ export const japaneseTransforms = {
             rules: [
                 suffixInflection('かれる', 'く', ['v1'], ['v5']),
                 suffixInflection('がれる', 'ぐ', ['v1'], ['v5']),
-                suffixInflection('される', 'す', ['v1'], ['v5']),
+                suffixInflection('される', 'す', ['v1'], ['v5d', 'v5sp']),
                 suffixInflection('たれる', 'つ', ['v1'], ['v5']),
                 suffixInflection('なれる', 'ぬ', ['v1'], ['v5']),
                 suffixInflection('ばれる', 'ぶ', ['v1'], ['v5']),
@@ -1341,28 +1362,6 @@ export const japaneseTransforms = {
                 suffixInflection('来まい', '来る', [], ['vk']),
                 suffixInflection('來まい', '來る', [], ['vk']),
                 suffixInflection('まい', '', [], ['-ます']),
-            ],
-        },
-        'causative-passive': {
-            name: 'causative-passive',
-            description: 'Contraction of the passive of the causative form of verbs.\n' +
-            'Someone was made to do something by someone else.\n' +
-            'Usage: ～せられる becomes ~される (only for godan verbs)',
-            i18n: [
-                {
-                    language: 'ja',
-                    name: '～される',
-                },
-            ],
-            rules: [
-                suffixInflection('かされる', 'く', ['v1'], ['v5']),
-                suffixInflection('がされる', 'ぐ', ['v1'], ['v5']),
-                suffixInflection('たされる', 'つ', ['v1'], ['v5']),
-                suffixInflection('なされる', 'ぬ', ['v1'], ['v5']),
-                suffixInflection('ばされる', 'ぶ', ['v1'], ['v5']),
-                suffixInflection('まされる', 'む', ['v1'], ['v5']),
-                suffixInflection('らされる', 'る', ['v1'], ['v5']),
-                suffixInflection('わされる', 'う', ['v1'], ['v5']),
             ],
         },
         '-おく': {

--- a/test/language/japanese-transforms.test.js
+++ b/test/language/japanese-transforms.test.js
@@ -171,7 +171,6 @@ const tests = [
             {term: '買う', source: '買おう',           rule: 'v5', reasons: ['volitional']},
             {term: '買う', source: '買おっか',           rule: 'v5', reasons: ['volitional slang']},
             {term: '買う', source: '買うまい',       rule: 'v5', reasons: ['-まい']},
-            {term: '買う', source: '買わされる',       rule: 'v5', reasons: ['causative-passive']},
             {term: '買う', source: '買わされる',       rule: 'v5', reasons: ['short causative', 'passive']},
 
             {term: '買う', source: '買っておく',       rule: 'v5', reasons: ['-て', '-おく']},
@@ -246,7 +245,6 @@ const tests = [
             {term: '行く', source: '行こう',           rule: 'v5', reasons: ['volitional']},
             {term: '行く', source: '行こっか',           rule: 'v5', reasons: ['volitional slang']},
             {term: '行く', source: '行くまい',       rule: 'v5', reasons: ['-まい']},
-            {term: '行く', source: '行かされる',       rule: 'v5', reasons: ['causative-passive']},
             {term: '行く', source: '行かされる',       rule: 'v5', reasons: ['short causative', 'passive']},
 
             {term: '行く', source: '行っておく',       rule: 'v5', reasons: ['-て', '-おく']},
@@ -321,7 +319,6 @@ const tests = [
             {term: '泳ぐ', source: '泳ごう',           rule: 'v5', reasons: ['volitional']},
             {term: '泳ぐ', source: '泳ごっか',           rule: 'v5', reasons: ['volitional slang']},
             {term: '泳ぐ', source: '泳ぐまい',       rule: 'v5', reasons: ['-まい']},
-            {term: '泳ぐ', source: '泳がされる',       rule: 'v5', reasons: ['causative-passive']},
             {term: '泳ぐ', source: '泳がされる',       rule: 'v5', reasons: ['short causative', 'passive']},
 
             {term: '泳ぐ', source: '泳いでおく',       rule: 'v5', reasons: ['-て', '-おく']},
@@ -474,7 +471,6 @@ const tests = [
             {term: '待つ', source: '待とう',           rule: 'v5', reasons: ['volitional']},
             {term: '待つ', source: '待とっか',           rule: 'v5', reasons: ['volitional slang']},
             {term: '待つ', source: '待つまい',       rule: 'v5', reasons: ['-まい']},
-            {term: '待つ', source: '待たされる',       rule: 'v5', reasons: ['causative-passive']},
             {term: '待つ', source: '待たされる',       rule: 'v5', reasons: ['short causative', 'passive']},
 
             {term: '待つ', source: '待っておく',       rule: 'v5', reasons: ['-て', '-おく']},
@@ -550,7 +546,6 @@ const tests = [
             {term: '死ぬ', source: '死のう',           rule: 'v5', reasons: ['volitional']},
             {term: '死ぬ', source: '死のっか',           rule: 'v5', reasons: ['volitional slang']},
             {term: '死ぬ', source: '死ぬまい',       rule: 'v5', reasons: ['-まい']},
-            {term: '死ぬ', source: '死なされる',       rule: 'v5', reasons: ['causative-passive']},
             {term: '死ぬ', source: '死なされる',       rule: 'v5', reasons: ['short causative', 'passive']},
 
             {term: '死ぬ', source: '死んでおく',       rule: 'v5', reasons: ['-て', '-おく']},
@@ -624,7 +619,6 @@ const tests = [
             {term: '遊ぶ', source: '遊ぼう',           rule: 'v5', reasons: ['volitional']},
             {term: '遊ぶ', source: '遊ぼっか',           rule: 'v5', reasons: ['volitional slang']},
             {term: '遊ぶ', source: '遊ぶまい',       rule: 'v5', reasons: ['-まい']},
-            {term: '遊ぶ', source: '遊ばされる',       rule: 'v5', reasons: ['causative-passive']},
             {term: '遊ぶ', source: '遊ばされる',       rule: 'v5', reasons: ['short causative', 'passive']},
 
             {term: '遊ぶ', source: '遊んでおく',       rule: 'v5', reasons: ['-て', '-おく']},
@@ -698,7 +692,6 @@ const tests = [
             {term: '飲む', source: '飲もう',           rule: 'v5', reasons: ['volitional']},
             {term: '飲む', source: '飲もっか',           rule: 'v5', reasons: ['volitional slang']},
             {term: '飲む', source: '飲むまい',       rule: 'v5', reasons: ['-まい']},
-            {term: '飲む', source: '飲まされる',       rule: 'v5', reasons: ['causative-passive']},
             {term: '飲む', source: '飲まされる',       rule: 'v5', reasons: ['short causative', 'passive']},
 
             {term: '飲む', source: '飲んでおく',       rule: 'v5', reasons: ['-て', '-おく']},
@@ -771,7 +764,6 @@ const tests = [
             {term: '作る', source: '作ろう',           rule: 'v5', reasons: ['volitional']},
             {term: '作る', source: '作ろっか',           rule: 'v5', reasons: ['volitional slang']},
             {term: '作る', source: '作るまい',       rule: 'v5', reasons: ['-まい']},
-            {term: '作る', source: '作らされる',       rule: 'v5', reasons: ['causative-passive']},
             {term: '作る', source: '作らされる',       rule: 'v5', reasons: ['short causative', 'passive']},
 
             {term: '作る', source: '作っておく',       rule: 'v5', reasons: ['-て', '-おく']},
@@ -1431,6 +1423,21 @@ const tests = [
             {term: '食べる', source: '食べましたい', rule: null, reasons: ['-ます', '-たい']},
             {term: '済ます', source: '済ません', rule: null, reasons: ['-ます', 'negative']},
             {term: '済ます', source: '済ましょう', rule: null, reasons: ['-ます', 'volitional']},
+        ],
+    },
+    {
+        category: 'incorrect causative-passive chains',
+        valid: false,
+        tests: [
+            {term: '食べる', source: '食べさされる', rule: null, reasons: ['short causative', 'passive']},
+            {term: '話す', source: '話さされる', rule: null, reasons: ['short causative', 'passive']},
+            {term: '論ずる', source: '論じさされる', rule: null, reasons: ['short causative', 'passive']},
+            {term: '論ずる', source: '論ぜさされる', rule: null, reasons: ['short causative', 'passive']},
+            {term: 'する', source: 'さされる', rule: null, reasons: ['short causative', 'passive']},
+            {term: '為る', source: '為される', rule: null, reasons: ['short causative', 'passive']},
+            {term: 'くる', source: 'こさされる', rule: null, reasons: ['short causative', 'passive']},
+            {term: '来る', source: '来さされる', rule: null, reasons: ['short causative', 'passive']},
+            {term: '來る', source: '來さされる', rule: null, reasons: ['short causative', 'passive']},
         ],
     },
     // Kansai-ben

--- a/test/language/japanese-transforms.test.js
+++ b/test/language/japanese-transforms.test.js
@@ -1426,7 +1426,7 @@ const tests = [
         ],
     },
     {
-        category: 'incorrect causative-passive chains',
+        category: 'incorrect short causative -> passive chains',
         valid: false,
         tests: [
             {term: '食べる', source: '食べさされる', rule: null, reasons: ['short causative', 'passive']},


### PR DESCRIPTION
- Remove `causative-passive` form, basically it's just `short causative -> passive` form.
- Avoid conjugating short causative with さす ending with passive form (食べさされる is wrong)