### PR TITLE
Refactor touch scan behavior

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -462,7 +462,6 @@
                                     "hideDelay",
                                     "length",
                                     "deepDomScan",
-                                    "scanAltText",
                                     "popupNestingMaxDepth",
                                     "enablePopupSearch",
                                     "enableOnPopupExpressions",
@@ -715,10 +714,6 @@
                                     "deepDomScan": {
                                         "type": "boolean",
                                         "default": false
-                                    },
-                                    "scanAltText": {
-                                        "type": "boolean",
-                                        "default": true
                                     },
                                     "popupNestingMaxDepth": {
                                         "type": "integer",

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -513,7 +513,6 @@ export class Frontend {
             matchTypePrefix: scanningOptions.matchTypePrefix,
             preventMiddleMouse,
             sentenceParsingOptions,
-            scanAltText: scanningOptions.scanAltText,
             scanWithoutMousemove: scanningOptions.scanWithoutMousemove,
             scanResolution: scanningOptions.scanResolution,
         });

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -563,6 +563,7 @@ export class OptionsUtil {
             this._updateVersion49,
             this._updateVersion50,
             this._updateVersion51,
+            this._updateVersion52,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1484,6 +1485,16 @@ export class OptionsUtil {
     async _updateVersion51(options) {
         for (const profile of options.profiles) {
             profile.options.scanning.scanResolution = 'character';
+        }
+    }
+
+    /**
+     * - Remove scanning.scanAltText
+     * @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion52(options) {
+        for (const profile of options.profiles) {
+            delete profile.options.scanning.scanAltText;
         }
     }
 

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -464,7 +464,6 @@ export class Display extends EventDispatcher {
                 preventMiddleMouse: scanningOptions.preventMiddleMouse.onSearchQuery,
                 matchTypePrefix: false,
                 sentenceParsingOptions,
-                scanAltText: scanningOptions.scanAltText,
                 scanWithoutMousemove: scanningOptions.scanWithoutMousemove,
                 scanResolution: scanningOptions.scanResolution,
             },
@@ -2033,7 +2032,6 @@ export class Display extends EventDispatcher {
             layoutAwareScan: scanningOptions.layoutAwareScan,
             preventMiddleMouse: false,
             sentenceParsingOptions,
-            scanAltText: scanningOptions.scanAltText,
         });
 
         this._contentTextScanner.setEnabled(true);

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -96,6 +96,17 @@ export class TextSourceRange {
     }
 
     /**
+     * Determines whether the imposter source element is an input or textarea element.
+     * @return {boolean} `true` if the imposter source element is an input or textarea element, `false` otherwise.
+     */
+     isImposterInputOrTextArea() {
+        if (this._imposterSourceElement) {
+            return this._imposterSourceElement.tagName === 'INPUT' || this._imposterSourceElement.tagName === 'TEXTAREA';
+        }
+        return false;
+     }
+
+    /**
      * Creates a clone of the instance.
      * @returns {TextSourceRange} The new clone.
      */

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -101,7 +101,8 @@ export class TextSourceRange {
      */
      isImposterInputOrTextArea() {
         if (this._imposterSourceElement) {
-            return this._imposterSourceElement.tagName === 'INPUT' || this._imposterSourceElement.tagName === 'TEXTAREA';
+            const type = this._imposterSourceElement.nodeName.toUpperCase();
+            return type === 'INPUT' || type === 'TEXTAREA';
         }
         return false;
      }

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -124,8 +124,6 @@ export class TextScanner extends EventDispatcher {
         this._sentenceBackwardQuoteMap = new Map();
         /** @type {import('text-scanner').InputConfig[]} */
         this._inputs = [];
-        /** @type {boolean} */
-        this._scanAltText = true;
 
         /** @type {boolean} */
         this._enabled = false;
@@ -257,7 +255,6 @@ export class TextScanner extends EventDispatcher {
         preventMiddleMouse,
         sentenceParsingOptions,
         matchTypePrefix,
-        scanAltText,
         scanWithoutMousemove,
         scanResolution,
     }) {
@@ -293,9 +290,6 @@ export class TextScanner extends EventDispatcher {
         }
         if (typeof matchTypePrefix === 'boolean') {
             this._matchTypePrefix = matchTypePrefix;
-        }
-        if (typeof scanAltText === 'boolean') {
-            this._scanAltText = scanAltText;
         }
         if (typeof scanWithoutMousemove === 'boolean') {
             this._scanWithoutMousemove = scanWithoutMousemove;
@@ -348,9 +342,9 @@ export class TextScanner extends EventDispatcher {
         clonedTextSource.setEndOffset(length, false, layoutAwareScan);
 
         const includeSelector = this._includeSelector;
-        const excludeSelector = this._excludeSelector;
-        if (includeSelector !== null || excludeSelector !== null) {
-            this._constrainTextSource(clonedTextSource, includeSelector, excludeSelector, layoutAwareScan, pointerType);
+        const excludeSelector = this._getExcludeSelectorForPointerType(pointerType);
+        if (includeSelector !== null || excludeSelector !== null ) {
+            this._constrainTextSource(clonedTextSource, includeSelector, excludeSelector, layoutAwareScan);
         }
 
         return clonedTextSource.text();
@@ -460,7 +454,8 @@ export class TextScanner extends EventDispatcher {
     async _search(textSource, searchTerms, searchKanji, inputInfo, showEmpty = false) {
         try {
             const isAltText = textSource instanceof TextSourceElement;
-            if (isAltText && !this._scanAltText) {
+            // Prevent scanning of alt text on touch event
+            if (isAltText && inputInfo.pointerType === 'touch') {
                 return;
             }
 
@@ -1637,11 +1632,9 @@ export class TextScanner extends EventDispatcher {
      * @param {?string} includeSelector
      * @param {?string} excludeSelector
      * @param {boolean} layoutAwareScan
-     * @param {import('input').PointerType | undefined} pointerType
      */
-    _constrainTextSource(textSource, includeSelector, excludeSelector, layoutAwareScan, pointerType) {
+    _constrainTextSource(textSource, includeSelector, excludeSelector, layoutAwareScan) {
         let length = textSource.text().length;
-        excludeSelector = this._createExcludeSelectorForPointerType(excludeSelector, pointerType);
 
         while (length > 0) {
             const nodes = textSource.getNodesInRange();
@@ -1658,17 +1651,16 @@ export class TextScanner extends EventDispatcher {
     }
 
     /**
-     * @param {?string} excludeSelector
      * @param {import('input').PointerType | undefined} pointerType
      * @returns {?string}
      */
-    _createExcludeSelectorForPointerType(excludeSelector, pointerType) {
+    _getExcludeSelectorForPointerType(pointerType) {
         if (pointerType === 'touch') {
-            // Avoid trigger search with tapping on popup link, tag and inflection.
-            const popupClickableSelector = '.gloss-link, .gloss-link *, .tag, .tag *, .inflection';
-            return excludeSelector ? `${excludeSelector},${popupClickableSelector}` : popupClickableSelector;
+            // Avoid trigger search with tapping on interactive elements.
+            const popupClickableSelector = '.gloss-link,.gloss-link *,.tag, .tag *, .inflection, a, a *, input, textarea, textarea *';
+            return this._excludeSelector ? `${this._excludeSelector},${popupClickableSelector}` : popupClickableSelector;
         }
-        return excludeSelector;
+        return this._excludeSelector;
     }
 
     /**

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -23,6 +23,7 @@ import {log} from '../core/log.js';
 import {clone} from '../core/utilities.js';
 import {anyNodeMatchesSelector, everyNodeMatchesSelector, getActiveModifiers, getActiveModifiersAndButtons, isPointInSelection} from '../dom/document-util.js';
 import {TextSourceElement} from '../dom/text-source-element.js';
+import {TextSourceRange} from '../dom/text-source-range.js';
 
 /**
  * @augments EventDispatcher<import('text-scanner').Events>
@@ -454,8 +455,8 @@ export class TextScanner extends EventDispatcher {
     async _search(textSource, searchTerms, searchKanji, inputInfo, showEmpty = false) {
         try {
             const isAltText = textSource instanceof TextSourceElement;
-            // Prevent scanning of alt text on touch event
-            if (isAltText && inputInfo.pointerType === 'touch') {
+            const isInputOrTextArea = textSource instanceof TextSourceRange && textSource.isImposterInputOrTextArea();
+            if (inputInfo.pointerType === 'touch' && (isAltText || isInputOrTextArea)) {
                 return;
             }
 

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -1657,7 +1657,6 @@ export class TextScanner extends EventDispatcher {
     _getExcludeSelectorForPointerType(pointerType) {
         if (pointerType === 'touch') {
             // Avoid trigger search with tapping on interactive elements.
-            const popupClickableSelector = '.gloss-link,.gloss-link *,.tag, .tag *, .inflection, a, a *, input, textarea, textarea *';
             const popupClickableSelector = '.gloss-link,.gloss-link *,.tag, .tag *, .inflection, a, a *'
             return this._excludeSelector ? `${this._excludeSelector},${popupClickableSelector}` : popupClickableSelector;
         }

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -1658,6 +1658,7 @@ export class TextScanner extends EventDispatcher {
         if (pointerType === 'touch') {
             // Avoid trigger search with tapping on interactive elements.
             const popupClickableSelector = '.gloss-link,.gloss-link *,.tag, .tag *, .inflection, a, a *, input, textarea, textarea *';
+            const popupClickableSelector = '.gloss-link,.gloss-link *,.tag, .tag *, .inflection, a, a *'
             return this._excludeSelector ? `${this._excludeSelector},${popupClickableSelector}` : popupClickableSelector;
         }
         return this._excludeSelector;

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -477,15 +477,6 @@
                 <label class="toggle"><input type="checkbox" data-setting="scanning.deepDomScan"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
-        <div class="settings-item"><div class="settings-item-inner">
-            <div class="settings-item-left">
-                <div class="settings-item-label">Scan alt text</div>
-                <div class="settings-item-description">Scan text that is used for image and button descriptions.</div>
-            </div>
-            <div class="settings-item-right">
-                <label class="toggle"><input type="checkbox" data-setting="scanning.scanAltText"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
-            </div>
-        </div></div>
         <div class="settings-item advanced-only">
             <div class="settings-item-inner">
                 <div class="settings-item-left">

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -348,7 +348,6 @@ function createProfileOptionsUpdatedTestData1() {
             hidePopupOnCursorExit: false,
             hidePopupOnCursorExitDelay: 0,
             normalizeCssZoom: true,
-            scanAltText: true,
             preventMiddleMouse: {
                 onWebPages: false,
                 onPopupPages: false,
@@ -645,7 +644,7 @@ function createOptionsUpdatedTestData1() {
             },
         ],
         profileCurrent: 0,
-        version: 51,
+        version: 52,
         global: {
             database: {
                 prefixWildcardsSupported: false,

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -197,7 +197,6 @@ export type ScanningOptions = {
     hidePopupOnCursorExit: boolean;
     hidePopupOnCursorExitDelay: number;
     normalizeCssZoom: boolean;
-    scanAltText: boolean;
     scanWithoutMousemove: boolean;
     scanResolution: string;
 };

--- a/types/ext/text-scanner.d.ts
+++ b/types/ext/text-scanner.d.ts
@@ -41,7 +41,6 @@ export type Options = {
     preventMiddleMouse?: boolean;
     matchTypePrefix?: boolean;
     sentenceParsingOptions?: SentenceParsingOptions;
-    scanAltText?: boolean;
     scanWithoutMousemove?: boolean;
     scanResolution?: string;
 };


### PR DESCRIPTION
Fixes #1433

Changes:
- Remove `scanAltText` option, default to not scan alt text on touch event.
- Not scan on hyperlink, input and textarea on touch event.

I don't know if there is any use case of scanning alt text, hyperlink or input on mobile or touch screen. If this is not intended behavior then we can disable them on touch event.
Making this behavior a settings such as `scanInteractiveElements` is not a really good idea because touch-screen laptops exist and users need to take extra step in settings to disable/enable them.