### PR TITLE
Fix UTF32 characters breaking sentence parser due directly accessing string array indexes

### DIFF
--- a/ext/js/dom/text-source-generator.js
+++ b/ext/js/dom/text-source-generator.js
@@ -66,7 +66,7 @@ export class TextSourceGenerator {
         source = source.clone();
         const startLength = source.setStartOffset(extent, layoutAwareScan);
         const endLength = source.setEndOffset(extent * 2 - startLength, true, layoutAwareScan);
-        const text = source.text();
+        const text = [...source.text()];
         const textLength = text.length;
         const textEndAnchor = textLength - endLength;
 
@@ -173,7 +173,7 @@ export class TextSourceGenerator {
 
         // Result
         return {
-            text: text.substring(cursorStart, cursorEnd),
+            text: text.slice(cursorStart, cursorEnd).join(''),
             offset: startLength - cursorStart,
         };
     }


### PR DESCRIPTION
UTF32 characters take up two indexes in JS strings and the sentence parser was indexing the string directly causing an incorrect offset to be applied to the sentence. This causes the `{cloze-prefix}`, `{cloze-body}`, and `{cloze-suffix}` handlebars to select the wrong text.

Converting the text to an array before parsing combines UTF32 characters into a single index.

Discovered on this page: https://learnjapanese.moe/texthooker.html. It has a UTF32 emoji character in the top right (🚫) which gets pulled into the sentence parser. 
