### PR TITLE
syntax error message made more verbose

### DIFF
--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -815,8 +815,19 @@ export class DictionaryImporter {
         const results = [];
         for (const file of files) {
             const content = await this._getData(file, new TextWriter());
-            /** @type {unknown} */
-            const entries = parseJson(content);
+            let entries;
+
+            try {
+                /** @type {unknown} */
+                entries = parseJson(content);
+            }
+            catch (error) {
+                if (error instanceof Error) {
+                    let newError = new Error(error.message + `. Dictionary has invalid data in '${file.filename}'`);
+                    console.error(newError);
+                    throw newError;
+                }
+            }
 
             startIndex = progressData.index;
             this._progress();

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -820,12 +820,9 @@ export class DictionaryImporter {
             try {
                 /** @type {unknown} */
                 entries = parseJson(content);
-            }
-            catch (error) {
+            } catch (error) {
                 if (error instanceof Error) {
-                    let newError = new Error(error.message + `. Dictionary has invalid data in '${file.filename}'`);
-                    console.error(newError);
-                    throw newError;
+                    throw new Error(error.message + ` in '${file.filename}'`);
                 }
             }
 


### PR DESCRIPTION
when validating a dictionary as it is being imported, if a syntax error is encountered, a message would describe the syntax error that has occurred. To provide clarity, the syntax error message will now also describe the file in which this error occurred.