### PR TITLE
Guard against frequency dicts with values of 0 or less

### DIFF
--- a/ext/js/data/anki-note-data-creator.js
+++ b/ext/js/data/anki-note-data-creator.js
@@ -187,11 +187,16 @@ function getFrequencyNumbers(dictionaryEntry) {
         if (displayValue !== null) {
             const frequencyMatch = displayValue.match(/\d+/);
             if (frequencyMatch !== null) {
-                frequencies.push(Number.parseInt(frequencyMatch[0], 10));
-                continue;
+                const frequencyParsed = Number.parseInt(frequencyMatch[0], 10);
+                if (frequencyParsed > 0) {
+                    frequencies.push();
+                    continue;
+                }
             }
         }
-        frequencies.push(frequency);
+        if (frequency > 0) {
+            frequencies.push(frequency);
+        }
     }
     return frequencies;
 }


### PR DESCRIPTION
Frequency of <=0 messes up frequency calculation so these values should be ignored.